### PR TITLE
Improved TLS verify settings.

### DIFF
--- a/test/async_pubsub.cpp
+++ b/test/async_pubsub.cpp
@@ -175,7 +175,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                 return true;
             });
         c->set_unsuback_handler(
-            [&order, &c, &pub_seq_finished, &pid_unsub]
+            [&order, &c, &pid_unsub]
             (std::uint16_t packet_id) {
                 BOOST_TEST(order++ == 4);
                 BOOST_TEST(packet_id == pid_unsub);
@@ -278,7 +278,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                 return true;
             });
         c->set_unsuback_handler(
-            [&order, &c, &pub_seq_finished, &pid_unsub]
+            [&order, &c, &pid_unsub]
             (std::uint16_t packet_id) {
                 BOOST_TEST(order++ == 5);
                 BOOST_TEST(packet_id == pid_unsub);
@@ -475,7 +475,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                 return true;
             });
         c->set_unsuback_handler(
-            [&order, &c, &pub_seq_finished, &pid_unsub]
+            [&order, &c, &pid_unsub]
             (std::uint16_t packet_id) {
                 BOOST_CHECK(order == 5);
                 ++order;
@@ -583,7 +583,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                 return true;
             });
         c->set_unsuback_handler(
-            [&order, &c, &pub_seq_finished, &pid_unsub]
+            [&order, &c, &pid_unsub]
             (std::uint16_t packet_id) {
                 BOOST_CHECK(order == 6);
                 ++order;
@@ -592,7 +592,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                 return true;
             });
         c->set_publish_handler(
-            [&order, &c, &recv_packet_id]
+            [&order, &recv_packet_id]
             (std::uint8_t header,
              boost::optional<std::uint16_t> packet_id,
              std::string topic,
@@ -781,7 +781,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                 return true;
             });
         c->set_unsuback_handler(
-            [&order, &c, &pub_seq_finished, &pid_unsub]
+            [&order, &c, &pid_unsub]
             (std::uint16_t packet_id) {
                 BOOST_CHECK(order == 5);
                 ++order;
@@ -889,7 +889,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                 return true;
             });
         c->set_unsuback_handler(
-            [&order, &c, &pub_seq_finished, &pid_unsub]
+            [&order, &c, &pid_unsub]
             (std::uint16_t packet_id) {
                 BOOST_CHECK(order == 6);
                 ++order;

--- a/test/connect.cpp
+++ b/test/connect.cpp
@@ -197,7 +197,7 @@ BOOST_AUTO_TEST_CASE( nocid_noclean ) {
     auto test = [](boost::asio::io_service& ios, auto& c, auto& s) {
         int order = 0;
         c->set_connack_handler(
-            [&order, &c]
+            [&order]
             (bool sp, std::uint8_t connack_return_code) {
                 BOOST_TEST(order++ == 0);
                 BOOST_TEST(sp == false);

--- a/test/multi_sub.cpp
+++ b/test/multi_sub.cpp
@@ -300,7 +300,6 @@ BOOST_AUTO_TEST_CASE( multi_client_qos1 ) {
     test_broker b;
     test_server_no_tls s(ios, b);
     // c3 --publish--> topic1 ----> c1, c2
-    int sub_count = 0;
 
     bool c1ready = false;
     bool c2ready = false;
@@ -349,7 +348,7 @@ BOOST_AUTO_TEST_CASE( multi_client_qos1 ) {
             BOOST_CHECK(false);
         });
     c1->set_suback_handler(
-        [&order1, &c1, &sub_count, &c1ready, &c2ready, &c3ready, &c3, &pid_sub1, &pid_pub3]
+        [&order1, &c1ready, &c2ready, &c3ready, &c3, &pid_sub1, &pid_pub3]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order1++ == 1);
             BOOST_TEST(packet_id == pid_sub1);
@@ -411,7 +410,7 @@ BOOST_AUTO_TEST_CASE( multi_client_qos1 ) {
             BOOST_CHECK(false);
         });
     c2->set_suback_handler(
-        [&order2, &c2, &sub_count, &c1ready, &c2ready, &c3ready, &c3, &pid_sub2, &pid_pub3]
+        [&order2, &c1ready, &c2ready, &c3ready, &c3, &pid_sub2, &pid_pub3]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order2++ == 1);
             BOOST_TEST(packet_id == pid_sub2);

--- a/test/offline.cpp
+++ b/test/offline.cpp
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE( publish_qos1 ) {
                 }
             });
         c->set_error_handler(
-            [&order, &c]
+            []
             (boost::system::error_code const&) {
                 BOOST_CHECK(false);
             });
@@ -117,12 +117,12 @@ BOOST_AUTO_TEST_CASE( publish_qos2 ) {
                 }
             });
         c->set_error_handler(
-            [&order, &c]
+            []
             (boost::system::error_code const&) {
                 BOOST_CHECK(false);
             });
         c->set_pubrec_handler(
-            [&order, &c, &pid_pub]
+            [&order, &pid_pub]
             (std::uint16_t packet_id) {
                 BOOST_TEST(order++ == 3);
                 BOOST_TEST(packet_id == pid_pub);
@@ -190,7 +190,7 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1 ) {
                 }
             });
         c->set_error_handler(
-            [&order, &c]
+            []
             (boost::system::error_code const&) {
                 BOOST_CHECK(false);
             });
