### PR TITLE
Fix include/CMakeLists.txt

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,11 +1,31 @@
-
 file(GLOB HDR_ROOT "*.hpp")
 file(GLOB HDR_MQTT "mqtt/*.hpp")
 
 add_library(mqtt_cpp_iface INTERFACE)
 
-target_include_directories(mqtt_cpp_iface INTERFACE ${HDR_ROOT} ${HDR_MQTT})
+set(ROOT_INCLUDE_TARGET include)
+set(ROOT_MQTT_TARGET include/mqtt)
 
-install(FILES ${HDR_ROOT} DESTINATION include)
-install(FILES ${HDR_MQTT} DESTINATION include/mqtt)
+target_include_directories(mqtt_cpp_iface
+  INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${ROOT_INCLUDE_TARGET}>
+    $<INSTALL_INTERFACE:${ROOT_MQTT_TARGET}>
+)
 
+IF (MQTT_NO_TLS)
+    target_compile_definitions(mqtt_cpp_iface INTERFACE MQTT_NO_TLS)
+ENDIF ()
+
+IF (MQTT_USE_WS)
+    target_compile_definitions(mqtt_cpp_iface INTERFACE MQTT_USE_WS)
+ENDIF ()
+
+IF (MQTT_USE_STR_CHECK)
+    target_compile_definitions(mqtt_cpp_iface INTERFACE MQTT_USE_STR_CHECK)
+ENDIF ()
+
+target_link_libraries(mqtt_cpp_iface INTERFACE Boost::system Threads::Threads)
+
+install(FILES ${HDR_ROOT} DESTINATION ${ROOT_INCLUDE_TARGET})
+install(FILES ${HDR_MQTT} DESTINATION ${ROOT_MQTT_TARGET})


### PR DESCRIPTION
This is the bare minimum that I needed to do in order to use mqtt_cpp with my code.

I have a project structure like this

/
 - 3rdparty/mqtt_cpp
 - src/CMakeLists.txt

Where my CMakeLists.txt has "add_subdirectory(../3rdparty/mqtt_cpp)", and then I use mqtt_cpp using "target_link_library(myapp mqtt_cpp_iface)"

The pull request does not replace https://github.com/redboltz/mqtt_cpp/pull/149 . There are other good improvements in that other PR.