### PR TITLE
v5 property allocation management, and static asserts

### DIFF
--- a/test/property.cpp
+++ b/test/property.cpp
@@ -122,8 +122,6 @@ BOOST_AUTO_TEST_CASE( shared_subscription_available ) {
 // property has _ref
 
 BOOST_AUTO_TEST_CASE( content_type_ref ) {
-    static_assert(std::is_convertible<mqtt::v5::property::content_type, mqtt::v5::property::content_type_ref>::value, "");
-    static_assert(std::is_convertible<mqtt::v5::property::content_type_ref, mqtt::v5::property::content_type>::value, "");
     mqtt::v5::property::content_type v1 { "abc" };
     mqtt::v5::property::content_type_ref v_ref1 { "abc" };
 
@@ -137,8 +135,6 @@ BOOST_AUTO_TEST_CASE( content_type_ref ) {
 }
 
 BOOST_AUTO_TEST_CASE( response_topic_ref ) {
-    static_assert(std::is_convertible<mqtt::v5::property::response_topic, mqtt::v5::property::response_topic_ref>::value, "");
-    static_assert(std::is_convertible<mqtt::v5::property::response_topic_ref, mqtt::v5::property::response_topic>::value, "");
     mqtt::v5::property::response_topic v1 { "abc" };
     mqtt::v5::property::response_topic_ref v_ref1 { "abc" };
 
@@ -152,8 +148,6 @@ BOOST_AUTO_TEST_CASE( response_topic_ref ) {
 }
 
 BOOST_AUTO_TEST_CASE( correlation_data_ref ) {
-    static_assert(std::is_convertible<mqtt::v5::property::correlation_data, mqtt::v5::property::correlation_data_ref>::value, "");
-    static_assert(std::is_convertible<mqtt::v5::property::correlation_data_ref, mqtt::v5::property::correlation_data>::value, "");
     mqtt::v5::property::correlation_data v1 { "abc" };
     mqtt::v5::property::correlation_data_ref v_ref1 { "abc" };
 
@@ -167,8 +161,6 @@ BOOST_AUTO_TEST_CASE( correlation_data_ref ) {
 }
 
 BOOST_AUTO_TEST_CASE( assigned_client_identifier_ref ) {
-    static_assert(std::is_convertible<mqtt::v5::property::assigned_client_identifier, mqtt::v5::property::assigned_client_identifier_ref>::value, "");
-    static_assert(std::is_convertible<mqtt::v5::property::assigned_client_identifier_ref, mqtt::v5::property::assigned_client_identifier>::value, "");
     mqtt::v5::property::assigned_client_identifier v1 { "abc" };
     mqtt::v5::property::assigned_client_identifier_ref v_ref1 { "abc" };
 
@@ -182,8 +174,6 @@ BOOST_AUTO_TEST_CASE( assigned_client_identifier_ref ) {
 }
 
 BOOST_AUTO_TEST_CASE( authentication_method_ref ) {
-    static_assert(std::is_convertible<mqtt::v5::property::authentication_method, mqtt::v5::property::authentication_method_ref>::value, "");
-    static_assert(std::is_convertible<mqtt::v5::property::authentication_method_ref, mqtt::v5::property::authentication_method>::value, "");
     mqtt::v5::property::authentication_method v1 { "abc" };
     mqtt::v5::property::authentication_method_ref v_ref1 { "abc" };
 
@@ -197,8 +187,6 @@ BOOST_AUTO_TEST_CASE( authentication_method_ref ) {
 }
 
 BOOST_AUTO_TEST_CASE( authentication_data_ref ) {
-    static_assert(std::is_convertible<mqtt::v5::property::authentication_data, mqtt::v5::property::authentication_data_ref>::value, "");
-    static_assert(std::is_convertible<mqtt::v5::property::authentication_data_ref, mqtt::v5::property::authentication_data>::value, "");
     mqtt::v5::property::authentication_data v1 { "abc" };
     mqtt::v5::property::authentication_data_ref v_ref1 { "abc" };
 
@@ -212,8 +200,6 @@ BOOST_AUTO_TEST_CASE( authentication_data_ref ) {
 }
 
 BOOST_AUTO_TEST_CASE( response_information_ref ) {
-    static_assert(std::is_convertible<mqtt::v5::property::response_information, mqtt::v5::property::response_information_ref>::value, "");
-    static_assert(std::is_convertible<mqtt::v5::property::response_information_ref, mqtt::v5::property::response_information>::value, "");
     mqtt::v5::property::response_information v1 { "abc" };
     mqtt::v5::property::response_information_ref v_ref1 { "abc" };
 
@@ -227,8 +213,6 @@ BOOST_AUTO_TEST_CASE( response_information_ref ) {
 }
 
 BOOST_AUTO_TEST_CASE( server_reference_ref ) {
-    static_assert(std::is_convertible<mqtt::v5::property::server_reference, mqtt::v5::property::server_reference_ref>::value, "");
-    static_assert(std::is_convertible<mqtt::v5::property::server_reference_ref, mqtt::v5::property::server_reference>::value, "");
     mqtt::v5::property::server_reference v1 { "abc" };
     mqtt::v5::property::server_reference_ref v_ref1 { "abc" };
 
@@ -242,8 +226,6 @@ BOOST_AUTO_TEST_CASE( server_reference_ref ) {
 }
 
 BOOST_AUTO_TEST_CASE( reason_string_ref ) {
-    static_assert(std::is_convertible<mqtt::v5::property::reason_string, mqtt::v5::property::reason_string_ref>::value, "");
-    static_assert(std::is_convertible<mqtt::v5::property::reason_string_ref, mqtt::v5::property::reason_string>::value, "");
     mqtt::v5::property::reason_string v1 { "abc" };
     mqtt::v5::property::reason_string_ref v_ref1 { "abc" };
 
@@ -257,8 +239,6 @@ BOOST_AUTO_TEST_CASE( reason_string_ref ) {
 }
 
 BOOST_AUTO_TEST_CASE( user_property_ref ) {
-    static_assert(std::is_convertible<mqtt::v5::property::user_property, mqtt::v5::property::user_property_ref>::value, "");
-    static_assert(std::is_convertible<mqtt::v5::property::user_property_ref, mqtt::v5::property::user_property>::value, "");
     mqtt::v5::property::user_property v1 { "abc", "def" };
     mqtt::v5::property::user_property_ref v_ref1 { "abc", "def" };
 


### PR DESCRIPTION
-- Use the explicit keyword to prevent accidental construction of datatypes that require allocation
-- Take as constructor parameters the data types stored inside the property, allowing to std::move
-- Move several static assertions into the code itself, instead of unit tests, to ensure the assertions are always compiled.