### PR TITLE
Clean up private functions.

### DIFF
--- a/example/no_tls_ws_client.cpp
+++ b/example/no_tls_ws_client.cpp
@@ -68,7 +68,7 @@ int main(int argc, char** argv) {
             return true;
         });
     c->set_pubrec_handler(
-        [&c]
+        [&]
         (std::uint16_t packet_id){
             std::cout << "pubrec received. packet_id: " << packet_id << std::endl;
             return true;


### PR DESCRIPTION
Removed unused capture in example.