### PR TITLE
Remove usage of C++14 feature 'return type deduction'.

### DIFF
--- a/include/mqtt/client.hpp
+++ b/include/mqtt/client.hpp
@@ -218,7 +218,7 @@ public:
         setup_socket(base::socket());
         auto self = this->shared_from_this();
         as::async_connect(
-            base::socket()->lowest_layer(), it,
+            base::socket()->socket().lowest_layer(), it,
             [this, self, func]
             (boost::system::error_code const& ec, as::ip::tcp::resolver::iterator) mutable {
                 base::set_close_handler([this](){ handle_close(); });

--- a/include/mqtt/tcp_endpoint.hpp
+++ b/include/mqtt/tcp_endpoint.hpp
@@ -39,14 +39,6 @@ public:
     Socket& socket() { return tcp_; }
     Socket const& socket() const { return tcp_; }
 
-    auto& lowest_layer() {
-        return tcp_.lowest_layer();
-    }
-
-    auto& next_layer() {
-        return tcp_.next_layer();
-    }
-
     template <typename T>
     void set_option(T&& t) {
         tcp_.set_option(std::forward<T>(t));


### PR DESCRIPTION
The readme states the only used C++14 feature are binary literals, so
let's keep it like that if trivially possible like in this case.