### PR TITLE
Fixed #112.

### DIFF
--- a/test/connect.cpp
+++ b/test/connect.cpp
@@ -315,7 +315,7 @@ BOOST_AUTO_TEST_CASE( nocid_noclean ) {
             // connect
             "h_connack",
             // disconnect
-            "h_close",
+            "h_error",
             "finish",
         };
 
@@ -339,16 +339,16 @@ BOOST_AUTO_TEST_CASE( nocid_noclean ) {
                 return true;
             });
         c->set_close_handler(
-            [&order, &current, &s]
+            []
             () {
-                BOOST_TEST(current() == "h_close");
-                ++order;
-                s.close();
+                BOOST_CHECK(false);
             });
         c->set_error_handler(
-            []
+            [&order, &current, &s]
             (boost::system::error_code const&) {
-                BOOST_CHECK(false);
+                BOOST_TEST(current() == "h_error");
+                ++order;
+                s.close();
             });
         c->connect();
         ios.run();


### PR DESCRIPTION
Breaking change.

close_handler will be called only when `disconnect()` or
`async_disconnect()` is called.
If the socket is closed cleanly from server side other reasons, error_handler is
called. Before this fix, close_handler is called.

User usually want to re-connect only when unexpected close is detected.
In other words, user don't want to re-connect in close_handler if the
handler is called by `disconnect()` or `async_disconnect()`.

After the fix, user can achieve the expected behavior writing re-connect
code only in error_handler.