### PR TITLE
Fixed #314.

### DIFF
--- a/test/checker.hpp
+++ b/test/checker.hpp
@@ -181,17 +181,15 @@ struct checker {
         }
     }
 
-    // cannot use BOOST_TEST here
     ~checker() {
         if (!all_called_) {
             bool ret = true;
             for (auto const& e : entries_) {
                 if (!e.passed) {
-                    std::cout << e.self + " has not been passed" << std::endl;
+                    BOOST_ERROR(e.self + " has not been passed");
                     ret = false;
                 }
             }
-            BOOST_ASSERT(ret);
         }
     }
 

--- a/test/checker.hpp
+++ b/test/checker.hpp
@@ -183,11 +183,9 @@ struct checker {
 
     ~checker() {
         if (!all_called_) {
-            bool ret = true;
             for (auto const& e : entries_) {
                 if (!e.passed) {
                     BOOST_ERROR(e.self + " has not been passed");
-                    ret = false;
                 }
             }
         }


### PR DESCRIPTION
Thrown exception in test case are caught by Boost.Test correctly.