### PR TITLE
Improved pingreq sending timing.

### DIFF
--- a/include/mqtt/client.hpp
+++ b/include/mqtt/client.hpp
@@ -503,7 +503,6 @@ private:
     void handle_timer(boost::system::error_code const& ec) {
         if (!ec) {
             base::pingreq();
-            set_timer();
         }
     }
 

--- a/test/connect.cpp
+++ b/test/connect.cpp
@@ -180,6 +180,90 @@ BOOST_AUTO_TEST_CASE( keep_alive ) {
     do_combi_test(test);
 }
 
+BOOST_AUTO_TEST_CASE( keep_alive_and_send_control_packet ) {
+    auto test = [](boost::asio::io_service& ios, auto& c, auto& s) {
+        c->set_client_id("cid1");
+        c->set_clean_session(true);
+
+        int order = 0;
+
+        std::vector<std::string> const expected = {
+            // connect
+            "h_connack",
+            "2sec",
+            "h_pingresp",
+            "4sec_cancelled",
+            // disconnect
+            "h_close",
+            "finish",
+        };
+
+        auto current =
+            [&order, &expected]() -> std::string {
+                try {
+                    return expected.at(order);
+                }
+                catch (std::out_of_range const& e) {
+                    return e.what();
+                }
+            };
+
+        boost::asio::deadline_timer tim(ios);
+        c->set_connack_handler(
+            [&order, &current, &c, &tim]
+            (bool sp, std::uint8_t connack_return_code) {
+                BOOST_TEST(current() == "h_connack");
+                ++order;
+                BOOST_TEST(sp == false);
+                BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
+                tim.expires_from_now(boost::posix_time::seconds(2));
+                tim.async_wait(
+                    [&order, &current, &c, &tim](boost::system::error_code const& ec) {
+                        BOOST_TEST(current() == "2sec");
+                        ++order;
+                        BOOST_CHECK(!ec);
+                        c->publish_at_most_once("topic1", "timer_reset");
+                        tim.expires_from_now(boost::posix_time::seconds(4));
+                        tim.async_wait(
+                            [&order, &current](boost::system::error_code const& ec) {
+                                BOOST_TEST(current() == "4sec_cancelled");
+                                ++order;
+                                BOOST_TEST(ec == boost::asio::error::operation_aborted );
+                            }
+                        );
+                    }
+                );
+                return true;
+            });
+        c->set_close_handler(
+            [&order, &current, &s]
+            () {
+                BOOST_TEST(current() == "h_close");
+                ++order;
+                s.close();
+            });
+        c->set_error_handler(
+            []
+            (boost::system::error_code const&) {
+                BOOST_CHECK(false);
+            });
+        c->set_pingresp_handler(
+            [&order, &current, &c, &tim]
+            () {
+                BOOST_TEST(current() == "h_pingresp");
+                ++order;
+                tim.cancel();
+                c->disconnect();
+                return true;
+            });
+        c->set_keep_alive_sec_ping_ms(3, 3 * 1000);
+        c->connect();
+        ios.run();
+        BOOST_TEST(current() == "finish");
+    };
+    do_combi_test(test);
+}
+
 BOOST_AUTO_TEST_CASE( connect_again ) {
     auto test = [](boost::asio::io_service& ios, auto& c, auto& s) {
         c->set_client_id("cid1");


### PR DESCRIPTION
It used to be sent each ping_duration_ms_.
After this update, pingreq is sent ping_duration_ms_ passed
after any mqtt control packet sent.