### PR TITLE
Fix header include path

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -4,7 +4,7 @@ file(GLOB HDR_MQTT "mqtt/*.hpp")
 
 add_library(mqtt_cpp_iface INTERFACE)
 
-target_include_directories(mqtt_cpp_iface INTERFACE ${HDR_ROOT} ${HDR_MQTT})
+target_include_directories(mqtt_cpp_iface INTERFACE .)
 
 install(FILES ${HDR_ROOT} DESTINATION include)
 install(FILES ${HDR_MQTT} DESTINATION include/mqtt)


### PR DESCRIPTION
target_include_directories() does not take a list of files. It takes a list of directories that the files live in.

This change allows me to have the git repository for mqtt_cpp in a subdirectory (e.g. 3rdparty/mqtt_cpp) and then use CMake's add_subdirectory() feature to add mqtt_cpp to my build. Then I use TARGET_LINK_LIBRARIES(myapp mqtt_cpp_iface) to get those include paths to work in my code.