### PR TITLE
Implemented #194.

### DIFF
--- a/include/mqtt/endpoint.hpp
+++ b/include/mqtt/endpoint.hpp
@@ -5948,6 +5948,16 @@ private:
     void do_async_write() {
         std::vector<as::const_buffer> buf;
         std::vector<async_handler_t> handlers;
+
+        std::size_t total_const_buffer_sequence = 0;
+        for (auto const& elem : queue_) {
+            auto const& mv = elem.message();
+            total_const_buffer_sequence += num_of_const_buffer_sequence(mv);
+        }
+
+        buf.reserve(total_const_buffer_sequence);
+        handlers.reserve(queue_.size());
+
         std::size_t total = 0;
         for (auto const& elem : queue_) {
             auto const& mv = elem.message();

--- a/include/mqtt/endpoint.hpp
+++ b/include/mqtt/endpoint.hpp
@@ -5987,11 +5987,14 @@ private:
 
         std::size_t total_const_buffer_sequence = 0;
         auto start = queue_.cbegin();
-        auto end = [&] {
-                       if (max_queue_send_count_ == 0) return queue_.cend();
-                       if (max_queue_send_count_ >= queue_.size()) return queue_.cend();
-                       return start + static_cast<typename decltype(start)::difference_type>(max_queue_send_count_);
-                   } ();
+        auto end =
+            [&] {
+                if (max_queue_send_count_ == 0) return queue_.cend();
+                if (max_queue_send_count_ >= queue_.size()) return queue_.cend();
+                return
+                    start +
+                    static_cast<typename std::deque<async_packet>::const_iterator::difference_type>(max_queue_send_count_);
+            } ();
 
         std::size_t total = 0;
         for (auto it = start; it != end; ++it) {

--- a/include/mqtt/endpoint.hpp
+++ b/include/mqtt/endpoint.hpp
@@ -5990,7 +5990,7 @@ private:
         auto end = [&] {
                        if (max_queue_send_count_ == 0) return queue_.cend();
                        if (max_queue_send_count_ >= queue_.size()) return queue_.cend();
-                       return start + max_queue_send_count_;
+                       return start + static_cast<typename decltype(start)::difference_type>(max_queue_send_count_);
                    } ();
 
         std::size_t total = 0;
@@ -6031,7 +6031,7 @@ private:
                         if (h) h(ec);
                     }
                 },
-                std::distance(start, end),
+                static_cast<std::size_t>(std::distance(start, end)),
                 total
             )
         );

--- a/include/mqtt/endpoint.hpp
+++ b/include/mqtt/endpoint.hpp
@@ -6052,9 +6052,9 @@ private:
         }
         std::shared_ptr<this_type> self_;
         async_handler_t func_;
-        std::size_t expected_;
         std::size_t num_of_messages_;
-    };
+        std::size_t expected_;
+   };
 
 private:
     std::unique_ptr<Socket> socket_;

