### PR TITLE
Add the REQUIRED argument to the FIND_PACKAGE(Boost) command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ ENDIF ()
 SET (Boost_USE_STATIC_LIBS        ON) # only find static libs
 SET (Boost_USE_MULTITHREADED      ON)
 # SET (Boost_USE_STATIC_RUNTIME    OFF)
-FIND_PACKAGE (Boost 1.59.0 COMPONENTS chrono timer test_exec_monitor system)
+FIND_PACKAGE (Boost 1.59.0 REQUIRED COMPONENTS chrono timer test_exec_monitor system)
 FIND_PACKAGE (Threads)
 
 IF (NOT MQTT_BEAST_INCLUDE_DIR)


### PR DESCRIPTION
I got an error while compiling your library for the first time. My machine did not have Boost libraries >= 1.59 installed.

The cmake command generated the Makefile, but after that, the compiler complained about missing boost headers. 

Adding the REQUIRED argument to the FIND_PACKAGE(Boost) command should fix this issue.