### PR TITLE
Cleanup of various functions regarding strings

### DIFF
--- a/test/pubsub.cpp
+++ b/test/pubsub.cpp
@@ -223,7 +223,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
                     pid_sub = c->subscribe(
-                        std::vector<std::tuple<std::string, std::uint8_t>> {
+                        std::vector<std::tuple<mqtt::string_view, std::uint8_t>> {
                             std::make_tuple("topic1", mqtt::qos::at_most_once)
                         }
                     );
@@ -236,7 +236,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                     BOOST_TEST(packet_id == pid_pub);
                     pub_seq_finished = true;
                     pid_unsub = c->unsubscribe(
-                        std::vector<std::string> {"topic1"});
+                        std::vector<mqtt::string_view> {"topic1"});
                     return true;
                 });
             c->set_pubrec_handler(
@@ -293,7 +293,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
                     pid_sub = c->subscribe(
-                        std::vector<std::tuple<std::string, std::uint8_t>> {
+                        std::vector<std::tuple<mqtt::string_view, std::uint8_t>> {
                             std::make_tuple("topic1", mqtt::qos::at_most_once)
                         }
                     );
@@ -306,7 +306,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                     BOOST_TEST(packet_id == pid_pub);
                     pub_seq_finished = true;
                     pid_unsub = c->unsubscribe(
-                        std::vector<std::string> {"topic1"});
+                        std::vector<mqtt::string_view> {"topic1"});
                     return true;
                 });
             c->set_v5_pubrec_handler(

--- a/test/sub.cpp
+++ b/test/sub.cpp
@@ -219,7 +219,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec ) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-                    std::vector<std::tuple<std::string, std::uint8_t>> v;
+                    std::vector<std::tuple<mqtt::string_view, std::uint8_t>> v;
                     v.emplace_back("topic1", mqtt::qos::at_most_once);
                     v.emplace_back("topic2", mqtt::qos::exactly_once);
                     c->subscribe(v);
@@ -229,7 +229,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec ) {
                 [&chk, &c]
                 (packet_id_t /*packet_id*/, std::vector<mqtt::optional<std::uint8_t>> /*results*/) {
                     MQTT_CHK("h_suback");
-                    std::vector<std::string> v
+                    std::vector<mqtt::string_view> v
                         {
                          "topic1",
                          "topic2",
@@ -252,7 +252,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec ) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == mqtt::connect_return_code::accepted);
-                    std::vector<std::tuple<std::string, std::uint8_t>> v;
+                    std::vector<std::tuple<mqtt::string_view, std::uint8_t>> v;
                     v.emplace_back("topic1", mqtt::qos::at_most_once);
                     v.emplace_back("topic2", mqtt::qos::exactly_once);
                     c->subscribe(v);
@@ -262,7 +262,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec ) {
                 [&chk, &c]
                 (packet_id_t /*packet_id*/, std::vector<std::uint8_t> /*reasons*/, std::vector<mqtt::v5::property_variant> /*props*/) {
                     MQTT_CHK("h_suback");
-                    std::vector<std::string> v
+                    std::vector<mqtt::string_view> v
                         {
                          "topic1",
                          "topic2",


### PR DESCRIPTION
Trying to improve the lifetime management of string objects. Use string_view where ownership doesn't need to transfer, using std::move() where it does.