### PR TITLE
Fixed invalid qos comparison on subscribe.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 6.0.4
+* Fixed invalid subscribe qos comparison on receive. (#385)
+
 ## 6.0.3
 * Fixed sync subscribe/unsubscribe with properties APIs dispatch to deprecated APIs problem. (#383)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MQTT client/server for C++14 based on Boost.Asio
 
-Version 6.0.3 [![Build Status](https://travis-ci.org/redboltz/mqtt_cpp.svg?branch=master)](https://travis-ci.org/redboltz/mqtt_cpp)[![Build Status](https://dev.azure.com/redboltz/redboltz/_apis/build/status/redboltz.mqtt_cpp?branchName=master)](https://dev.azure.com/redboltz/redboltz/_build/latest?definitionId=6&branchName=master)[![codecov](https://codecov.io/gh/redboltz/mqtt_cpp/branch/master/graph/badge.svg)](https://codecov.io/gh/redboltz/mqtt_cpp)
+Version 6.0.4 [![Build Status](https://travis-ci.org/redboltz/mqtt_cpp.svg?branch=master)](https://travis-ci.org/redboltz/mqtt_cpp)[![Build Status](https://dev.azure.com/redboltz/redboltz/_apis/build/status/redboltz.mqtt_cpp?branchName=master)](https://dev.azure.com/redboltz/redboltz/_build/latest?definitionId=6&branchName=master)[![codecov](https://codecov.io/gh/redboltz/mqtt_cpp/branch/master/graph/badge.svg)](https://codecov.io/gh/redboltz/mqtt_cpp)
 
 Important note https://github.com/redboltz/mqtt_cpp/wiki/News.
 

--- a/include/mqtt/endpoint.hpp
+++ b/include/mqtt/endpoint.hpp
@@ -13345,14 +13345,15 @@ private:
                             topic_filter = force_move(topic_filter)
                         ]
                         (buffer body, buffer buf, async_handler_t func, this_type_sp self) mutable {
-                            auto requested_qos = static_cast<std::uint8_t>(body[0]);
+                            auto option = static_cast<std::uint8_t>(body[0]);
+                            auto requested_qos = subscribe::get_qos(option);
                             if (requested_qos != qos::at_most_once &&
                                 requested_qos != qos::at_least_once &&
                                 requested_qos != qos::exactly_once) {
                                 call_protocol_error_handlers(func);
                                 return;
                             }
-                            info.entries.emplace_back(force_move(topic_filter), requested_qos);
+                            info.entries.emplace_back(force_move(topic_filter), option);
                             process_subscribe_impl(
                                 force_move(func),
                                 force_move(buf),


### PR DESCRIPTION
It didn't work with MQTT v5 subscribe option.