### PR TITLE
Add server::port() accessor

### DIFF
--- a/include/mqtt/server.hpp
+++ b/include/mqtt/server.hpp
@@ -78,6 +78,8 @@ public:
         do_accept();
     }
 
+    unsigned short port() const { return acceptor_.local_endpoint().port(); }
+
     void close() {
         close_request_ = true;
         acceptor_.close();


### PR DESCRIPTION
When used in a unit test environment, it is useful to run the server on an ephemeral port (by specifying port `0`). This accessor can be used to identify which port was assigned.