### PR TITLE
Fixed #314.

### DIFF
--- a/include/mqtt/variant.hpp
+++ b/include/mqtt/variant.hpp
@@ -14,18 +14,22 @@
 #else  // defined(MQTT_STD_VARIANT)
 
 
-#if defined(BOOST_MPL_LIMIT_LIST_SIZE)
+// user intentionally defined BOOST_MPL_LIMIT_LIST_SIZE but size is too small
+// NOTE: if BOOST_MPL_LIMIT_LIST_SIZE is not defined, the value is evaluate as 0.
+#if defined(BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS) && BOOST_MPL_LIMIT_LIST_SIZE < 40
 
-#if BOOST_MPL_LIMIT_LIST_SIZE < 40
 #error BOOST_MPL_LIMIT_LIST_SIZE need to greator or equal to 40
-#endif // BOOST_MPL_LIMIT_LIST_SIZE < 40
 
-#else  // defined(BOOST_MPL_LIMIT_LIST_SIZE)
+#else  // defined(BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS) && BOOST_MPL_LIMIT_LIST_SIZE < 40
 
+// user doesn't define BOOST_MPL_LIMIT_LIST_SIZE intentionally
+// but the defult value could be defined
+
+#undef BOOST_MPL_LIMIT_LIST_SIZE
 #define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
 #define BOOST_MPL_LIMIT_LIST_SIZE 40
 
-#endif // defined(BOOST_MPL_LIMIT_LIST_SIZE)
+#endif // defined(BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS) && BOOST_MPL_LIMIT_LIST_SIZE < 40
 
 #include <boost/variant.hpp>
 #include <boost/variant/apply_visitor.hpp>


### PR DESCRIPTION
Evaluate BOOST_MPL_LIMIT_LIST_SIZE only if
BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS is defined,
otherwise undef BOOST_MPL_LIMIT_LIST_SIZE and redefine
BOOST_MPL_LIMIT_LIST_SIZE to 40.