### PR TITLE
Remove usage of C++14 feature 'return type deduction'.

### DIFF
--- a/include/mqtt/tcp_endpoint.hpp
+++ b/include/mqtt/tcp_endpoint.hpp
@@ -39,12 +39,8 @@ public:
     Socket& socket() { return tcp_; }
     Socket const& socket() const { return tcp_; }
 
-    auto& lowest_layer() {
+    typename Socket::lowest_layer_type& lowest_layer() {
         return tcp_.lowest_layer();
-    }
-
-    auto& next_layer() {
-        return tcp_.next_layer();
     }
 
     template <typename T>

--- a/include/mqtt/ws_endpoint.hpp
+++ b/include/mqtt/ws_endpoint.hpp
@@ -44,11 +44,11 @@ public:
         return ws_.get_io_service();
     }
 
-    auto& lowest_layer() {
+    typename boost::beast::websocket::stream<Socket>::lowest_layer_type& lowest_layer() {
         return ws_.lowest_layer();
     }
 
-    auto& next_layer() {
+    typename boost::beast::websocket::stream<Socket>::next_layer_type& next_layer() {
         return ws_.next_layer();
     }
 


### PR DESCRIPTION
The readme states the only used C++14 feature are binary literals, so
let's keep it like that if trivially possible like in this case.

Also remove tcp_endpoint::next_layer() method, as the underlying
boost::asio::ip::tcp::socket type doesn't have any such method. (NB: If
this method were actually used in the code, compilation would have
failed before)