### PR TITLE
Removed redundant callback.

### DIFF
--- a/include/mqtt/endpoint.hpp
+++ b/include/mqtt/endpoint.hpp
@@ -8390,9 +8390,6 @@ private:
         if (ret) {
             h_mqtt_message_processed_(std::move(func));
         }
-        else if (func) {
-            func(boost::system::errc::make_error_code(boost::system::errc::success));
-        }
     }
 
     bool handle_connect(async_handler_t const& func) {


### PR DESCRIPTION
The original purpose of the removed code was if user returns false from
handler, then inform user the next read is stopped.

However, this code passed not only th user hander return false, but also
internal error happens. In the internal error case, `func` is called
twice.

So I removed the code. The user that returns false at the handler, user
alread knows the next read never happen.