--- a/include/mqtt/message.hpp
+++ b/include/mqtt/message.hpp
@@ -74,6 +74,14 @@ public:
     }
 
     /**
+     * @brief Get number of element of const_buffer_sequence
+     * @return number of element of const_buffer_sequence
+     */
+    std::size_t num_of_const_buffer_sequence() const {
+        return 1;
+    }
+
+    /**
      * @brief Create one continuours buffer.
      *        All sequence of buffers are concatinated.
      *        It is useful to store to file/database.
@@ -127,6 +135,14 @@ public:
      */
     std::size_t size() const {
         return message_.size();
+    }
+
+    /**
+     * @brief Get number of element of const_buffer_sequence
+     * @return number of element of const_buffer_sequence
+     */
+    std::size_t num_of_const_buffer_sequence() const {
+        return 1;
     }
 
     /**
@@ -260,6 +276,14 @@ public:
     }
 
     /**
+     * @brief Get number of element of const_buffer_sequence
+     * @return number of element of const_buffer_sequence
+     */
+    std::size_t num_of_const_buffer_sequence() const {
+        return 1;
+    }
+
+    /**
      * @brief Create one continuours buffer.
      *        All sequence of buffers are concatinated.
      *        It is useful to store to file/database.
@@ -352,20 +376,7 @@ public:
      */
     std::vector<as::const_buffer> const_buffer_sequence() const {
         std::vector<as::const_buffer> ret;
-        ret.reserve(
-            1 +                   // fixed header
-            1 +                   // remaining length
-            1 +                   // protocol name and level
-            1 +                   // connect flags
-            1 +                   // keep alive
-
-            2 +                   // client id length, client id
-
-            2 +                   // will topic name length, will topic name
-            2 +                   // will message length, will message
-            2 +                   // user name length, user name
-            2                     // password length, password
-        );
+        ret.reserve(num_of_const_buffer_sequence());
 
         ret.emplace_back(as::buffer(&fixed_header_, 1));
         ret.emplace_back(as::buffer(remaining_length_buf_.data(), remaining_length_buf_.size()));
@@ -402,6 +413,26 @@ public:
      */
     std::size_t size() const {
         return 1 + remaining_length_buf_.size() + remaining_length_;
+    }
+
+    /**
+     * @brief Get number of element of const_buffer_sequence
+     * @return number of element of const_buffer_sequence
+     */
+    std::size_t num_of_const_buffer_sequence() const {
+        return
+            1 +                   // fixed header
+            1 +                   // remaining length
+            1 +                   // protocol name and level
+            1 +                   // connect flags
+            1 +                   // keep alive
+
+            2 +                   // client id length, client id
+
+            2 +                   // will topic name length, will topic name
+            2 +                   // will message length, will message
+            2 +                   // user name length, user name
+            2;                    // password length, password
     }
 
     /**
@@ -581,6 +612,19 @@ public:
     }
 
     /**
+     * @brief Get number of element of const_buffer_sequence
+     * @return number of element of const_buffer_sequence
+     */
+    std::size_t num_of_const_buffer_sequence() const {
+        return
+            1 +                   // fixed header
+            1 +                   // remaining length
+            2 +                   // topic name length, topic name
+            (packet_id_.empty() ? 0 : 1) +  // packet_id
+            1;                    // payload
+    }
+
+    /**
      * @brief Create one continuours buffer.
      *        All sequence of buffers are concatinated.
      *        It is useful to store to file/database.
@@ -740,12 +784,7 @@ public:
      */
     std::vector<as::const_buffer> const_buffer_sequence() const {
         std::vector<as::const_buffer> ret;
-        ret.reserve(
-            1 +                   // fixed header
-            1 +                   // remaining length
-            1 +                   // packet id
-            entries_.size() * 3   // topic name length, topic name, qos
-        );
+        ret.reserve(num_of_const_buffer_sequence());
 
         ret.emplace_back(as::buffer(&fixed_header_, 1));
 
@@ -769,6 +808,18 @@ public:
      */
     std::size_t size() const {
         return 1 + remaining_length_buf_.size() + remaining_length_;
+    }
+
+    /**
+     * @brief Get number of element of const_buffer_sequence
+     * @return number of element of const_buffer_sequence
+     */
+    std::size_t num_of_const_buffer_sequence() const {
+        return
+            1 +                   // fixed header
+            1 +                   // remaining length
+            1 +                   // packet id
+            entries_.size() * 3;  // topic name length, topic name, qos
     }
 
     /**
@@ -835,7 +886,7 @@ public:
      */
     std::vector<as::const_buffer> const_buffer_sequence() const {
         std::vector<as::const_buffer> ret;
-        ret.reserve(4); // fixed header, remaining length, packet_id, entries
+        ret.reserve(num_of_const_buffer_sequence());
 
         ret.emplace_back(as::buffer(&fixed_header_, 1));
         ret.emplace_back(as::buffer(remaining_length_buf_.data(), remaining_length_buf_.size()));
@@ -851,6 +902,14 @@ public:
      */
     std::size_t size() const {
         return 1 + remaining_length_buf_.size() + remaining_length_;
+    }
+
+    /**
+     * @brief Get number of element of const_buffer_sequence
+     * @return number of element of const_buffer_sequence
+     */
+    std::size_t num_of_const_buffer_sequence() const {
+        return 4; // fixed header, remaining length, packet_id, entries
     }
 
     /**
@@ -925,12 +984,7 @@ public:
      */
     std::vector<as::const_buffer> const_buffer_sequence() const {
         std::vector<as::const_buffer> ret;
-        ret.reserve(
-            1 +                   // fixed header
-            1 +                   // remaining length
-            1 +                   // packet id
-            entries_.size() * 2   // topic name length, topic name
-        );
+        ret.reserve(num_of_const_buffer_sequence());
 
         ret.emplace_back(as::buffer(&fixed_header_, 1));
         ret.emplace_back(as::buffer(remaining_length_buf_.data(), remaining_length_buf_.size()));
@@ -943,7 +997,6 @@ public:
             ret.emplace_back(e.topic_name);
         }
 
-
         return ret;
     }
 
@@ -953,6 +1006,18 @@ public:
      */
     std::size_t size() const {
         return 1 + remaining_length_buf_.size() + remaining_length_;
+    }
+
+    /**
+     * @brief Get number of element of const_buffer_sequence
+     * @return number of element of const_buffer_sequence
+     */
+    std::size_t num_of_const_buffer_sequence() const {
+        return
+            1 +                   // fixed header
+            1 +                   // remaining length
+            1 +                   // packet id
+            entries_.size() * 2;  // topic name length, topic name
     }
 
     /**

--- a/include/mqtt/message_variant.hpp
+++ b/include/mqtt/message_variant.hpp
@@ -72,6 +72,19 @@ struct size_visitor
     }
 };
 
+struct num_of_const_buffer_sequence_visitor
+
+#if !defined(MQTT_STD_VARIANT)
+    : boost::static_visitor<std::size_t>
+#endif // !defined(MQTT_STD_VARIANT)
+
+{
+    template <typename T>
+    std::size_t operator()(T&& t) const {
+        return t.num_of_const_buffer_sequence();
+    }
+};
+
 struct continuous_buffer_visitor
 
 #if !defined(MQTT_STD_VARIANT)
@@ -96,6 +109,12 @@ inline std::vector<as::const_buffer> const_buffer_sequence(
 template <std::size_t PacketIdBytes>
 inline std::size_t size(basic_message_variant<PacketIdBytes> const& mv) {
     return mqtt::visit(detail::size_visitor(), mv);
+}
+
+template <std::size_t PacketIdBytes>
+inline std::size_t num_of_const_buffer_sequence(
+    basic_message_variant<PacketIdBytes> const& mv) {
+    return mqtt::visit(detail::num_of_const_buffer_sequence_visitor(), mv);
 }
 
 template <std::size_t PacketIdBytes>


### PR DESCRIPTION
Send multiple messages in `queue_` all at once.
Size limit is not implemented yet.