### PR TITLE
Add inline keyword to several functions to avoid ODR issue

### DIFF
--- a/include/mqtt/endpoint.hpp
+++ b/include/mqtt/endpoint.hpp
@@ -7894,9 +7894,9 @@ private:
     >::type
     async_unsuback_imp(
         packet_id_t packet_id,
-        qos qos_value,
+        std::uint8_t payload,
         Args&&... args) {
-        async_send_unsuback(std::vector<std::uint8_t>{}, packet_id, qos_value, std::forward<Args>(args)...);
+        async_send_unsuback(std::vector<std::uint8_t>{}, packet_id, payload, std::forward<Args>(args)...);
     }
 
     template <typename... Args>
@@ -7908,8 +7908,8 @@ private:
     >::type
     async_unsuback_imp(
         packet_id_t packet_id,
-        Args&&... qos) {
-        async_send_unsuback(std::vector<std::uint8_t>({qos...}), packet_id, async_handler_t());
+        Args&&... payload) {
+        async_send_unsuback(std::vector<std::uint8_t>({payload...}), packet_id, async_handler_t());
     }
 
     class send_buffer {
@@ -13045,16 +13045,16 @@ private:
 
     template <typename... Args>
     void async_send_unsuback(
-        std::vector<qos> params,
+        std::vector<std::uint8_t> params,
         packet_id_t packet_id,
-        qos qos_value,
+        std::uint8_t payload,
         Args&&... args) {
-        params.push_back(qos_value);
+        params.push_back(payload);
         async_send_unsuback(force_move(params), packet_id, std::forward<Args>(args)...);
     }
 
     void async_send_unsuback(
-        std::vector<qos> params,
+        std::vector<std::uint8_t> params,
         packet_id_t packet_id,
         std::vector<v5::property_variant> props,
         async_handler_t func

--- a/include/mqtt/subscribe_options.hpp
+++ b/include/mqtt/subscribe_options.hpp
@@ -61,26 +61,26 @@ struct subscribe_options
     std::uint8_t data_;
 };
 
-subscribe_options operator|(subscribe_options lhs, retain_handling rhs) { lhs |= rhs; return lhs; }
-subscribe_options operator|(subscribe_options lhs, rap rhs) { lhs |= rhs; return lhs; }
-subscribe_options operator|(subscribe_options lhs, nl rhs) { lhs |= rhs; return lhs; }
-subscribe_options operator|(subscribe_options lhs, qos rhs) { lhs |= rhs; return lhs; }
+inline subscribe_options operator|(subscribe_options lhs, retain_handling rhs) { lhs |= rhs; return lhs; }
+inline subscribe_options operator|(subscribe_options lhs, rap rhs) { lhs |= rhs; return lhs; }
+inline subscribe_options operator|(subscribe_options lhs, nl rhs) { lhs |= rhs; return lhs; }
+inline subscribe_options operator|(subscribe_options lhs, qos rhs) { lhs |= rhs; return lhs; }
 
-subscribe_options operator|(retain_handling lhs, rap rhs) { return subscribe_options(lhs) | rhs; }
-subscribe_options operator|(retain_handling lhs, nl rhs) { return subscribe_options(lhs) | rhs; }
-subscribe_options operator|(retain_handling lhs, qos rhs) { return subscribe_options(lhs) | rhs; }
+inline subscribe_options operator|(retain_handling lhs, rap rhs) { return subscribe_options(lhs) | rhs; }
+inline subscribe_options operator|(retain_handling lhs, nl rhs) { return subscribe_options(lhs) | rhs; }
+inline subscribe_options operator|(retain_handling lhs, qos rhs) { return subscribe_options(lhs) | rhs; }
 
-subscribe_options operator|(rap lhs, retain_handling rhs) { return subscribe_options(lhs) | rhs; }
-subscribe_options operator|(rap lhs, nl rhs) { return subscribe_options(lhs) | rhs; }
-subscribe_options operator|(rap lhs, qos rhs) { return subscribe_options(lhs) | rhs; }
+inline subscribe_options operator|(rap lhs, retain_handling rhs) { return subscribe_options(lhs) | rhs; }
+inline subscribe_options operator|(rap lhs, nl rhs) { return subscribe_options(lhs) | rhs; }
+inline subscribe_options operator|(rap lhs, qos rhs) { return subscribe_options(lhs) | rhs; }
 
-subscribe_options operator|(nl lhs, retain_handling rhs) { return subscribe_options(lhs) | rhs; }
-subscribe_options operator|(nl lhs, rap rhs) { return subscribe_options(lhs) | rhs; }
-subscribe_options operator|(nl lhs, qos rhs) { return subscribe_options(lhs) | rhs; }
+inline subscribe_options operator|(nl lhs, retain_handling rhs) { return subscribe_options(lhs) | rhs; }
+inline subscribe_options operator|(nl lhs, rap rhs) { return subscribe_options(lhs) | rhs; }
+inline subscribe_options operator|(nl lhs, qos rhs) { return subscribe_options(lhs) | rhs; }
 
-subscribe_options operator|(qos lhs, retain_handling rhs) { return subscribe_options(lhs) | rhs; }
-subscribe_options operator|(qos lhs, rap rhs) { return subscribe_options(lhs) | rhs; }
-subscribe_options operator|(qos lhs, nl rhs) { return subscribe_options(lhs) | rhs; }
+inline subscribe_options operator|(qos lhs, retain_handling rhs) { return subscribe_options(lhs) | rhs; }
+inline subscribe_options operator|(qos lhs, rap rhs) { return subscribe_options(lhs) | rhs; }
+inline subscribe_options operator|(qos lhs, nl rhs) { return subscribe_options(lhs) | rhs; }
 
 
 constexpr char const* qos_to_str(qos v) {


### PR DESCRIPTION
Also resolves an accidental change to the parameters for some unsuback functions.