### PR TITLE
Refined visitor for properties.

### DIFF
--- a/include/mqtt/property.hpp
+++ b/include/mqtt/property.hpp
@@ -279,6 +279,7 @@ struct variable_property {
 
 class payload_format_indicator : public detail::n_bytes_property<1> {
 public:
+    using recv = payload_format_indicator;
     enum payload_format {
         binary,
         string
@@ -303,6 +304,7 @@ public:
 
 class message_expiry_interval : public detail::n_bytes_property<4> {
 public:
+    using recv = message_expiry_interval;
     message_expiry_interval(std::uint32_t val)
         : detail::n_bytes_property<4>(id::message_expiry_interval, { MQTT_32BITNUM_TO_BYTE_SEQ(val) } ) {}
 
@@ -315,50 +317,58 @@ public:
     }
 };
 
-class content_type : public detail::string_property {
-public:
-    content_type(string_view type)
-        : detail::string_property(id::content_type, type) {}
-};
-
 class content_type_ref : public detail::string_property_ref {
 public:
+    using recv = content_type_ref;
     content_type_ref(string_view type)
         : detail::string_property_ref(id::content_type, type) {}
 };
 
-class response_topic : public detail::string_property {
+class content_type : public detail::string_property {
 public:
-    response_topic(string_view type)
-        : detail::string_property(id::response_topic, type) {}
+    using recv = content_type_ref;
+    content_type(string_view type)
+        : detail::string_property(id::content_type, type) {}
 };
 
 class response_topic_ref : public detail::string_property_ref {
 public:
+    using recv = response_topic_ref;
     response_topic_ref(string_view type)
         : detail::string_property_ref(id::response_topic, type) {}
 };
 
-class correlation_data : public detail::string_property {
+class response_topic : public detail::string_property {
 public:
-    correlation_data(string_view type)
-        : detail::string_property(id::correlation_data, type) {}
+    using recv = response_topic_ref;
+    response_topic(string_view type)
+        : detail::string_property(id::response_topic, type) {}
 };
 
 class correlation_data_ref : public detail::string_property_ref {
 public:
+    using recv = correlation_data_ref;
     correlation_data_ref(string_view type)
         : detail::string_property_ref(id::correlation_data, type) {}
 };
 
+class correlation_data : public detail::string_property {
+public:
+    using recv = correlation_data_ref;
+    correlation_data(string_view type)
+        : detail::string_property(id::correlation_data, type) {}
+};
+
 class subscription_identifier : public detail::variable_property {
 public:
+    using recv = subscription_identifier;
     subscription_identifier(std::size_t subscription_id)
         : detail::variable_property(id::subscription_identifier, subscription_id) {}
 };
 
 class session_expiry_interval : public detail::n_bytes_property<4> {
 public:
+    using recv = session_expiry_interval;
     session_expiry_interval(std::uint32_t val)
         : detail::n_bytes_property<4>(id::session_expiry_interval, { MQTT_32BITNUM_TO_BYTE_SEQ(val) } ) {}
 
@@ -371,20 +381,23 @@ public:
     }
 };
 
-class assigned_client_identifier : public detail::string_property {
-public:
-    assigned_client_identifier(string_view type)
-        : detail::string_property(id::assigned_client_identifier, type) {}
-};
-
 class assigned_client_identifier_ref : public detail::string_property_ref {
 public:
+    using recv = assigned_client_identifier_ref;
     assigned_client_identifier_ref(string_view type)
         : detail::string_property_ref(id::assigned_client_identifier, type) {}
 };
 
+class assigned_client_identifier : public detail::string_property {
+public:
+    using recv = assigned_client_identifier_ref;
+    assigned_client_identifier(string_view type)
+        : detail::string_property(id::assigned_client_identifier, type) {}
+};
+
 class server_keep_alive : public detail::n_bytes_property<2> {
 public:
+    using recv = server_keep_alive;
     server_keep_alive(std::uint16_t val)
         : detail::n_bytes_property<2>(id::server_keep_alive, { MQTT_16BITNUM_TO_BYTE_SEQ(val) } ) {}
 
@@ -397,32 +410,37 @@ public:
     }
 };
 
-class authentication_method : public detail::string_property {
-public:
-    authentication_method(string_view type)
-        : detail::string_property(id::authentication_method, type) {}
-};
-
 class authentication_method_ref : public detail::string_property_ref {
 public:
+    using recv = authentication_method_ref;
     authentication_method_ref(string_view type)
         : detail::string_property_ref(id::authentication_method, type) {}
 };
 
-class authentication_data : public detail::binary_property {
+class authentication_method : public detail::string_property {
 public:
-    authentication_data(string_view type)
-        : detail::binary_property(id::authentication_data, type) {}
+    using recv = authentication_method_ref;
+    authentication_method(string_view type)
+        : detail::string_property(id::authentication_method, type) {}
 };
 
 class authentication_data_ref : public detail::binary_property_ref {
 public:
+    using recv = authentication_data_ref;
     authentication_data_ref(string_view type)
         : detail::binary_property_ref(id::authentication_data, type) {}
 };
 
+class authentication_data : public detail::binary_property {
+public:
+    using recv = authentication_data_ref;
+    authentication_data(string_view type)
+        : detail::binary_property(id::authentication_data, type) {}
+};
+
 class request_problem_information : public detail::n_bytes_property<1> {
 public:
+    using recv = request_problem_information;
     request_problem_information(bool value)
         : detail::n_bytes_property<1>(id::request_problem_information, { value ? char(1) : char(0) } ) {}
 
@@ -437,6 +455,7 @@ public:
 
 class will_delay_interval : public detail::n_bytes_property<4> {
 public:
+    using recv = will_delay_interval;
     will_delay_interval(std::uint32_t val)
         : detail::n_bytes_property<4>(id::will_delay_interval, { MQTT_32BITNUM_TO_BYTE_SEQ(val) } ) {}
 
@@ -451,6 +470,7 @@ public:
 
 class request_response_information : public detail::n_bytes_property<1> {
 public:
+    using recv = request_response_information;
     request_response_information(bool value)
         : detail::n_bytes_property<1>(id::request_response_information, { value ? char(1) : char(0) } ) {}
 
@@ -463,44 +483,51 @@ public:
     }
 };
 
-class response_information : public detail::string_property {
-public:
-    response_information(string_view type)
-        : detail::string_property(id::response_information, type) {}
-};
-
 class response_information_ref : public detail::string_property_ref {
 public:
+    using recv = response_information_ref;
     response_information_ref(string_view type)
         : detail::string_property_ref(id::response_information, type) {}
 };
 
-class server_reference : public detail::string_property {
+class response_information : public detail::string_property {
 public:
-    server_reference(string_view type)
-        : detail::string_property(id::server_reference, type) {}
+    using recv = response_information_ref;
+    response_information(string_view type)
+        : detail::string_property(id::response_information, type) {}
 };
 
 class server_reference_ref : public detail::string_property_ref {
 public:
+    using recv = server_reference_ref;
     server_reference_ref(string_view type)
         : detail::string_property_ref(id::server_reference, type) {}
 };
 
-class reason_string : public detail::string_property {
+class server_reference : public detail::string_property {
 public:
-    reason_string(string_view type)
-        : detail::string_property(id::reason_string, type) {}
+    using recv = server_reference_ref;
+    server_reference(string_view type)
+        : detail::string_property(id::server_reference, type) {}
 };
 
 class reason_string_ref : public detail::string_property_ref {
 public:
+    using recv = reason_string_ref;
     reason_string_ref(string_view type)
         : detail::string_property_ref(id::reason_string, type) {}
 };
 
+class reason_string : public detail::string_property {
+public:
+    using recv = reason_string_ref;
+    reason_string(string_view type)
+        : detail::string_property(id::reason_string, type) {}
+};
+
 class receive_maximum : public detail::n_bytes_property<2> {
 public:
+    using recv = receive_maximum;
     receive_maximum(std::uint16_t val)
         : detail::n_bytes_property<2>(id::receive_maximum, { MQTT_16BITNUM_TO_BYTE_SEQ(val) } ) {}
 
@@ -515,6 +542,7 @@ public:
 
 class topic_alias_maximum : public detail::n_bytes_property<2> {
 public:
+    using recv = topic_alias_maximum;
     topic_alias_maximum(std::uint16_t val)
         : detail::n_bytes_property<2>(id::topic_alias_maximum, { MQTT_16BITNUM_TO_BYTE_SEQ(val) } ) {}
 
@@ -529,6 +557,7 @@ public:
 
 class topic_alias : public detail::n_bytes_property<2> {
 public:
+    using recv = topic_alias;
     topic_alias(std::uint16_t val)
         : detail::n_bytes_property<2>(id::topic_alias, { MQTT_16BITNUM_TO_BYTE_SEQ(val) } ) {}
 
@@ -543,6 +572,7 @@ public:
 
 class maximum_qos : public detail::n_bytes_property<1> {
 public:
+    using recv = maximum_qos;
     maximum_qos(std::uint8_t qos)
         : detail::n_bytes_property<1>(id::maximum_qos, { static_cast<char>(qos) } ) {
         if (qos != qos::at_most_once &&
@@ -561,6 +591,7 @@ public:
 
 class retain_available : public detail::n_bytes_property<1> {
 public:
+    using recv = retain_available;
     retain_available(bool value)
         : detail::n_bytes_property<1>(id::retain_available, { value ? char(1) : char(0) } ) {}
 
@@ -573,105 +604,12 @@ public:
     }
 };
 
-class user_property {
-    struct len_str {
-        explicit len_str(string_view v)
-            : len{MQTT_16BITNUM_TO_BYTE_SEQ(v.size())}
-            , str(v.data(), v.size())
-        {}
-        std::size_t size() const {
-            return len.size() + str.size();
-        }
-        boost::container::static_vector<char, 2> len;
-        std::string str;
-    };
-public:
-    user_property(string_view key, string_view val)
-        : key_(key), val_(val) {}
-
-    /**
-     * @brief Add const buffer sequence into the given buffer.
-     * @param v buffer to add
-     */
-    void add_const_buffer_sequence(std::vector<as::const_buffer>& v) const {
-        v.emplace_back(as::buffer(&id_, 1));
-        v.emplace_back(as::buffer(key_.len.data(), key_.len.size()));
-        v.emplace_back(as::buffer(key_.str.data(), key_.str.size()));
-        v.emplace_back(as::buffer(val_.len.data(), val_.len.size()));
-        v.emplace_back(as::buffer(val_.str.data(), val_.str.size()));
-    }
-
-    template <typename It>
-    void fill(It b, It e) const {
-        BOOST_ASSERT(static_cast<std::size_t>(std::distance(b, e)) >= size());
-
-        *b++ = static_cast<typename std::iterator_traits<It>::value_type>(id_);
-        {
-            std::copy(key_.len.begin(), key_.len.end(), b);
-            b += static_cast<typename It::difference_type>(key_.len.size());
-            auto ptr = key_.str.data();
-            auto size = key_.str.size();
-            std::copy(ptr, ptr + size, b);
-            b += static_cast<typename It::difference_type>(size);
-        }
-        {
-            std::copy(val_.len.begin(), val_.len.end(), b);
-            b += static_cast<typename It::difference_type>(val_.len.size());
-            auto ptr = val_.str.data();
-            auto size = val_.str.size();
-            std::copy(ptr, ptr + size, b);
-            b += static_cast<typename It::difference_type>(size);
-        }
-    }
-
-    /**
-     * @brief Get whole size of sequence
-     * @return whole size
-     */
-    std::size_t size() const {
-        return
-            1 + // id_
-            key_.size() +
-            val_.size();
-    }
-
-    /**
-     * @brief Get number of element of const_buffer_sequence
-     * @return number of element of const_buffer_sequence
-     */
-    std::size_t num_of_const_buffer_sequence() const {
-        return
-            1 + // header
-            2 + // key (len, str)
-            2;  // val (len, str)
-    }
-
-    string_view key() const {
-        return key_.str;
-    }
-
-    string_view val() const {
-        return val_.str;
-    }
-
-private:
-    property::id id_ = id::user_property;
-    len_str key_;
-    len_str val_;
-};
-
 class user_property_ref {
     struct len_str {
         explicit len_str(string_view v)
             : len{MQTT_16BITNUM_TO_BYTE_SEQ(v.size())}
             , str(as::buffer(v.data(), v.size()))
         {}
-#if 0
-        explicit len_str(as::const_buffer v)
-            : len{MQTT_16BITNUM_TO_BYTE_SEQ(get_size(v))}
-            , str(v)
-        {}
-#endif
         std::size_t size() const {
             return len.size() + get_size(str);
         }
@@ -679,6 +617,7 @@ class user_property_ref {
         as::const_buffer str;
     };
 public:
+    using recv = user_property_ref;
     user_property_ref(string_view key, string_view val)
         : key_(key), val_(val) {}
 
@@ -753,8 +692,97 @@ private:
     len_str val_;
 };
 
+class user_property {
+    struct len_str {
+        explicit len_str(string_view v)
+            : len{MQTT_16BITNUM_TO_BYTE_SEQ(v.size())}
+            , str(v.data(), v.size())
+        {}
+        std::size_t size() const {
+            return len.size() + str.size();
+        }
+        boost::container::static_vector<char, 2> len;
+        std::string str;
+    };
+public:
+    using recv = user_property_ref;
+    user_property(string_view key, string_view val)
+        : key_(key), val_(val) {}
+
+    /**
+     * @brief Add const buffer sequence into the given buffer.
+     * @param v buffer to add
+     */
+    void add_const_buffer_sequence(std::vector<as::const_buffer>& v) const {
+        v.emplace_back(as::buffer(&id_, 1));
+        v.emplace_back(as::buffer(key_.len.data(), key_.len.size()));
+        v.emplace_back(as::buffer(key_.str.data(), key_.str.size()));
+        v.emplace_back(as::buffer(val_.len.data(), val_.len.size()));
+        v.emplace_back(as::buffer(val_.str.data(), val_.str.size()));
+    }
+
+    template <typename It>
+    void fill(It b, It e) const {
+        BOOST_ASSERT(static_cast<std::size_t>(std::distance(b, e)) >= size());
+
+        *b++ = static_cast<typename std::iterator_traits<It>::value_type>(id_);
+        {
+            std::copy(key_.len.begin(), key_.len.end(), b);
+            b += static_cast<typename It::difference_type>(key_.len.size());
+            auto ptr = key_.str.data();
+            auto size = key_.str.size();
+            std::copy(ptr, ptr + size, b);
+            b += static_cast<typename It::difference_type>(size);
+        }
+        {
+            std::copy(val_.len.begin(), val_.len.end(), b);
+            b += static_cast<typename It::difference_type>(val_.len.size());
+            auto ptr = val_.str.data();
+            auto size = val_.str.size();
+            std::copy(ptr, ptr + size, b);
+            b += static_cast<typename It::difference_type>(size);
+        }
+    }
+
+    /**
+     * @brief Get whole size of sequence
+     * @return whole size
+     */
+    std::size_t size() const {
+        return
+            1 + // id_
+            key_.size() +
+            val_.size();
+    }
+
+    /**
+     * @brief Get number of element of const_buffer_sequence
+     * @return number of element of const_buffer_sequence
+     */
+    std::size_t num_of_const_buffer_sequence() const {
+        return
+            1 + // header
+            2 + // key (len, str)
+            2;  // val (len, str)
+    }
+
+    string_view key() const {
+        return key_.str;
+    }
+
+    string_view val() const {
+        return val_.str;
+    }
+
+private:
+    property::id id_ = id::user_property;
+    len_str key_;
+    len_str val_;
+};
+
 class maximum_packet_size : public detail::n_bytes_property<4> {
 public:
+    using recv = maximum_packet_size;
     maximum_packet_size(std::uint32_t val)
         : detail::n_bytes_property<4>(id::maximum_packet_size, { MQTT_32BITNUM_TO_BYTE_SEQ(val) } ) {}
 
@@ -769,6 +797,7 @@ public:
 
 class wildcard_subscription_available : public detail::n_bytes_property<1> {
 public:
+    using recv = wildcard_subscription_available;
     wildcard_subscription_available(bool value)
         : detail::n_bytes_property<1>(id::wildcard_subscription_available, { value ? char(1) : char(0) } ) {}
 
@@ -783,6 +812,7 @@ public:
 
 class subscription_identifier_available : public detail::n_bytes_property<1> {
 public:
+    using recv = subscription_identifier_available;
     subscription_identifier_available(bool value)
         : detail::n_bytes_property<1>(id::subscription_identifier_available, { value ? char(1) : char(0) } ) {}
 
@@ -797,6 +827,7 @@ public:
 
 class shared_subscription_available : public detail::n_bytes_property<1> {
 public:
+    using recv = shared_subscription_available;
     shared_subscription_available(bool value)
         : detail::n_bytes_property<1>(id::shared_subscription_available, { value ? char(1) : char(0) } ) {}
 

--- a/include/mqtt_client_cpp.hpp
+++ b/include/mqtt_client_cpp.hpp
@@ -23,4 +23,5 @@
 #include <mqtt/str_connect_return_code.hpp>
 #include <mqtt/str_qos.hpp>
 #include <mqtt/utf8encoded_strings.hpp>
+#include <mqtt/visitor_util.hpp>
 #include <mqtt/will.hpp>

--- a/include/mqtt_server_cpp.hpp
+++ b/include/mqtt_server_cpp.hpp
@@ -21,4 +21,5 @@
 #include <mqtt/str_connect_return_code.hpp>
 #include <mqtt/str_qos.hpp>
 #include <mqtt/utf8encoded_strings.hpp>
+#include <mqtt/visitor_util.hpp>
 #include <mqtt/will.hpp>

--- a/test/async_pubsub_2.cpp
+++ b/test/async_pubsub_2.cpp
@@ -1017,22 +1017,22 @@ BOOST_AUTO_TEST_CASE( pub_sub_prop ) {
                 for (auto const& p : props) {
                     mqtt::visit(
                         mqtt::make_lambda_visitor<void>(
-                            [&](mqtt::v5::property::payload_format_indicator const& t) {
+                            [&](mqtt::v5::property::payload_format_indicator::recv const& t) {
                                 BOOST_TEST(t.val() == mqtt::v5::property::payload_format_indicator::string);
                             },
-                            [&](mqtt::v5::property::message_expiry_interval const& t) {
+                            [&](mqtt::v5::property::message_expiry_interval::recv const& t) {
                                 BOOST_TEST(t.val() == 0x12345678UL);
                             },
-                            [&](mqtt::v5::property::topic_alias const& t) {
+                            [&](mqtt::v5::property::topic_alias::recv const& t) {
                                 BOOST_TEST(t.val() == 0x1234U);
                             },
-                            [&](mqtt::v5::property::response_topic_ref const& t) {
+                            [&](mqtt::v5::property::response_topic::recv const& t) {
                                 BOOST_TEST(t.val() == "response topic");
                             },
-                            [&](mqtt::v5::property::correlation_data_ref const& t) {
+                            [&](mqtt::v5::property::correlation_data::recv const& t) {
                                 BOOST_TEST(t.val() == "correlation data");
                             },
-                            [&](mqtt::v5::property::user_property_ref const& t) {
+                            [&](mqtt::v5::property::user_property::recv const& t) {
                                 switch (user_prop_count++) {
                                 case 0:
                                     BOOST_TEST(t.key() == "key1");
@@ -1142,10 +1142,10 @@ BOOST_AUTO_TEST_CASE( puback_props ) {
                 for (auto const& p : props) {
                     mqtt::visit(
                         mqtt::make_lambda_visitor<void>(
-                            [&](mqtt::v5::property::reason_string_ref const& t) {
+                            [&](mqtt::v5::property::reason_string::recv const& t) {
                                 BOOST_TEST(t.val() == "test success");
                             },
-                            [&](mqtt::v5::property::user_property_ref const& t) {
+                            [&](mqtt::v5::property::user_property::recv const& t) {
                                 switch (puback_user_prop_count++) {
                                 case 0:
                                     BOOST_TEST(t.key() == "key1");
@@ -1332,10 +1332,10 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
                 for (auto const& p : props) {
                     mqtt::visit(
                         mqtt::make_lambda_visitor<void>(
-                            [&](mqtt::v5::property::reason_string_ref const& t) {
+                            [&](mqtt::v5::property::reason_string::recv const& t) {
                                 BOOST_TEST(t.val() == "test success");
                             },
-                            [&](mqtt::v5::property::user_property_ref const& t) {
+                            [&](mqtt::v5::property::user_property::recv const& t) {
                                 switch (pubrec_user_prop_count++) {
                                 case 0:
                                     BOOST_TEST(t.key() == "key1");
@@ -1366,10 +1366,10 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
                 for (auto const& p : props) {
                     mqtt::visit(
                         mqtt::make_lambda_visitor<void>(
-                            [&](mqtt::v5::property::reason_string_ref const& t) {
+                            [&](mqtt::v5::property::reason_string::recv const& t) {
                                 BOOST_TEST(t.val() == "test success");
                             },
-                            [&](mqtt::v5::property::user_property_ref const& t) {
+                            [&](mqtt::v5::property::user_property::recv const& t) {
                                 switch (pubrel_user_prop_count++) {
                                 case 0:
                                     BOOST_TEST(t.key() == "key1");
@@ -1400,10 +1400,10 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
                 for (auto const& p : props) {
                     mqtt::visit(
                         mqtt::make_lambda_visitor<void>(
-                            [&](mqtt::v5::property::reason_string_ref const& t) {
+                            [&](mqtt::v5::property::reason_string::recv const& t) {
                                 BOOST_TEST(t.val() == "test success");
                             },
-                            [&](mqtt::v5::property::user_property_ref const& t) {
+                            [&](mqtt::v5::property::user_property::recv const& t) {
                                 switch (pubcomp_user_prop_count++) {
                                 case 0:
                                     BOOST_TEST(t.key() == "key1");

--- a/test/connect.cpp
+++ b/test/connect.cpp
@@ -899,25 +899,25 @@ BOOST_AUTO_TEST_CASE( connect_disconnect_prop ) {
                 for (auto const& p : props) {
                     mqtt::visit(
                         mqtt::make_lambda_visitor<void>(
-                            [&](mqtt::v5::property::session_expiry_interval const& t) {
+                            [&](mqtt::v5::property::session_expiry_interval::recv const& t) {
                                 BOOST_TEST(t.val() == 0x12345678UL);
                             },
-                            [&](mqtt::v5::property::receive_maximum const& t) {
+                            [&](mqtt::v5::property::receive_maximum::recv const& t) {
                                 BOOST_TEST(t.val() == 0x1234U);
                             },
-                            [&](mqtt::v5::property::maximum_packet_size const& t) {
+                            [&](mqtt::v5::property::maximum_packet_size::recv const& t) {
                                 BOOST_TEST(t.val() == 0x12345678UL);
                             },
-                            [&](mqtt::v5::property::topic_alias_maximum const& t) {
+                            [&](mqtt::v5::property::topic_alias_maximum::recv const& t) {
                                 BOOST_TEST(t.val() == 0x1234U);
                             },
-                            [&](mqtt::v5::property::request_response_information const& t) {
+                            [&](mqtt::v5::property::request_response_information::recv const& t) {
                                 BOOST_TEST(t.val() == true);
                             },
-                            [&](mqtt::v5::property::request_problem_information const& t) {
+                            [&](mqtt::v5::property::request_problem_information::recv const& t) {
                                 BOOST_TEST(t.val() == false);
                             },
-                            [&](mqtt::v5::property::user_property_ref const& t) {
+                            [&](mqtt::v5::property::user_property::recv const& t) {
                                 switch (con_user_prop_count++) {
                                 case 0:
                                     BOOST_TEST(t.key() == "key1");
@@ -932,10 +932,10 @@ BOOST_AUTO_TEST_CASE( connect_disconnect_prop ) {
                                     break;
                                 }
                             },
-                            [&](mqtt::v5::property::authentication_method_ref const& t) {
+                            [&](mqtt::v5::property::authentication_method::recv const& t) {
                                 BOOST_TEST(t.val() == "test authentication method");
                             },
-                            [&](mqtt::v5::property::authentication_data_ref const& t) {
+                            [&](mqtt::v5::property::authentication_data::recv const& t) {
                                 BOOST_TEST(t.val() == "test authentication data");
                             },
                             [&](auto&& ...) {
@@ -954,13 +954,13 @@ BOOST_AUTO_TEST_CASE( connect_disconnect_prop ) {
                 for (auto const& p : props) {
                     mqtt::visit(
                         mqtt::make_lambda_visitor<void>(
-                            [&](mqtt::v5::property::session_expiry_interval const& t) {
+                            [&](mqtt::v5::property::session_expiry_interval::recv const& t) {
                                 BOOST_TEST(t.val() == 0x12345678UL);
                             },
-                            [&](mqtt::v5::property::reason_string_ref const& t) {
+                            [&](mqtt::v5::property::reason_string::recv const& t) {
                                 BOOST_TEST(t.val() == "test reason string");
                             },
-                            [&](mqtt::v5::property::user_property_ref const& t) {
+                            [&](mqtt::v5::property::user_property::recv const& t) {
                                 switch (discon_user_prop_count++) {
                                 case 0:
                                     BOOST_TEST(t.key() == "key1");
@@ -975,7 +975,7 @@ BOOST_AUTO_TEST_CASE( connect_disconnect_prop ) {
                                     break;
                                 }
                             },
-                            [&](mqtt::v5::property::server_reference_ref const& t) {
+                            [&](mqtt::v5::property::server_reference::recv const& t) {
                                 BOOST_TEST(t.val() == "test server reference");
                             },
                             [&](auto&& ...) {
@@ -1074,31 +1074,31 @@ BOOST_AUTO_TEST_CASE( connack_prop ) {
                 for (auto const& p : props) {
                     mqtt::visit(
                         mqtt::make_lambda_visitor<void>(
-                            [&](mqtt::v5::property::session_expiry_interval const& t) {
+                            [&](mqtt::v5::property::session_expiry_interval::recv const& t) {
                                 BOOST_TEST(t.val() == 0);
                             },
-                            [&](mqtt::v5::property::receive_maximum const& t) {
+                            [&](mqtt::v5::property::receive_maximum::recv const& t) {
                                 BOOST_TEST(t.val() == 0);
                             },
-                            [&](mqtt::v5::property::maximum_qos const& t) {
+                            [&](mqtt::v5::property::maximum_qos::recv const& t) {
                                 BOOST_TEST(t.val() == 2);
                             },
-                            [&](mqtt::v5::property::retain_available const& t) {
+                            [&](mqtt::v5::property::retain_available::recv const& t) {
                                 BOOST_TEST(t.val() == true);
                             },
-                            [&](mqtt::v5::property::maximum_packet_size const& t) {
+                            [&](mqtt::v5::property::maximum_packet_size::recv const& t) {
                                 BOOST_TEST(t.val() == 0);
                             },
-                            [&](mqtt::v5::property::assigned_client_identifier_ref const& t) {
+                            [&](mqtt::v5::property::assigned_client_identifier::recv const& t) {
                                 BOOST_TEST(t.val() == "test cid");
                             },
-                            [&](mqtt::v5::property::topic_alias_maximum const& t) {
+                            [&](mqtt::v5::property::topic_alias_maximum::recv const& t) {
                                 BOOST_TEST(t.val() == 0);
                             },
-                            [&](mqtt::v5::property::reason_string_ref const& t) {
+                            [&](mqtt::v5::property::reason_string::recv const& t) {
                                 BOOST_TEST(t.val() == "test connect success");
                             },
-                            [&](mqtt::v5::property::user_property_ref const& t) {
+                            [&](mqtt::v5::property::user_property::recv const& t) {
                                 switch (user_prop_count++) {
                                 case 0:
                                     BOOST_TEST(t.key() == "key1");
@@ -1113,28 +1113,28 @@ BOOST_AUTO_TEST_CASE( connack_prop ) {
                                     break;
                                 }
                             },
-                            [&](mqtt::v5::property::wildcard_subscription_available const& t) {
+                            [&](mqtt::v5::property::wildcard_subscription_available::recv const& t) {
                                 BOOST_TEST(t.val() == false);
                             },
-                            [&](mqtt::v5::property::subscription_identifier_available const& t) {
+                            [&](mqtt::v5::property::subscription_identifier_available::recv const& t) {
                                 BOOST_TEST(t.val() == false);
                             },
-                            [&](mqtt::v5::property::shared_subscription_available const& t) {
+                            [&](mqtt::v5::property::shared_subscription_available::recv const& t) {
                                 BOOST_TEST(t.val() == false);
                             },
-                            [&](mqtt::v5::property::server_keep_alive const& t) {
+                            [&](mqtt::v5::property::server_keep_alive::recv const& t) {
                                 BOOST_TEST(t.val() == 0);
                             },
-                            [&](mqtt::v5::property::response_information_ref const& t) {
+                            [&](mqtt::v5::property::response_information::recv const& t) {
                                 BOOST_TEST(t.val() == "test response information");
                             },
-                            [&](mqtt::v5::property::server_reference_ref const& t) {
+                            [&](mqtt::v5::property::server_reference::recv const& t) {
                                 BOOST_TEST(t.val() == "test server reference");
                             },
-                            [&](mqtt::v5::property::authentication_method_ref const& t) {
+                            [&](mqtt::v5::property::authentication_method::recv const& t) {
                                 BOOST_TEST(t.val() == "test authentication method");
                             },
-                            [&](mqtt::v5::property::authentication_data_ref const& t) {
+                            [&](mqtt::v5::property::authentication_data::recv const& t) {
                                 BOOST_TEST(t.val() == "test authentication data");
                             },
                             [&](auto&& ...) {

--- a/test/pubsub.cpp
+++ b/test/pubsub.cpp
@@ -2168,22 +2168,22 @@ BOOST_AUTO_TEST_CASE( pub_sub_prop ) {
                 for (auto const& p : props) {
                     mqtt::visit(
                         mqtt::make_lambda_visitor<void>(
-                            [&](mqtt::v5::property::payload_format_indicator const& t) {
+                            [&](mqtt::v5::property::payload_format_indicator::recv const& t) {
                                 BOOST_TEST(t.val() == mqtt::v5::property::payload_format_indicator::string);
                             },
-                            [&](mqtt::v5::property::message_expiry_interval const& t) {
+                            [&](mqtt::v5::property::message_expiry_interval::recv const& t) {
                                 BOOST_TEST(t.val() == 0x12345678UL);
                             },
-                            [&](mqtt::v5::property::topic_alias const& t) {
+                            [&](mqtt::v5::property::topic_alias::recv const& t) {
                                 BOOST_TEST(t.val() == 0x1234U);
                             },
-                            [&](mqtt::v5::property::response_topic_ref const& t) {
+                            [&](mqtt::v5::property::response_topic::recv const& t) {
                                 BOOST_TEST(t.val() == "response topic");
                             },
-                            [&](mqtt::v5::property::correlation_data_ref const& t) {
+                            [&](mqtt::v5::property::correlation_data::recv const& t) {
                                 BOOST_TEST(t.val() == "correlation data");
                             },
-                            [&](mqtt::v5::property::user_property_ref const& t) {
+                            [&](mqtt::v5::property::user_property::recv const& t) {
                                 switch (user_prop_count++) {
                                 case 0:
                                     BOOST_TEST(t.key() == "key1");
@@ -2300,10 +2300,10 @@ BOOST_AUTO_TEST_CASE( puback_prop ) {
                 for (auto const& p : props) {
                     mqtt::visit(
                         mqtt::make_lambda_visitor<void>(
-                            [&](mqtt::v5::property::reason_string_ref const& t) {
+                            [&](mqtt::v5::property::reason_string::recv const& t) {
                                 BOOST_TEST(t.val() == "test success");
                             },
-                            [&](mqtt::v5::property::user_property_ref const& t) {
+                            [&](mqtt::v5::property::user_property::recv const& t) {
                                 switch (puback_user_prop_count++) {
                                 case 0:
                                     BOOST_TEST(t.key() == "key1");
@@ -2457,10 +2457,10 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
                 for (auto const& p : props) {
                     mqtt::visit(
                         mqtt::make_lambda_visitor<void>(
-                            [&](mqtt::v5::property::reason_string_ref const& t) {
+                            [&](mqtt::v5::property::reason_string::recv const& t) {
                                 BOOST_TEST(t.val() == "test success");
                             },
-                            [&](mqtt::v5::property::user_property_ref const& t) {
+                            [&](mqtt::v5::property::user_property::recv const& t) {
                                 switch (pubrel_user_prop_count++) {
                                 case 0:
                                     BOOST_TEST(t.key() == "key1");
@@ -2518,10 +2518,10 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
                 for (auto const& p : props) {
                     mqtt::visit(
                         mqtt::make_lambda_visitor<void>(
-                            [&](mqtt::v5::property::reason_string_ref const& t) {
+                            [&](mqtt::v5::property::reason_string::recv const& t) {
                                 BOOST_TEST(t.val() == "test success");
                             },
-                            [&](mqtt::v5::property::user_property_ref const& t) {
+                            [&](mqtt::v5::property::user_property::recv const& t) {
                                 switch (pubrec_user_prop_count++) {
                                 case 0:
                                     BOOST_TEST(t.key() == "key1");
@@ -2558,10 +2558,10 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
                 for (auto const& p : props) {
                     mqtt::visit(
                         mqtt::make_lambda_visitor<void>(
-                            [&](mqtt::v5::property::reason_string_ref const& t) {
+                            [&](mqtt::v5::property::reason_string::recv const& t) {
                                 BOOST_TEST(t.val() == "test success");
                             },
-                            [&](mqtt::v5::property::user_property_ref const& t) {
+                            [&](mqtt::v5::property::user_property::recv const& t) {
                                 switch (pubcomp_user_prop_count++) {
                                 case 0:
                                     BOOST_TEST(t.key() == "key1");

--- a/test/resend.cpp
+++ b/test/resend.cpp
@@ -56,22 +56,22 @@ BOOST_AUTO_TEST_CASE( publish_qos1 ) {
                 for (auto const& p : props) {
                     mqtt::visit(
                         mqtt::make_lambda_visitor<void>(
-                            [&](mqtt::v5::property::payload_format_indicator const& t) {
+                            [&](mqtt::v5::property::payload_format_indicator::recv const& t) {
                                 BOOST_TEST(t.val() == mqtt::v5::property::payload_format_indicator::string);
                             },
-                            [&](mqtt::v5::property::message_expiry_interval const& t) {
+                            [&](mqtt::v5::property::message_expiry_interval::recv const& t) {
                                 BOOST_TEST(t.val() == 0x12345678UL);
                             },
-                            [&](mqtt::v5::property::topic_alias const& t) {
+                            [&](mqtt::v5::property::topic_alias::recv const& t) {
                                 BOOST_TEST(t.val() == 0x1234U);
                             },
-                            [&](mqtt::v5::property::response_topic_ref const& t) {
+                            [&](mqtt::v5::property::response_topic::recv const& t) {
                                 BOOST_TEST(t.val() == "response topic");
                             },
-                            [&](mqtt::v5::property::correlation_data_ref const& t) {
+                            [&](mqtt::v5::property::correlation_data::recv const& t) {
                                 BOOST_TEST(t.val() == "correlation data");
                             },
-                            [&](mqtt::v5::property::user_property_ref const& t) {
+                            [&](mqtt::v5::property::user_property::recv const& t) {
                                 switch (user_prop_count++) {
                                 case 0:
                                     BOOST_TEST(t.key() == "key1");
@@ -414,10 +414,10 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2 ) {
                 for (auto const& p : props) {
                     mqtt::visit(
                         mqtt::make_lambda_visitor<void>(
-                            [&](mqtt::v5::property::reason_string_ref const& t) {
+                            [&](mqtt::v5::property::reason_string::recv const& t) {
                                 BOOST_TEST(t.val() == "test success");
                             },
-                            [&](mqtt::v5::property::user_property_ref const& t) {
+                            [&](mqtt::v5::property::user_property::recv const& t) {
                                 switch (user_prop_count++) {
                                 case 0:
                                     BOOST_TEST(t.key() == "key1");

--- a/test/resend_serialize.cpp
+++ b/test/resend_serialize.cpp
@@ -784,22 +784,22 @@ BOOST_AUTO_TEST_CASE( publish_qos1_v5 ) {
             for (auto const& p : props) {
                 mqtt::visit(
                     mqtt::make_lambda_visitor<void>(
-                        [&](mqtt::v5::property::payload_format_indicator const& t) {
+                        [&](mqtt::v5::property::payload_format_indicator::recv const& t) {
                             BOOST_TEST(t.val() == mqtt::v5::property::payload_format_indicator::string);
                         },
-                        [&](mqtt::v5::property::message_expiry_interval const& t) {
+                        [&](mqtt::v5::property::message_expiry_interval::recv const& t) {
                             BOOST_TEST(t.val() == 0x12345678UL);
                         },
-                        [&](mqtt::v5::property::topic_alias const& t) {
+                        [&](mqtt::v5::property::topic_alias::recv const& t) {
                             BOOST_TEST(t.val() == 0x1234U);
                         },
-                        [&](mqtt::v5::property::response_topic_ref const& t) {
+                        [&](mqtt::v5::property::response_topic::recv const& t) {
                             BOOST_TEST(t.val() == "response topic");
                         },
-                        [&](mqtt::v5::property::correlation_data_ref const& t) {
+                        [&](mqtt::v5::property::correlation_data::recv const& t) {
                             BOOST_TEST(t.val() == "correlation data");
                         },
-                        [&](mqtt::v5::property::user_property_ref const& t) {
+                        [&](mqtt::v5::property::user_property::recv const& t) {
                             switch (user_prop_count++) {
                             case 0:
                                 BOOST_TEST(t.key() == "key1");
@@ -1105,10 +1105,10 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2_v5 ) {
             for (auto const& p : props) {
                 mqtt::visit(
                     mqtt::make_lambda_visitor<void>(
-                        [&](mqtt::v5::property::reason_string_ref const& t) {
+                        [&](mqtt::v5::property::reason_string::recv const& t) {
                             BOOST_TEST(t.val() == "test success");
                         },
-                        [&](mqtt::v5::property::user_property_ref const& t) {
+                        [&](mqtt::v5::property::user_property::recv const& t) {
                             switch (user_prop_count++) {
                             case 0:
                                 BOOST_TEST(t.key() == "key1");

--- a/test/resend_serialize_ptr_size.cpp
+++ b/test/resend_serialize_ptr_size.cpp
@@ -587,22 +587,22 @@ BOOST_AUTO_TEST_CASE( publish_qos1_v5 ) {
             for (auto const& p : props) {
                 mqtt::visit(
                     mqtt::make_lambda_visitor<void>(
-                        [&](mqtt::v5::property::payload_format_indicator const& t) {
+                        [&](mqtt::v5::property::payload_format_indicator::recv const& t) {
                             BOOST_TEST(t.val() == mqtt::v5::property::payload_format_indicator::string);
                         },
-                        [&](mqtt::v5::property::message_expiry_interval const& t) {
+                        [&](mqtt::v5::property::message_expiry_interval::recv const& t) {
                             BOOST_TEST(t.val() == 0x12345678UL);
                         },
-                        [&](mqtt::v5::property::topic_alias const& t) {
+                        [&](mqtt::v5::property::topic_alias::recv const& t) {
                             BOOST_TEST(t.val() == 0x1234U);
                         },
-                        [&](mqtt::v5::property::response_topic_ref const& t) {
+                        [&](mqtt::v5::property::response_topic::recv const& t) {
                             BOOST_TEST(t.val() == "response topic");
                         },
-                        [&](mqtt::v5::property::correlation_data_ref const& t) {
+                        [&](mqtt::v5::property::correlation_data::recv const& t) {
                             BOOST_TEST(t.val() == "correlation data");
                         },
-                        [&](mqtt::v5::property::user_property_ref const& t) {
+                        [&](mqtt::v5::property::user_property::recv const& t) {
                             switch (user_prop_count++) {
                             case 0:
                                 BOOST_TEST(t.key() == "key1");
@@ -880,10 +880,10 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2_v5 ) {
             for (auto const& p : props) {
                 mqtt::visit(
                     mqtt::make_lambda_visitor<void>(
-                        [&](mqtt::v5::property::reason_string_ref const& t) {
+                        [&](mqtt::v5::property::reason_string::recv const& t) {
                             BOOST_TEST(t.val() == "test success");
                         },
-                        [&](mqtt::v5::property::user_property_ref const& t) {
+                        [&](mqtt::v5::property::user_property::recv const& t) {
                             switch (user_prop_count++) {
                             case 0:
                                 BOOST_TEST(t.key() == "key1");

--- a/test/retain.cpp
+++ b/test/retain.cpp
@@ -724,22 +724,22 @@ BOOST_AUTO_TEST_CASE( prop ) {
                 for (auto const& p : props) {
                     mqtt::visit(
                         mqtt::make_lambda_visitor<void>(
-                            [&](mqtt::v5::property::payload_format_indicator const& t) {
+                            [&](mqtt::v5::property::payload_format_indicator::recv const& t) {
                                 BOOST_TEST(t.val() == mqtt::v5::property::payload_format_indicator::string);
                             },
-                            [&](mqtt::v5::property::message_expiry_interval const& t) {
+                            [&](mqtt::v5::property::message_expiry_interval::recv const& t) {
                                 BOOST_TEST(t.val() == 0x12345678UL);
                             },
-                            [&](mqtt::v5::property::topic_alias const& t) {
+                            [&](mqtt::v5::property::topic_alias::recv const& t) {
                                 BOOST_TEST(t.val() == 0x1234U);
                             },
-                            [&](mqtt::v5::property::response_topic_ref const& t) {
+                            [&](mqtt::v5::property::response_topic::recv const& t) {
                                 BOOST_TEST(t.val() == "response topic");
                             },
-                            [&](mqtt::v5::property::correlation_data_ref const& t) {
+                            [&](mqtt::v5::property::correlation_data::recv const& t) {
                                 BOOST_TEST(t.val() == "correlation data");
                             },
-                            [&](mqtt::v5::property::user_property_ref const& t) {
+                            [&](mqtt::v5::property::user_property::recv const& t) {
                                 switch (user_prop_count++) {
                                 case 0:
                                     BOOST_TEST(t.key() == "key1");
@@ -754,7 +754,7 @@ BOOST_AUTO_TEST_CASE( prop ) {
                                     break;
                                 }
                             },
-                            [&](mqtt::v5::property::subscription_identifier const& t) {
+                            [&](mqtt::v5::property::subscription_identifier::recv const& t) {
                                 BOOST_TEST(t.val() == 123U);
                             },
                             [&](auto&& ...) {

--- a/test/sub.cpp
+++ b/test/sub.cpp
@@ -657,10 +657,10 @@ BOOST_AUTO_TEST_CASE( sub_unsub_prop ) {
                 for (auto const& p : props) {
                     mqtt::visit(
                         mqtt::make_lambda_visitor<void>(
-                            [&](mqtt::v5::property::subscription_identifier const& t) {
+                            [&](mqtt::v5::property::subscription_identifier::recv const& t) {
                                 BOOST_TEST(t.val() == 268435455UL);
                             },
-                            [&](mqtt::v5::property::user_property_ref const& t) {
+                            [&](mqtt::v5::property::user_property::recv const& t) {
                                 switch (sub_user_prop_count++) {
                                 case 0:
                                     BOOST_TEST(t.key() == "key1");
@@ -691,7 +691,7 @@ BOOST_AUTO_TEST_CASE( sub_unsub_prop ) {
                 for (auto const& p : props) {
                     mqtt::visit(
                         mqtt::make_lambda_visitor<void>(
-                            [&](mqtt::v5::property::user_property_ref const& t) {
+                            [&](mqtt::v5::property::user_property::recv const& t) {
                                 switch (unsub_user_prop_count++) {
                                 case 0:
                                     BOOST_TEST(t.key() == "key1");
@@ -812,10 +812,10 @@ BOOST_AUTO_TEST_CASE( suback_unsuback_prop ) {
                 for (auto const& p : props) {
                     mqtt::visit(
                         mqtt::make_lambda_visitor<void>(
-                            [&](mqtt::v5::property::reason_string_ref const& t) {
+                            [&](mqtt::v5::property::reason_string::recv const& t) {
                                 BOOST_TEST(t.val() == "test success");
                             },
-                            [&](mqtt::v5::property::user_property_ref const& t) {
+                            [&](mqtt::v5::property::user_property::recv const& t) {
                                 switch (sub_user_prop_count++) {
                                 case 0:
                                     BOOST_TEST(t.key() == "key1");
@@ -849,10 +849,10 @@ BOOST_AUTO_TEST_CASE( suback_unsuback_prop ) {
                 for (auto const& p : props) {
                     mqtt::visit(
                         mqtt::make_lambda_visitor<void>(
-                            [&](mqtt::v5::property::reason_string_ref const& t) {
+                            [&](mqtt::v5::property::reason_string::recv const& t) {
                                 BOOST_TEST(t.val() == "test success");
                             },
-                            [&](mqtt::v5::property::user_property_ref const& t) {
+                            [&](mqtt::v5::property::user_property::recv const& t) {
                                 switch (unsub_user_prop_count++) {
                                 case 0:
                                     BOOST_TEST(t.key() == "key1");

--- a/test/will.cpp
+++ b/test/will.cpp
@@ -733,22 +733,22 @@ BOOST_AUTO_TEST_CASE( will_prop ) {
             for (auto const& p : props) {
                 mqtt::visit(
                     mqtt::make_lambda_visitor<void>(
-                        [&](mqtt::v5::property::payload_format_indicator const& t) {
+                        [&](mqtt::v5::property::payload_format_indicator::recv const& t) {
                             BOOST_TEST(t.val() == mqtt::v5::property::payload_format_indicator::string);
                         },
-                        [&](mqtt::v5::property::message_expiry_interval const& t) {
+                        [&](mqtt::v5::property::message_expiry_interval::recv const& t) {
                             BOOST_TEST(t.val() == 0x12345678UL);
                         },
-                        [&](mqtt::v5::property::topic_alias const& t) {
+                        [&](mqtt::v5::property::topic_alias::recv const& t) {
                             BOOST_TEST(t.val() == 0x1234U);
                         },
-                        [&](mqtt::v5::property::response_topic_ref const& t) {
+                        [&](mqtt::v5::property::response_topic::recv const& t) {
                             BOOST_TEST(t.val() == "response topic");
                         },
-                        [&](mqtt::v5::property::correlation_data_ref const& t) {
+                        [&](mqtt::v5::property::correlation_data::recv const& t) {
                             BOOST_TEST(t.val() == "correlation data");
                         },
-                        [&](mqtt::v5::property::user_property_ref const& t) {
+                        [&](mqtt::v5::property::user_property::recv const& t) {
                             switch (user_prop_count++) {
                             case 0:
                                 BOOST_TEST(t.key() == "key1");
@@ -763,7 +763,7 @@ BOOST_AUTO_TEST_CASE( will_prop ) {
                                 break;
                             }
                         },
-                        [&](mqtt::v5::property::subscription_identifier const& t) {
+                        [&](mqtt::v5::property::subscription_identifier::recv const& t) {
                             BOOST_TEST(t.val() == 123U);
                         },
                         [&](auto&& ...) {


### PR DESCRIPTION
Users needed to set *_ref property types if the property has _ref
type. It was annoying.

Now, user can always use `::recv` type. It's simpler.