@@ -270,7 +270,7 @@ BOOST_AUTO_TEST_CASE( async_publish_qos1 ) {
                 }
             });
         c->set_error_handler(
-            [&order, &c]
+            []
             (boost::system::error_code const&) {
                 BOOST_CHECK(false);
             });

--- a/test/pubsub.cpp
+++ b/test/pubsub.cpp
@@ -175,7 +175,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                 return true;
             });
         c->set_unsuback_handler(
-            [&order, &c, &pub_seq_finished, &pid_unsub]
+            [&order, &c, &pid_unsub]
             (std::uint16_t packet_id) {
                 BOOST_TEST(order++ == 4);
                 BOOST_TEST(packet_id == pid_unsub);
@@ -278,7 +278,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                 return true;
             });
         c->set_unsuback_handler(
-            [&order, &c, &pub_seq_finished, &pid_unsub]
+            [&order, &c, &pid_unsub]
             (std::uint16_t packet_id) {
                 BOOST_TEST(order++ == 5);
                 BOOST_TEST(packet_id == pid_unsub);
@@ -475,7 +475,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                 return true;
             });
         c->set_unsuback_handler(
-            [&order, &c, &pub_seq_finished, &pid_unsub]
+            [&order, &c, &pid_unsub]
             (std::uint16_t packet_id) {
                 BOOST_CHECK(order == 5);
                 ++order;
@@ -583,7 +583,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                 return true;
             });
         c->set_unsuback_handler(
-            [&order, &c, &pub_seq_finished, &pid_unsub]
+            [&order, &c, &pid_unsub]
             (std::uint16_t packet_id) {
                 BOOST_CHECK(order == 6);
                 ++order;
@@ -592,7 +592,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                 return true;
             });
         c->set_publish_handler(
-            [&order, &c, &recv_packet_id]
+            [&order, &recv_packet_id]
             (std::uint8_t header,
              boost::optional<std::uint16_t> packet_id,
              std::string topic,
@@ -781,7 +781,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                 return true;
             });
         c->set_unsuback_handler(
-            [&order, &c, &pub_seq_finished, &pid_unsub]
+            [&order, &c, &pid_unsub]
             (std::uint16_t packet_id) {
                 BOOST_CHECK(order == 5);
                 ++order;
@@ -889,7 +889,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                 return true;
             });
         c->set_unsuback_handler(
-            [&order, &c, &pub_seq_finished, &pid_unsub]
+            [&order, &c, &pid_unsub]
             (std::uint16_t packet_id) {
                 BOOST_CHECK(order == 6);
                 ++order;

--- a/test/pubsub_no_strand.cpp
+++ b/test/pubsub_no_strand.cpp
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
             return true;
         });
     c->set_unsuback_handler(
-        [&order, &c, &pub_seq_finished, &pid_unsub]
+        [&order, &c, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_TEST(order++ == 4);
             BOOST_TEST(packet_id == pid_unsub);
@@ -269,7 +269,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
             return true;
         });
     c->set_unsuback_handler(
-        [&order, &c, &pub_seq_finished, &pid_unsub]
+        [&order, &c, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_TEST(order++ == 5);
             BOOST_TEST(packet_id == pid_unsub);
@@ -454,7 +454,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
             return true;
         });
     c->set_unsuback_handler(
-        [&order, &c, &pub_seq_finished, &pid_unsub]
+        [&order, &c, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_CHECK(order == 3 || order == 4);
             ++order;
@@ -554,7 +554,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
             return true;
         });
     c->set_unsuback_handler(
-        [&order, &c, &pub_seq_finished, &pid_unsub]
+        [&order, &c, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_CHECK(order == 4 || order == 5);
             ++order;
@@ -740,7 +740,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
             return true;
         });
     c->set_unsuback_handler(
-        [&order, &c, &pub_seq_finished, &pid_unsub]
+        [&order, &c, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_CHECK(order == 3 || order == 4);
             ++order;
@@ -840,7 +840,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
             return true;
         });
     c->set_unsuback_handler(
-        [&order, &c, &pub_seq_finished, &pid_unsub]
+        [&order, &c, &pid_unsub]
         (std::uint16_t packet_id) {
             BOOST_CHECK(order == 4 || order == 5);
             ++order;

--- a/test/resend.cpp
+++ b/test/resend.cpp
@@ -130,7 +130,7 @@ BOOST_AUTO_TEST_CASE( publish_qos2 ) {
                 c->connect();
             });
         c->set_pubrec_handler(
-            [&order, &c, &pid_pub]
+            [&order, &pid_pub]
             (std::uint16_t packet_id) {
                 BOOST_TEST(order++ == 5);
                 BOOST_TEST(packet_id == pid_pub);

--- a/test/retain.cpp
+++ b/test/retain.cpp
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE( simple ) {
                 return true;
             });
         c->set_suback_handler(
-            [&order, &c, &pid_sub]
+            [&order, &pid_sub]
             (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
                 BOOST_TEST(order++ == 1);
                 BOOST_TEST(packet_id == pid_sub);
@@ -149,7 +149,7 @@ BOOST_AUTO_TEST_CASE( overwrite ) {
                 return true;
             });
         c->set_suback_handler(
-            [&order, &c, &pid_sub]
+            [&order, &pid_sub]
             (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
                 BOOST_TEST(order++ == 1);
                 BOOST_TEST(packet_id == pid_sub);

--- a/test/will.cpp
+++ b/test/will.cpp
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE( will_qos0 ) {
             s.close();
         });
     c2->set_suback_handler(
-        [&order2, &c2, &c1_force_disconnect, &pid_sub2]
+        [&order2, &c1_force_disconnect, &pid_sub2]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order2++ == 1);
             BOOST_TEST(packet_id == pid_sub2);
@@ -185,7 +185,7 @@ BOOST_AUTO_TEST_CASE( will_qos1 ) {
             BOOST_CHECK(false);
         });
     c2->set_suback_handler(
-        [&order2, &c2, &c1_force_disconnect, &pid_sub2]
+        [&order2, &c1_force_disconnect, &pid_sub2]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order2++ == 1);
             BOOST_TEST(packet_id == pid_sub2);
@@ -293,7 +293,7 @@ BOOST_AUTO_TEST_CASE( will_qos2 ) {
             s.close();
         });
     c2->set_suback_handler(
-        [&order2, &c2, &c1_force_disconnect, &pid_sub2]
+        [&order2, &c1_force_disconnect, &pid_sub2]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(order2++ == 1);
             BOOST_TEST(packet_id == pid_sub2);
@@ -401,7 +401,7 @@ BOOST_AUTO_TEST_CASE( will_retain ) {
             s.close();
         });
     c2->set_suback_handler(
-        [&order2, &c2, &c1_force_disconnect, &pid_sub2]
+        [&order2, &c1_force_disconnect, &pid_sub2]
         (std::uint16_t packet_id, std::vector<boost::optional<std::uint8_t>> results) {
             BOOST_TEST(packet_id == pid_sub2);
             BOOST_TEST(results.size() == 1U);


### PR DESCRIPTION
You can set your verify mode and callback. They are passed to asio.
The default verify mode is verify_peer. It is the same as original
behavior.