### PR TITLE
Fixed BOOST_VERSION typo.

### DIFF
--- a/include/mqtt/const_buffer_util.hpp
+++ b/include/mqtt/const_buffer_util.hpp
@@ -15,19 +15,11 @@ namespace MQTT_NS {
 namespace as = boost::asio;
 
 inline char const* get_pointer(as::const_buffer const& cb) {
-#if BOOST_VERION >= 106600
     return static_cast<char const*>(cb.data());
-#else  // BOOST_VERION >= 106600
-    return as::buffer_cast<char const*>(cb);
-#endif // BOOST_VERION >= 106600
 }
 
 inline std::size_t get_size(as::const_buffer const& cb) {
-#if BOOST_VERION >= 106600
     return cb.size();
-#else  // BOOST_VERION >= 106600
-    return as::buffer_size(cb);
-#endif // BOOST_VERION >= 106600
 }
 
 } // namespace MQTT_NS


### PR DESCRIPTION
mqtt_cpp requires Boost 1.66.0 or later, so `#if` isn't required any more.