### PR TITLE
Updated the parameter of set_accept_handler() from endpoint_t to std:…

### DIFF
--- a/example/no_tls_both.cpp
+++ b/example/no_tls_both.cpp
@@ -167,36 +167,38 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
         }
     );
     s.set_accept_handler(
-        [&](con_t& ep) {
+        [&s, &connections, &subs](con_sp_t spep) {
+            auto& ep = *spep;
+            std::weak_ptr<con_t> wp(spep);
+
             using packet_id_t = typename std::remove_reference_t<decltype(ep)>::packet_id_t;
             std::cout << "[server] accept" << std::endl;
-            auto sp = ep.shared_from_this();
             // For server close if ep is closed.
             auto g = MQTT_NS::shared_scope_guard(
-                [&] {
+                [&s] {
                     std::cout << "[server] session end" << std::endl;
                     s.close();
                 }
             );
-            ep.start_session(std::make_tuple(std::move(sp), std::move(g)));
+            ep.start_session(std::make_tuple(std::move(spep), std::move(g)));
 
             // set connection (lower than MQTT) level handlers
             ep.set_close_handler(
-                [&]
+                [&connections, &subs, wp]
                 (){
                     std::cout << "[server] closed." << std::endl;
-                    close_proc(connections, subs, ep.shared_from_this());
+                    close_proc(connections, subs, wp.lock());
                 });
             ep.set_error_handler(
-                [&]
+                [&connections, &subs, wp]
                 (boost::system::error_code const& ec){
                     std::cout << "[server] error: " << ec.message() << std::endl;
-                    close_proc(connections, subs, ep.shared_from_this());
+                    close_proc(connections, subs, wp.lock());
                 });
 
             // set MQTT level handlers
             ep.set_connect_handler(
-                [&]
+                [&connections, wp]
                 (MQTT_NS::buffer client_id,
                  MQTT_NS::optional<MQTT_NS::buffer> username,
                  MQTT_NS::optional<MQTT_NS::buffer> password,
@@ -209,53 +211,53 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                     std::cout << "[server] password     : " << (password ? password.value() : "none"_mb) << std::endl;
                     std::cout << "[server] clean_session: " << std::boolalpha << clean_session << std::endl;
                     std::cout << "[server] keep_alive   : " << keep_alive << std::endl;
-                    connections.insert(ep.shared_from_this());
-                    ep.connack(false, MQTT_NS::connect_return_code::accepted);
+                    connections.insert(wp.lock());
+                    wp.lock()->connack(false, MQTT_NS::connect_return_code::accepted);
                     return true;
                 }
             );
             ep.set_disconnect_handler(
-                [&]
+                [&connections, &subs, wp]
                 (){
                     std::cout << "[server] disconnect received." << std::endl;
-                    close_proc(connections, subs, ep.shared_from_this());
+                    close_proc(connections, subs, wp.lock());
                 });
             ep.set_puback_handler(
-                [&]
+                []
                 (packet_id_t packet_id){
                     std::cout << "[server] puback received. packet_id: " << packet_id << std::endl;
                     return true;
                 });
             ep.set_pubrec_handler(
-                [&]
+                []
                 (packet_id_t packet_id){
                     std::cout << "[server] pubrec received. packet_id: " << packet_id << std::endl;
                     return true;
                 });
             ep.set_pubrel_handler(
-                [&]
+                []
                 (packet_id_t packet_id){
                     std::cout << "[server] pubrel received. packet_id: " << packet_id << std::endl;
                     return true;
                 });
             ep.set_pubcomp_handler(
-                [&]
+                []
                 (packet_id_t packet_id){
                     std::cout << "[server] pubcomp received. packet_id: " << packet_id << std::endl;
                     return true;
                 });
             ep.set_publish_handler(
-                [&]
-                (bool dup,
+                [&subs]
+                (bool is_dup,
                  MQTT_NS::qos qos_value,
-                 bool retain,
+                 bool is_retain,
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::buffer topic_name,
                  MQTT_NS::buffer contents){
                     std::cout << "[server] publish received."
-                              << " dup: " << std::boolalpha << dup
+                              << " dup: " << std::boolalpha << is_dup
                               << " qos: " << qos_value
-                              << " retain: " << std::boolalpha << retain << std::endl;
+                              << " retain: " << std::boolalpha << is_retain << std::endl;
                     if (packet_id)
                         std::cout << "[server] packet_id: " << *packet_id << std::endl;
                     std::cout << "[server] topic_name: " << topic_name << std::endl;
@@ -268,13 +270,13 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                             boost::asio::buffer(contents),
                             std::make_pair(topic_name, contents),
                             std::min(r.first->qos_value, qos_value),
-                            retain
+                            is_retain
                         );
                     }
                     return true;
                 });
             ep.set_subscribe_handler(
-                [&]
+                [&subs, wp]
                 (packet_id_t packet_id,
                  std::vector<std::tuple<MQTT_NS::buffer, MQTT_NS::subscribe_options>> entries) {
                     std::cout << "[server]subscribe received. packet_id: " << packet_id << std::endl;
@@ -285,21 +287,21 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                         MQTT_NS::qos qos_value = std::get<1>(e).get_qos();
                         std::cout << "[server] topic: " << topic  << " qos: " << qos_value << std::endl;
                         res.emplace_back(static_cast<MQTT_NS::suback_reason_code>(qos_value));
-                        subs.emplace(std::move(topic), ep.shared_from_this(), qos_value);
+                        subs.emplace(std::move(topic), wp.lock(), qos_value);
                     }
-                    ep.suback(packet_id, res);
+                    wp.lock()->suback(packet_id, res);
                     return true;
                 }
             );
             ep.set_unsubscribe_handler(
-                [&]
+                [&subs, wp]
                 (packet_id_t packet_id,
                  std::vector<MQTT_NS::buffer> topics) {
                     std::cout << "[server]unsubscribe received. packet_id: " << packet_id << std::endl;
                     for (auto const& topic : topics) {
                         subs.erase(topic);
                     }
-                    ep.unsuback(packet_id);
+                    wp.lock()->unsuback(packet_id);
                     return true;
                 }
             );

--- a/example/no_tls_both.cpp
+++ b/example/no_tls_both.cpp
@@ -180,6 +180,10 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                     s.close();
                 }
             );
+
+            // Pass spep to keep lifetime.
+            // It makes sure wp.lock() never return nullptr in the handlers below
+            // including close_handler and error_handler.
             ep.start_session(std::make_tuple(std::move(spep), std::move(g)));
 
             // set connection (lower than MQTT) level handlers
@@ -187,13 +191,17 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                 [&connections, &subs, wp]
                 (){
                     std::cout << "[server] closed." << std::endl;
-                    close_proc(connections, subs, wp.lock());
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    close_proc(connections, subs, sp);
                 });
             ep.set_error_handler(
                 [&connections, &subs, wp]
                 (boost::system::error_code const& ec){
                     std::cout << "[server] error: " << ec.message() << std::endl;
-                    close_proc(connections, subs, wp.lock());
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    close_proc(connections, subs, sp);
                 });
 
             // set MQTT level handlers
@@ -211,8 +219,10 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                     std::cout << "[server] password     : " << (password ? password.value() : "none"_mb) << std::endl;
                     std::cout << "[server] clean_session: " << std::boolalpha << clean_session << std::endl;
                     std::cout << "[server] keep_alive   : " << keep_alive << std::endl;
-                    connections.insert(wp.lock());
-                    wp.lock()->connack(false, MQTT_NS::connect_return_code::accepted);
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    connections.insert(sp);
+                    sp->connack(false, MQTT_NS::connect_return_code::accepted);
                     return true;
                 }
             );
@@ -220,7 +230,9 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                 [&connections, &subs, wp]
                 (){
                     std::cout << "[server] disconnect received." << std::endl;
-                    close_proc(connections, subs, wp.lock());
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    close_proc(connections, subs, sp);
                 });
             ep.set_puback_handler(
                 []
@@ -282,14 +294,16 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                     std::cout << "[server]subscribe received. packet_id: " << packet_id << std::endl;
                     std::vector<MQTT_NS::suback_reason_code> res;
                     res.reserve(entries.size());
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
                     for (auto const& e : entries) {
                         MQTT_NS::buffer topic = std::get<0>(e);
                         MQTT_NS::qos qos_value = std::get<1>(e).get_qos();
                         std::cout << "[server] topic: " << topic  << " qos: " << qos_value << std::endl;
                         res.emplace_back(static_cast<MQTT_NS::suback_reason_code>(qos_value));
-                        subs.emplace(std::move(topic), wp.lock(), qos_value);
+                        subs.emplace(std::move(topic), sp, qos_value);
                     }
-                    wp.lock()->suback(packet_id, res);
+                    sp->suback(packet_id, res);
                     return true;
                 }
             );
@@ -301,7 +315,9 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                     for (auto const& topic : topics) {
                         subs.erase(topic);
                     }
-                    wp.lock()->unsuback(packet_id);
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    sp->unsuback(packet_id);
                     return true;
                 }
             );

--- a/example/no_tls_server.cpp
+++ b/example/no_tls_server.cpp
@@ -79,29 +79,32 @@ int main(int argc, char** argv) {
     mi_sub_con subs;
 
     s.set_accept_handler(
-        [&](con_t& ep) {
+        [&connections, &subs](con_sp_t spep) {
+            auto& ep = *spep;
+            std::weak_ptr<con_t> wp(spep);
+
             using packet_id_t = typename std::remove_reference_t<decltype(ep)>::packet_id_t;
             std::cout << "accept" << std::endl;
-            auto sp = ep.shared_from_this();
-            ep.start_session(sp); // keeping ep's lifetime as sp until session finished
+
+            ep.start_session(std::move(spep)); // keeping ep's lifetime as sp until session finished
 
             // set connection (lower than MQTT) level handlers
             ep.set_close_handler(
-                [&]
+                [&connections, &subs, wp]
                 (){
-                    std::cout << "closed." << std::endl;
-                    close_proc(connections, subs, ep.shared_from_this());
+                    std::cout << "[server] closed." << std::endl;
+                    close_proc(connections, subs, wp.lock());
                 });
             ep.set_error_handler(
-                [&]
+                [&connections, &subs, wp]
                 (boost::system::error_code const& ec){
-                    std::cout << "error: " << ec.message() << std::endl;
-                    close_proc(connections, subs, ep.shared_from_this());
+                    std::cout << "[server] error: " << ec.message() << std::endl;
+                    close_proc(connections, subs, wp.lock());
                 });
 
             // set MQTT level handlers
             ep.set_connect_handler(
-                [&]
+                [&connections, wp]
                 (MQTT_NS::buffer client_id,
                  MQTT_NS::optional<MQTT_NS::buffer> username,
                  MQTT_NS::optional<MQTT_NS::buffer> password,
@@ -109,62 +112,62 @@ int main(int argc, char** argv) {
                  bool clean_session,
                  std::uint16_t keep_alive) {
                     using namespace MQTT_NS::literals;
-                    std::cout << "client_id    : " << client_id << std::endl;
-                    std::cout << "username     : " << (username ? username.value() : "none"_mb) << std::endl;
-                    std::cout << "password     : " << (password ? password.value() : "none"_mb) << std::endl;
-                    std::cout << "clean_session: " << std::boolalpha << clean_session << std::endl;
-                    std::cout << "keep_alive   : " << keep_alive << std::endl;
-                    connections.insert(ep.shared_from_this());
-                    ep.connack(false, MQTT_NS::connect_return_code::accepted);
+                    std::cout << "[server] client_id    : " << client_id << std::endl;
+                    std::cout << "[server] username     : " << (username ? username.value() : "none"_mb) << std::endl;
+                    std::cout << "[server] password     : " << (password ? password.value() : "none"_mb) << std::endl;
+                    std::cout << "[server] clean_session: " << std::boolalpha << clean_session << std::endl;
+                    std::cout << "[server] keep_alive   : " << keep_alive << std::endl;
+                    connections.insert(wp.lock());
+                    wp.lock()->connack(false, MQTT_NS::connect_return_code::accepted);
                     return true;
                 }
             );
             ep.set_disconnect_handler(
-                [&]
+                [&connections, &subs, wp]
                 (){
-                    std::cout << "disconnect received." << std::endl;
-                    close_proc(connections, subs, ep.shared_from_this());
+                    std::cout << "[server] disconnect received." << std::endl;
+                    close_proc(connections, subs, wp.lock());
                 });
             ep.set_puback_handler(
-                [&]
+                []
                 (packet_id_t packet_id){
-                    std::cout << "puback received. packet_id: " << packet_id << std::endl;
+                    std::cout << "[server] puback received. packet_id: " << packet_id << std::endl;
                     return true;
                 });
             ep.set_pubrec_handler(
-                [&]
+                []
                 (packet_id_t packet_id){
-                    std::cout << "pubrec received. packet_id: " << packet_id << std::endl;
+                    std::cout << "[server] pubrec received. packet_id: " << packet_id << std::endl;
                     return true;
                 });
             ep.set_pubrel_handler(
-                [&]
+                []
                 (packet_id_t packet_id){
-                    std::cout << "pubrel received. packet_id: " << packet_id << std::endl;
+                    std::cout << "[server] pubrel received. packet_id: " << packet_id << std::endl;
                     return true;
                 });
             ep.set_pubcomp_handler(
-                [&]
+                []
                 (packet_id_t packet_id){
-                    std::cout << "pubcomp received. packet_id: " << packet_id << std::endl;
+                    std::cout << "[server] pubcomp received. packet_id: " << packet_id << std::endl;
                     return true;
                 });
             ep.set_publish_handler(
-                [&]
+                [&subs]
                 (bool is_dup,
                  MQTT_NS::qos qos_value,
                  bool is_retain,
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::buffer topic_name,
                  MQTT_NS::buffer contents){
-                    std::cout << "publish received."
+                    std::cout << "[server] publish received."
                               << " dup: " << std::boolalpha << is_dup
                               << " qos: " << qos_value
                               << " retain: " << std::boolalpha << is_retain << std::endl;
                     if (packet_id)
-                        std::cout << "packet_id: " << *packet_id << std::endl;
-                    std::cout << "topic_name: " << topic_name << std::endl;
-                    std::cout << "contents: " << contents << std::endl;
+                        std::cout << "[server] packet_id: " << *packet_id << std::endl;
+                    std::cout << "[server] topic_name: " << topic_name << std::endl;
+                    std::cout << "[server] contents: " << contents << std::endl;
                     auto const& idx = subs.get<tag_topic>();
                     auto r = idx.equal_range(topic_name);
                     for (; r.first != r.second; ++r.first) {
@@ -179,32 +182,32 @@ int main(int argc, char** argv) {
                     return true;
                 });
             ep.set_subscribe_handler(
-                [&]
+                [&subs, wp]
                 (packet_id_t packet_id,
                  std::vector<std::tuple<MQTT_NS::buffer, MQTT_NS::subscribe_options>> entries) {
-                    std::cout << "subscribe received. packet_id: " << packet_id << std::endl;
+                    std::cout << "[server]subscribe received. packet_id: " << packet_id << std::endl;
                     std::vector<MQTT_NS::suback_reason_code> res;
                     res.reserve(entries.size());
                     for (auto const& e : entries) {
                         MQTT_NS::buffer topic = std::get<0>(e);
                         MQTT_NS::qos qos_value = std::get<1>(e).get_qos();
-                        std::cout << "topic: " << topic  << " qos: " << qos_value << std::endl;
+                        std::cout << "[server] topic: " << topic  << " qos: " << qos_value << std::endl;
                         res.emplace_back(static_cast<MQTT_NS::suback_reason_code>(qos_value));
-                        subs.emplace(std::move(topic), ep.shared_from_this(), qos_value);
+                        subs.emplace(std::move(topic), wp.lock(), qos_value);
                     }
-                    ep.suback(packet_id, res);
+                    wp.lock()->suback(packet_id, res);
                     return true;
                 }
             );
             ep.set_unsubscribe_handler(
-                [&]
+                [&subs, wp]
                 (packet_id_t packet_id,
                  std::vector<MQTT_NS::buffer> topics) {
-                    std::cout << "unsubscribe received. packet_id: " << packet_id << std::endl;
+                    std::cout << "[server]unsubscribe received. packet_id: " << packet_id << std::endl;
                     for (auto const& topic : topics) {
                         subs.erase(topic);
                     }
-                    ep.unsuback(packet_id);
+                    wp.lock()->unsuback(packet_id);
                     return true;
                 }
             );

--- a/example/no_tls_ws_both.cpp
+++ b/example/no_tls_ws_both.cpp
@@ -167,36 +167,38 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
         }
     );
     s.set_accept_handler(
-        [&](con_t& ep) {
+        [&s, &connections, &subs](con_sp_t spep) {
+            auto& ep = *spep;
+            std::weak_ptr<con_t> wp(spep);
+
             using packet_id_t = typename std::remove_reference_t<decltype(ep)>::packet_id_t;
             std::cout << "[server] accept" << std::endl;
-            auto sp = ep.shared_from_this();
             // For server close if ep is closed.
             auto g = MQTT_NS::shared_scope_guard(
-                [&] {
+                [&s] {
                     std::cout << "[server] session end" << std::endl;
                     s.close();
                 }
             );
-            ep.start_session(std::make_tuple(std::move(sp), std::move(g)));
+            ep.start_session(std::make_tuple(std::move(spep), std::move(g)));
 
             // set connection (lower than MQTT) level handlers
             ep.set_close_handler(
-                [&]
+                [&connections, &subs, wp]
                 (){
                     std::cout << "[server] closed." << std::endl;
-                    close_proc(connections, subs, ep.shared_from_this());
+                    close_proc(connections, subs, wp.lock());
                 });
             ep.set_error_handler(
-                [&]
+                [&connections, &subs, wp]
                 (boost::system::error_code const& ec){
                     std::cout << "[server] error: " << ec.message() << std::endl;
-                    close_proc(connections, subs, ep.shared_from_this());
+                    close_proc(connections, subs, wp.lock());
                 });
 
             // set MQTT level handlers
             ep.set_connect_handler(
-                [&]
+                [&connections, wp]
                 (MQTT_NS::buffer client_id,
                  MQTT_NS::optional<MQTT_NS::buffer> username,
                  MQTT_NS::optional<MQTT_NS::buffer> password,
@@ -209,43 +211,43 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                     std::cout << "[server] password     : " << (password ? password.value() : "none"_mb) << std::endl;
                     std::cout << "[server] clean_session: " << std::boolalpha << clean_session << std::endl;
                     std::cout << "[server] keep_alive   : " << keep_alive << std::endl;
-                    connections.insert(ep.shared_from_this());
-                    ep.connack(false, MQTT_NS::connect_return_code::accepted);
+                    connections.insert(wp.lock());
+                    wp.lock()->connack(false, MQTT_NS::connect_return_code::accepted);
                     return true;
                 }
             );
             ep.set_disconnect_handler(
-                [&]
+                [&connections, &subs, wp]
                 (){
                     std::cout << "[server] disconnect received." << std::endl;
-                    close_proc(connections, subs, ep.shared_from_this());
+                    close_proc(connections, subs, wp.lock());
                 });
             ep.set_puback_handler(
-                [&]
+                []
                 (packet_id_t packet_id){
                     std::cout << "[server] puback received. packet_id: " << packet_id << std::endl;
                     return true;
                 });
             ep.set_pubrec_handler(
-                [&]
+                []
                 (packet_id_t packet_id){
                     std::cout << "[server] pubrec received. packet_id: " << packet_id << std::endl;
                     return true;
                 });
             ep.set_pubrel_handler(
-                [&]
+                []
                 (packet_id_t packet_id){
                     std::cout << "[server] pubrel received. packet_id: " << packet_id << std::endl;
                     return true;
                 });
             ep.set_pubcomp_handler(
-                [&]
+                []
                 (packet_id_t packet_id){
                     std::cout << "[server] pubcomp received. packet_id: " << packet_id << std::endl;
                     return true;
                 });
             ep.set_publish_handler(
-                [&]
+                [&subs]
                 (bool is_dup,
                  MQTT_NS::qos qos_value,
                  bool is_retain,
@@ -274,7 +276,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                     return true;
                 });
             ep.set_subscribe_handler(
-                [&]
+                [&subs, wp]
                 (packet_id_t packet_id,
                  std::vector<std::tuple<MQTT_NS::buffer, MQTT_NS::subscribe_options>> entries) {
                     std::cout << "[server]subscribe received. packet_id: " << packet_id << std::endl;
@@ -285,21 +287,21 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                         MQTT_NS::qos qos_value = std::get<1>(e).get_qos();
                         std::cout << "[server] topic: " << topic  << " qos: " << qos_value << std::endl;
                         res.emplace_back(static_cast<MQTT_NS::suback_reason_code>(qos_value));
-                        subs.emplace(std::move(topic), ep.shared_from_this(), qos_value);
+                        subs.emplace(std::move(topic), wp.lock(), qos_value);
                     }
-                    ep.suback(packet_id, res);
+                    wp.lock()->suback(packet_id, res);
                     return true;
                 }
             );
             ep.set_unsubscribe_handler(
-                [&]
+                [&subs, wp]
                 (packet_id_t packet_id,
                  std::vector<MQTT_NS::buffer> topics) {
                     std::cout << "[server]unsubscribe received. packet_id: " << packet_id << std::endl;
                     for (auto const& topic : topics) {
                         subs.erase(topic);
                     }
-                    ep.unsuback(packet_id);
+                    wp.lock()->unsuback(packet_id);
                     return true;
                 }
             );

--- a/example/no_tls_ws_both.cpp
+++ b/example/no_tls_ws_both.cpp
@@ -180,6 +180,9 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                     s.close();
                 }
             );
+            // Pass spep to keep lifetime.
+            // It makes sure wp.lock() never return nullptr in the handlers below
+            // including close_handler and error_handler.
             ep.start_session(std::make_tuple(std::move(spep), std::move(g)));
 
             // set connection (lower than MQTT) level handlers
@@ -187,13 +190,17 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                 [&connections, &subs, wp]
                 (){
                     std::cout << "[server] closed." << std::endl;
-                    close_proc(connections, subs, wp.lock());
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    close_proc(connections, subs, sp);
                 });
             ep.set_error_handler(
                 [&connections, &subs, wp]
                 (boost::system::error_code const& ec){
                     std::cout << "[server] error: " << ec.message() << std::endl;
-                    close_proc(connections, subs, wp.lock());
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    close_proc(connections, subs, sp);
                 });
 
             // set MQTT level handlers
@@ -211,8 +218,10 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                     std::cout << "[server] password     : " << (password ? password.value() : "none"_mb) << std::endl;
                     std::cout << "[server] clean_session: " << std::boolalpha << clean_session << std::endl;
                     std::cout << "[server] keep_alive   : " << keep_alive << std::endl;
-                    connections.insert(wp.lock());
-                    wp.lock()->connack(false, MQTT_NS::connect_return_code::accepted);
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    connections.insert(sp);
+                    sp->connack(false, MQTT_NS::connect_return_code::accepted);
                     return true;
                 }
             );
@@ -220,7 +229,9 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                 [&connections, &subs, wp]
                 (){
                     std::cout << "[server] disconnect received." << std::endl;
-                    close_proc(connections, subs, wp.lock());
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    close_proc(connections, subs, sp);
                 });
             ep.set_puback_handler(
                 []
@@ -282,14 +293,16 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                     std::cout << "[server]subscribe received. packet_id: " << packet_id << std::endl;
                     std::vector<MQTT_NS::suback_reason_code> res;
                     res.reserve(entries.size());
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
                     for (auto const& e : entries) {
                         MQTT_NS::buffer topic = std::get<0>(e);
                         MQTT_NS::qos qos_value = std::get<1>(e).get_qos();
                         std::cout << "[server] topic: " << topic  << " qos: " << qos_value << std::endl;
                         res.emplace_back(static_cast<MQTT_NS::suback_reason_code>(qos_value));
-                        subs.emplace(std::move(topic), wp.lock(), qos_value);
+                        subs.emplace(std::move(topic), sp, qos_value);
                     }
-                    wp.lock()->suback(packet_id, res);
+                    sp->suback(packet_id, res);
                     return true;
                 }
             );
@@ -301,7 +314,9 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                     for (auto const& topic : topics) {
                         subs.erase(topic);
                     }
-                    wp.lock()->unsuback(packet_id);
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    sp->unsuback(packet_id);
                     return true;
                 }
             );

--- a/example/no_tls_ws_server.cpp
+++ b/example/no_tls_ws_server.cpp
@@ -79,29 +79,32 @@ int main(int argc, char** argv) {
     mi_sub_con subs;
 
     s.set_accept_handler(
-        [&](con_t& ep) {
+        [&connections, &subs](con_sp_t spep) {
+            auto& ep = *spep;
+            std::weak_ptr<con_t> wp(spep);
+
             using packet_id_t = typename std::remove_reference_t<decltype(ep)>::packet_id_t;
             std::cout << "accept" << std::endl;
-            auto sp = ep.shared_from_this();
-            ep.start_session(sp); // keeping ep's lifetime as sp until session finished
+
+            ep.start_session(std::move(spep)); // keeping ep's lifetime as sp until session finished
 
             // set connection (lower than MQTT) level handlers
             ep.set_close_handler(
-                [&]
+                [&connections, &subs, wp]
                 (){
-                    std::cout << "closed." << std::endl;
-                    close_proc(connections, subs, ep.shared_from_this());
+                    std::cout << "[server] closed." << std::endl;
+                    close_proc(connections, subs, wp.lock());
                 });
             ep.set_error_handler(
-                [&]
+                [&connections, &subs, wp]
                 (boost::system::error_code const& ec){
-                    std::cout << "error: " << ec.message() << std::endl;
-                    close_proc(connections, subs, ep.shared_from_this());
+                    std::cout << "[server] error: " << ec.message() << std::endl;
+                    close_proc(connections, subs, wp.lock());
                 });
 
             // set MQTT level handlers
             ep.set_connect_handler(
-                [&]
+                [&connections, wp]
                 (MQTT_NS::buffer client_id,
                  MQTT_NS::optional<MQTT_NS::buffer> username,
                  MQTT_NS::optional<MQTT_NS::buffer> password,
@@ -109,62 +112,62 @@ int main(int argc, char** argv) {
                  bool clean_session,
                  std::uint16_t keep_alive) {
                     using namespace MQTT_NS::literals;
-                    std::cout << "client_id    : " << client_id << std::endl;
-                    std::cout << "username     : " << (username ? username.value() : "none"_mb) << std::endl;
-                    std::cout << "password     : " << (password ? password.value() : "none"_mb) << std::endl;
-                    std::cout << "clean_session: " << std::boolalpha << clean_session << std::endl;
-                    std::cout << "keep_alive   : " << keep_alive << std::endl;
-                    connections.insert(ep.shared_from_this());
-                    ep.connack(false, MQTT_NS::connect_return_code::accepted);
+                    std::cout << "[server] client_id    : " << client_id << std::endl;
+                    std::cout << "[server] username     : " << (username ? username.value() : "none"_mb) << std::endl;
+                    std::cout << "[server] password     : " << (password ? password.value() : "none"_mb) << std::endl;
+                    std::cout << "[server] clean_session: " << std::boolalpha << clean_session << std::endl;
+                    std::cout << "[server] keep_alive   : " << keep_alive << std::endl;
+                    connections.insert(wp.lock());
+                    wp.lock()->connack(false, MQTT_NS::connect_return_code::accepted);
                     return true;
                 }
             );
             ep.set_disconnect_handler(
-                [&]
+                [&connections, &subs, wp]
                 (){
-                    std::cout << "disconnect received." << std::endl;
-                    close_proc(connections, subs, ep.shared_from_this());
+                    std::cout << "[server] disconnect received." << std::endl;
+                    close_proc(connections, subs, wp.lock());
                 });
             ep.set_puback_handler(
-                [&]
+                []
                 (packet_id_t packet_id){
-                    std::cout << "puback received. packet_id: " << packet_id << std::endl;
+                    std::cout << "[server] puback received. packet_id: " << packet_id << std::endl;
                     return true;
                 });
             ep.set_pubrec_handler(
-                [&]
+                []
                 (packet_id_t packet_id){
-                    std::cout << "pubrec received. packet_id: " << packet_id << std::endl;
+                    std::cout << "[server] pubrec received. packet_id: " << packet_id << std::endl;
                     return true;
                 });
             ep.set_pubrel_handler(
-                [&]
+                []
                 (packet_id_t packet_id){
-                    std::cout << "pubrel received. packet_id: " << packet_id << std::endl;
+                    std::cout << "[server] pubrel received. packet_id: " << packet_id << std::endl;
                     return true;
                 });
             ep.set_pubcomp_handler(
-                [&]
+                []
                 (packet_id_t packet_id){
-                    std::cout << "pubcomp received. packet_id: " << packet_id << std::endl;
+                    std::cout << "[server] pubcomp received. packet_id: " << packet_id << std::endl;
                     return true;
                 });
             ep.set_publish_handler(
-                [&]
+                [&subs]
                 (bool is_dup,
                  MQTT_NS::qos qos_value,
                  bool is_retain,
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::buffer topic_name,
                  MQTT_NS::buffer contents){
-                    std::cout << "publish received."
+                    std::cout << "[server] publish received."
                               << " dup: " << std::boolalpha << is_dup
                               << " qos: " << qos_value
                               << " retain: " << std::boolalpha << is_retain << std::endl;
                     if (packet_id)
-                        std::cout << "packet_id: " << *packet_id << std::endl;
-                    std::cout << "topic_name: " << topic_name << std::endl;
-                    std::cout << "contents: " << contents << std::endl;
+                        std::cout << "[server] packet_id: " << *packet_id << std::endl;
+                    std::cout << "[server] topic_name: " << topic_name << std::endl;
+                    std::cout << "[server] contents: " << contents << std::endl;
                     auto const& idx = subs.get<tag_topic>();
                     auto r = idx.equal_range(topic_name);
                     for (; r.first != r.second; ++r.first) {
@@ -179,32 +182,32 @@ int main(int argc, char** argv) {
                     return true;
                 });
             ep.set_subscribe_handler(
-                [&]
+                [&subs, wp]
                 (packet_id_t packet_id,
                  std::vector<std::tuple<MQTT_NS::buffer, MQTT_NS::subscribe_options>> entries) {
-                    std::cout << "subscribe received. packet_id: " << packet_id << std::endl;
+                    std::cout << "[server]subscribe received. packet_id: " << packet_id << std::endl;
                     std::vector<MQTT_NS::suback_reason_code> res;
                     res.reserve(entries.size());
                     for (auto const& e : entries) {
                         MQTT_NS::buffer topic = std::get<0>(e);
                         MQTT_NS::qos qos_value = std::get<1>(e).get_qos();
-                        std::cout << "topic: " << topic  << " qos: " << qos_value << std::endl;
+                        std::cout << "[server] topic: " << topic  << " qos: " << qos_value << std::endl;
                         res.emplace_back(static_cast<MQTT_NS::suback_reason_code>(qos_value));
-                        subs.emplace(std::move(topic), ep.shared_from_this(), qos_value);
+                        subs.emplace(std::move(topic), wp.lock(), qos_value);
                     }
-                    ep.suback(packet_id, res);
+                    wp.lock()->suback(packet_id, res);
                     return true;
                 }
             );
             ep.set_unsubscribe_handler(
-                [&]
+                [&subs, wp]
                 (packet_id_t packet_id,
                  std::vector<MQTT_NS::buffer> topics) {
-                    std::cout << "unsubscribe received. packet_id: " << packet_id << std::endl;
+                    std::cout << "[server]unsubscribe received. packet_id: " << packet_id << std::endl;
                     for (auto const& topic : topics) {
                         subs.erase(topic);
                     }
-                    ep.unsuback(packet_id);
+                    wp.lock()->unsuback(packet_id);
                     return true;
                 }
             );

--- a/example/tls_both.cpp
+++ b/example/tls_both.cpp
@@ -182,6 +182,9 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                     s.close();
                 }
             );
+            // Pass spep to keep lifetime.
+            // It makes sure wp.lock() never return nullptr in the handlers below
+            // including close_handler and error_handler.
             ep.start_session(std::make_tuple(std::move(spep), std::move(g)));
 
             // set connection (lower than MQTT) level handlers
@@ -189,13 +192,17 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                 [&connections, &subs, wp]
                 (){
                     std::cout << "[server] closed." << std::endl;
-                    close_proc(connections, subs, wp.lock());
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    close_proc(connections, subs, sp);
                 });
             ep.set_error_handler(
                 [&connections, &subs, wp]
                 (boost::system::error_code const& ec){
                     std::cout << "[server] error: " << ec.message() << std::endl;
-                    close_proc(connections, subs, wp.lock());
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    close_proc(connections, subs, sp);
                 });
 
             // set MQTT level handlers
@@ -213,8 +220,10 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                     std::cout << "[server] password     : " << (password ? password.value() : "none"_mb) << std::endl;
                     std::cout << "[server] clean_session: " << std::boolalpha << clean_session << std::endl;
                     std::cout << "[server] keep_alive   : " << keep_alive << std::endl;
-                    connections.insert(wp.lock());
-                    wp.lock()->connack(false, MQTT_NS::connect_return_code::accepted);
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    connections.insert(sp);
+                    sp->connack(false, MQTT_NS::connect_return_code::accepted);
                     return true;
                 }
             );
@@ -222,7 +231,9 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                 [&connections, &subs, wp]
                 (){
                     std::cout << "[server] disconnect received." << std::endl;
-                    close_proc(connections, subs, wp.lock());
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    close_proc(connections, subs, sp);
                 });
             ep.set_puback_handler(
                 []
@@ -284,14 +295,16 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                     std::cout << "[server]subscribe received. packet_id: " << packet_id << std::endl;
                     std::vector<MQTT_NS::suback_reason_code> res;
                     res.reserve(entries.size());
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
                     for (auto const& e : entries) {
                         MQTT_NS::buffer topic = std::get<0>(e);
                         MQTT_NS::qos qos_value = std::get<1>(e).get_qos();
                         std::cout << "[server] topic: " << topic  << " qos: " << qos_value << std::endl;
                         res.emplace_back(static_cast<MQTT_NS::suback_reason_code>(qos_value));
-                        subs.emplace(std::move(topic), wp.lock(), qos_value);
+                        subs.emplace(std::move(topic), sp, qos_value);
                     }
-                    wp.lock()->suback(packet_id, res);
+                    sp->suback(packet_id, res);
                     return true;
                 }
             );
@@ -303,7 +316,9 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                     for (auto const& topic : topics) {
                         subs.erase(topic);
                     }
-                    wp.lock()->unsuback(packet_id);
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    sp->unsuback(packet_id);
                     return true;
                 }
             );

--- a/example/tls_both.cpp
+++ b/example/tls_both.cpp
@@ -169,36 +169,38 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
         }
     );
     s.set_accept_handler(
-        [&](con_t& ep) {
+        [&s, &connections, &subs](con_sp_t spep) {
+            auto& ep = *spep;
+            std::weak_ptr<con_t> wp(spep);
+
             using packet_id_t = typename std::remove_reference_t<decltype(ep)>::packet_id_t;
-            std::cout << "[server]accept" << std::endl;
-            auto sp = ep.shared_from_this();
+            std::cout << "[server] accept" << std::endl;
             // For server close if ep is closed.
             auto g = MQTT_NS::shared_scope_guard(
-                [&] {
+                [&s] {
                     std::cout << "[server] session end" << std::endl;
                     s.close();
                 }
             );
-            ep.start_session(std::make_tuple(std::move(sp), std::move(g)));
+            ep.start_session(std::make_tuple(std::move(spep), std::move(g)));
 
             // set connection (lower than MQTT) level handlers
             ep.set_close_handler(
-                [&]
+                [&connections, &subs, wp]
                 (){
-                    std::cout << "[server]closed." << std::endl;
-                    close_proc(connections, subs, ep.shared_from_this());
+                    std::cout << "[server] closed." << std::endl;
+                    close_proc(connections, subs, wp.lock());
                 });
             ep.set_error_handler(
-                [&]
+                [&connections, &subs, wp]
                 (boost::system::error_code const& ec){
-                    std::cout << "[server]error: " << ec.message() << std::endl;
-                    close_proc(connections, subs, ep.shared_from_this());
+                    std::cout << "[server] error: " << ec.message() << std::endl;
+                    close_proc(connections, subs, wp.lock());
                 });
 
             // set MQTT level handlers
             ep.set_connect_handler(
-                [&]
+                [&connections, wp]
                 (MQTT_NS::buffer client_id,
                  MQTT_NS::optional<MQTT_NS::buffer> username,
                  MQTT_NS::optional<MQTT_NS::buffer> password,
@@ -206,62 +208,62 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                  bool clean_session,
                  std::uint16_t keep_alive) {
                     using namespace MQTT_NS::literals;
-                    std::cout << "[server]client_id    : " << client_id << std::endl;
-                    std::cout << "[server]username     : " << (username ? username.value() : "none"_mb) << std::endl;
-                    std::cout << "[server]password     : " << (password ? password.value() : "none"_mb) << std::endl;
-                    std::cout << "[server]clean_session: " << std::boolalpha << clean_session << std::endl;
-                    std::cout << "[server]keep_alive   : " << keep_alive << std::endl;
-                    connections.insert(ep.shared_from_this());
-                    ep.connack(false, MQTT_NS::connect_return_code::accepted);
+                    std::cout << "[server] client_id    : " << client_id << std::endl;
+                    std::cout << "[server] username     : " << (username ? username.value() : "none"_mb) << std::endl;
+                    std::cout << "[server] password     : " << (password ? password.value() : "none"_mb) << std::endl;
+                    std::cout << "[server] clean_session: " << std::boolalpha << clean_session << std::endl;
+                    std::cout << "[server] keep_alive   : " << keep_alive << std::endl;
+                    connections.insert(wp.lock());
+                    wp.lock()->connack(false, MQTT_NS::connect_return_code::accepted);
                     return true;
                 }
             );
             ep.set_disconnect_handler(
-                [&]
+                [&connections, &subs, wp]
                 (){
-                    std::cout << "[server]disconnect received." << std::endl;
-                    close_proc(connections, subs, ep.shared_from_this());
+                    std::cout << "[server] disconnect received." << std::endl;
+                    close_proc(connections, subs, wp.lock());
                 });
             ep.set_puback_handler(
-                [&]
+                []
                 (packet_id_t packet_id){
-                    std::cout << "[server]puback received. packet_id: " << packet_id << std::endl;
+                    std::cout << "[server] puback received. packet_id: " << packet_id << std::endl;
                     return true;
                 });
             ep.set_pubrec_handler(
-                [&]
+                []
                 (packet_id_t packet_id){
-                    std::cout << "[server]pubrec received. packet_id: " << packet_id << std::endl;
+                    std::cout << "[server] pubrec received. packet_id: " << packet_id << std::endl;
                     return true;
                 });
             ep.set_pubrel_handler(
-                [&]
+                []
                 (packet_id_t packet_id){
-                    std::cout << "[server]pubrel received. packet_id: " << packet_id << std::endl;
+                    std::cout << "[server] pubrel received. packet_id: " << packet_id << std::endl;
                     return true;
                 });
             ep.set_pubcomp_handler(
-                [&]
+                []
                 (packet_id_t packet_id){
-                    std::cout << "[server]pubcomp received. packet_id: " << packet_id << std::endl;
+                    std::cout << "[server] pubcomp received. packet_id: " << packet_id << std::endl;
                     return true;
                 });
             ep.set_publish_handler(
-                [&]
+                [&subs]
                 (bool is_dup,
                  MQTT_NS::qos qos_value,
                  bool is_retain,
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::buffer topic_name,
                  MQTT_NS::buffer contents){
-                    std::cout << "[server]publish received."
+                    std::cout << "[server] publish received."
                               << " dup: " << std::boolalpha << is_dup
                               << " qos: " << qos_value
-                              << " retain: " << is_retain << std::endl;
+                              << " retain: " << std::boolalpha << is_retain << std::endl;
                     if (packet_id)
-                        std::cout << "[server]packet_id: " << *packet_id << std::endl;
-                    std::cout << "[server]topic_name: " << topic_name << std::endl;
-                    std::cout << "[server]contents: " << contents << std::endl;
+                        std::cout << "[server] packet_id: " << *packet_id << std::endl;
+                    std::cout << "[server] topic_name: " << topic_name << std::endl;
+                    std::cout << "[server] contents: " << contents << std::endl;
                     auto const& idx = subs.get<tag_topic>();
                     auto r = idx.equal_range(topic_name);
                     for (; r.first != r.second; ++r.first) {
@@ -276,7 +278,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                     return true;
                 });
             ep.set_subscribe_handler(
-                [&]
+                [&subs, wp]
                 (packet_id_t packet_id,
                  std::vector<std::tuple<MQTT_NS::buffer, MQTT_NS::subscribe_options>> entries) {
                     std::cout << "[server]subscribe received. packet_id: " << packet_id << std::endl;
@@ -285,23 +287,23 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                     for (auto const& e : entries) {
                         MQTT_NS::buffer topic = std::get<0>(e);
                         MQTT_NS::qos qos_value = std::get<1>(e).get_qos();
-                        std::cout << "[server]topic: " << topic  << " qos: " << qos_value << std::endl;
+                        std::cout << "[server] topic: " << topic  << " qos: " << qos_value << std::endl;
                         res.emplace_back(static_cast<MQTT_NS::suback_reason_code>(qos_value));
-                        subs.emplace(std::move(topic), ep.shared_from_this(), qos_value);
+                        subs.emplace(std::move(topic), wp.lock(), qos_value);
                     }
-                    ep.suback(packet_id, res);
+                    wp.lock()->suback(packet_id, res);
                     return true;
                 }
             );
             ep.set_unsubscribe_handler(
-                [&]
+                [&subs, wp]
                 (packet_id_t packet_id,
                  std::vector<MQTT_NS::buffer> topics) {
                     std::cout << "[server]unsubscribe received. packet_id: " << packet_id << std::endl;
                     for (auto const& topic : topics) {
                         subs.erase(topic);
                     }
-                    ep.unsuback(packet_id);
+                    wp.lock()->unsuback(packet_id);
                     return true;
                 }
             );

--- a/example/tls_server.cpp
+++ b/example/tls_server.cpp
@@ -98,20 +98,27 @@ int main(int argc, char** argv) {
             using packet_id_t = typename std::remove_reference_t<decltype(ep)>::packet_id_t;
             std::cout << "accept" << std::endl;
 
-            ep.start_session(std::move(spep)); // keeping ep's lifetime as sp until session finished
+            // Pass spep to keep lifetime.
+            // It makes sure wp.lock() never return nullptr in the handlers below
+            // including close_handler and error_handler.
+            ep.start_session(std::move(spep));
 
             // set connection (lower than MQTT) level handlers
             ep.set_close_handler(
                 [&connections, &subs, wp]
                 (){
                     std::cout << "[server] closed." << std::endl;
-                    close_proc(connections, subs, wp.lock());
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    close_proc(connections, subs, sp);
                 });
             ep.set_error_handler(
                 [&connections, &subs, wp]
                 (boost::system::error_code const& ec){
                     std::cout << "[server] error: " << ec.message() << std::endl;
-                    close_proc(connections, subs, wp.lock());
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    close_proc(connections, subs, sp);
                 });
 
             // set MQTT level handlers
@@ -129,8 +136,10 @@ int main(int argc, char** argv) {
                     std::cout << "[server] password     : " << (password ? password.value() : "none"_mb) << std::endl;
                     std::cout << "[server] clean_session: " << std::boolalpha << clean_session << std::endl;
                     std::cout << "[server] keep_alive   : " << keep_alive << std::endl;
-                    connections.insert(wp.lock());
-                    wp.lock()->connack(false, MQTT_NS::connect_return_code::accepted);
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    connections.insert(sp);
+                    sp->connack(false, MQTT_NS::connect_return_code::accepted);
                     return true;
                 }
             );
@@ -138,7 +147,9 @@ int main(int argc, char** argv) {
                 [&connections, &subs, wp]
                 (){
                     std::cout << "[server] disconnect received." << std::endl;
-                    close_proc(connections, subs, wp.lock());
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    close_proc(connections, subs, sp);
                 });
             ep.set_puback_handler(
                 []
@@ -200,14 +211,16 @@ int main(int argc, char** argv) {
                     std::cout << "[server]subscribe received. packet_id: " << packet_id << std::endl;
                     std::vector<MQTT_NS::suback_reason_code> res;
                     res.reserve(entries.size());
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
                     for (auto const& e : entries) {
                         MQTT_NS::buffer topic = std::get<0>(e);
                         MQTT_NS::qos qos_value = std::get<1>(e).get_qos();
                         std::cout << "[server] topic: " << topic  << " qos: " << qos_value << std::endl;
                         res.emplace_back(static_cast<MQTT_NS::suback_reason_code>(qos_value));
-                        subs.emplace(std::move(topic), wp.lock(), qos_value);
+                        subs.emplace(std::move(topic), sp, qos_value);
                     }
-                    wp.lock()->suback(packet_id, res);
+                    sp->suback(packet_id, res);
                     return true;
                 }
             );
@@ -219,7 +232,9 @@ int main(int argc, char** argv) {
                     for (auto const& topic : topics) {
                         subs.erase(topic);
                     }
-                    wp.lock()->unsuback(packet_id);
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    sp->unsuback(packet_id);
                     return true;
                 }
             );

--- a/example/tls_server.cpp
+++ b/example/tls_server.cpp
@@ -91,29 +91,32 @@ int main(int argc, char** argv) {
     mi_sub_con subs;
 
     s.set_accept_handler(
-        [&](con_t& ep) {
+        [&connections, &subs](con_sp_t spep) {
+            auto& ep = *spep;
+            std::weak_ptr<con_t> wp(spep);
+
             using packet_id_t = typename std::remove_reference_t<decltype(ep)>::packet_id_t;
             std::cout << "accept" << std::endl;
-            auto sp = ep.shared_from_this();
-            ep.start_session(sp); // keeping ep's lifetime as sp until session finished
+
+            ep.start_session(std::move(spep)); // keeping ep's lifetime as sp until session finished
 
             // set connection (lower than MQTT) level handlers
             ep.set_close_handler(
-                [&]
+                [&connections, &subs, wp]
                 (){
-                    std::cout << "closed." << std::endl;
-                    close_proc(connections, subs, ep.shared_from_this());
+                    std::cout << "[server] closed." << std::endl;
+                    close_proc(connections, subs, wp.lock());
                 });
             ep.set_error_handler(
-                [&]
+                [&connections, &subs, wp]
                 (boost::system::error_code const& ec){
-                    std::cout << "error: " << ec.message() << std::endl;
-                    close_proc(connections, subs, ep.shared_from_this());
+                    std::cout << "[server] error: " << ec.message() << std::endl;
+                    close_proc(connections, subs, wp.lock());
                 });
 
             // set MQTT level handlers
             ep.set_connect_handler(
-                [&]
+                [&connections, wp]
                 (MQTT_NS::buffer client_id,
                  MQTT_NS::optional<MQTT_NS::buffer> username,
                  MQTT_NS::optional<MQTT_NS::buffer> password,
@@ -121,62 +124,62 @@ int main(int argc, char** argv) {
                  bool clean_session,
                  std::uint16_t keep_alive) {
                     using namespace MQTT_NS::literals;
-                    std::cout << "client_id    : " << client_id << std::endl;
-                    std::cout << "username     : " << (username ? username.value() : "none"_mb) << std::endl;
-                    std::cout << "password     : " << (password ? password.value() : "none"_mb) << std::endl;
-                    std::cout << "clean_session: " << std::boolalpha << clean_session << std::endl;
-                    std::cout << "keep_alive   : " << keep_alive << std::endl;
-                    connections.insert(ep.shared_from_this());
-                    ep.connack(false, MQTT_NS::connect_return_code::accepted);
+                    std::cout << "[server] client_id    : " << client_id << std::endl;
+                    std::cout << "[server] username     : " << (username ? username.value() : "none"_mb) << std::endl;
+                    std::cout << "[server] password     : " << (password ? password.value() : "none"_mb) << std::endl;
+                    std::cout << "[server] clean_session: " << std::boolalpha << clean_session << std::endl;
+                    std::cout << "[server] keep_alive   : " << keep_alive << std::endl;
+                    connections.insert(wp.lock());
+                    wp.lock()->connack(false, MQTT_NS::connect_return_code::accepted);
                     return true;
                 }
             );
             ep.set_disconnect_handler(
-                [&]
+                [&connections, &subs, wp]
                 (){
-                    std::cout << "disconnect received." << std::endl;
-                    close_proc(connections, subs, ep.shared_from_this());
+                    std::cout << "[server] disconnect received." << std::endl;
+                    close_proc(connections, subs, wp.lock());
                 });
             ep.set_puback_handler(
-                [&]
+                []
                 (packet_id_t packet_id){
-                    std::cout << "puback received. packet_id: " << packet_id << std::endl;
+                    std::cout << "[server] puback received. packet_id: " << packet_id << std::endl;
                     return true;
                 });
             ep.set_pubrec_handler(
-                [&]
+                []
                 (packet_id_t packet_id){
-                    std::cout << "pubrec received. packet_id: " << packet_id << std::endl;
+                    std::cout << "[server] pubrec received. packet_id: " << packet_id << std::endl;
                     return true;
                 });
             ep.set_pubrel_handler(
-                [&]
+                []
                 (packet_id_t packet_id){
-                    std::cout << "pubrel received. packet_id: " << packet_id << std::endl;
+                    std::cout << "[server] pubrel received. packet_id: " << packet_id << std::endl;
                     return true;
                 });
             ep.set_pubcomp_handler(
-                [&]
+                []
                 (packet_id_t packet_id){
-                    std::cout << "pubcomp received. packet_id: " << packet_id << std::endl;
+                    std::cout << "[server] pubcomp received. packet_id: " << packet_id << std::endl;
                     return true;
                 });
             ep.set_publish_handler(
-                [&]
+                [&subs]
                 (bool is_dup,
                  MQTT_NS::qos qos_value,
                  bool is_retain,
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::buffer topic_name,
                  MQTT_NS::buffer contents){
-                    std::cout << "publish received."
+                    std::cout << "[server] publish received."
                               << " dup: " << std::boolalpha << is_dup
                               << " qos: " << qos_value
-                              << " retain: " << is_retain << std::endl;
+                              << " retain: " << std::boolalpha << is_retain << std::endl;
                     if (packet_id)
-                        std::cout << "packet_id: " << *packet_id << std::endl;
-                    std::cout << "topic_name: " << topic_name << std::endl;
-                    std::cout << "contents: " << contents << std::endl;
+                        std::cout << "[server] packet_id: " << *packet_id << std::endl;
+                    std::cout << "[server] topic_name: " << topic_name << std::endl;
+                    std::cout << "[server] contents: " << contents << std::endl;
                     auto const& idx = subs.get<tag_topic>();
                     auto r = idx.equal_range(topic_name);
                     for (; r.first != r.second; ++r.first) {
@@ -191,32 +194,32 @@ int main(int argc, char** argv) {
                     return true;
                 });
             ep.set_subscribe_handler(
-                [&]
+                [&subs, wp]
                 (packet_id_t packet_id,
                  std::vector<std::tuple<MQTT_NS::buffer, MQTT_NS::subscribe_options>> entries) {
-                    std::cout << "subscribe received. packet_id: " << packet_id << std::endl;
+                    std::cout << "[server]subscribe received. packet_id: " << packet_id << std::endl;
                     std::vector<MQTT_NS::suback_reason_code> res;
                     res.reserve(entries.size());
                     for (auto const& e : entries) {
                         MQTT_NS::buffer topic = std::get<0>(e);
                         MQTT_NS::qos qos_value = std::get<1>(e).get_qos();
-                        std::cout << "topic: " << topic  << " qos: " << qos_value << std::endl;
+                        std::cout << "[server] topic: " << topic  << " qos: " << qos_value << std::endl;
                         res.emplace_back(static_cast<MQTT_NS::suback_reason_code>(qos_value));
-                        subs.emplace(std::move(topic), ep.shared_from_this(), qos_value);
+                        subs.emplace(std::move(topic), wp.lock(), qos_value);
                     }
-                    ep.suback(packet_id, res);
+                    wp.lock()->suback(packet_id, res);
                     return true;
                 }
             );
             ep.set_unsubscribe_handler(
-                [&]
+                [&subs, wp]
                 (packet_id_t packet_id,
                  std::vector<MQTT_NS::buffer> topics) {
-                    std::cout << "unsubscribe received. packet_id: " << packet_id << std::endl;
+                    std::cout << "[server]unsubscribe received. packet_id: " << packet_id << std::endl;
                     for (auto const& topic : topics) {
                         subs.erase(topic);
                     }
-                    ep.unsuback(packet_id);
+                    wp.lock()->unsuback(packet_id);
                     return true;
                 }
             );

--- a/example/tls_ws_both.cpp
+++ b/example/tls_ws_both.cpp
@@ -168,36 +168,38 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
         }
     );
     s.set_accept_handler(
-        [&](con_t& ep) {
+        [&s, &connections, &subs](con_sp_t spep) {
+            auto& ep = *spep;
+            std::weak_ptr<con_t> wp(spep);
+
             using packet_id_t = typename std::remove_reference_t<decltype(ep)>::packet_id_t;
             std::cout << "[server] accept" << std::endl;
-            auto sp = ep.shared_from_this();
             // For server close if ep is closed.
             auto g = MQTT_NS::shared_scope_guard(
-                [&] {
+                [&s] {
                     std::cout << "[server] session end" << std::endl;
                     s.close();
                 }
             );
-            ep.start_session(std::make_tuple(std::move(sp), std::move(g)));
+            ep.start_session(std::make_tuple(std::move(spep), std::move(g)));
 
             // set connection (lower than MQTT) level handlers
             ep.set_close_handler(
-                [&]
+                [&connections, &subs, wp]
                 (){
                     std::cout << "[server] closed." << std::endl;
-                    close_proc(connections, subs, ep.shared_from_this());
+                    close_proc(connections, subs, wp.lock());
                 });
             ep.set_error_handler(
-                [&]
+                [&connections, &subs, wp]
                 (boost::system::error_code const& ec){
                     std::cout << "[server] error: " << ec.message() << std::endl;
-                    close_proc(connections, subs, ep.shared_from_this());
+                    close_proc(connections, subs, wp.lock());
                 });
 
             // set MQTT level handlers
             ep.set_connect_handler(
-                [&]
+                [&connections, wp]
                 (MQTT_NS::buffer client_id,
                  MQTT_NS::optional<MQTT_NS::buffer> username,
                  MQTT_NS::optional<MQTT_NS::buffer> password,
@@ -210,43 +212,43 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                     std::cout << "[server] password     : " << (password ? password.value() : "none"_mb) << std::endl;
                     std::cout << "[server] clean_session: " << std::boolalpha << clean_session << std::endl;
                     std::cout << "[server] keep_alive   : " << keep_alive << std::endl;
-                    connections.insert(ep.shared_from_this());
-                    ep.connack(false, MQTT_NS::connect_return_code::accepted);
+                    connections.insert(wp.lock());
+                    wp.lock()->connack(false, MQTT_NS::connect_return_code::accepted);
                     return true;
                 }
             );
             ep.set_disconnect_handler(
-                [&]
+                [&connections, &subs, wp]
                 (){
                     std::cout << "[server] disconnect received." << std::endl;
-                    close_proc(connections, subs, ep.shared_from_this());
+                    close_proc(connections, subs, wp.lock());
                 });
             ep.set_puback_handler(
-                [&]
+                []
                 (packet_id_t packet_id){
                     std::cout << "[server] puback received. packet_id: " << packet_id << std::endl;
                     return true;
                 });
             ep.set_pubrec_handler(
-                [&]
+                []
                 (packet_id_t packet_id){
                     std::cout << "[server] pubrec received. packet_id: " << packet_id << std::endl;
                     return true;
                 });
             ep.set_pubrel_handler(
-                [&]
+                []
                 (packet_id_t packet_id){
                     std::cout << "[server] pubrel received. packet_id: " << packet_id << std::endl;
                     return true;
                 });
             ep.set_pubcomp_handler(
-                [&]
+                []
                 (packet_id_t packet_id){
                     std::cout << "[server] pubcomp received. packet_id: " << packet_id << std::endl;
                     return true;
                 });
             ep.set_publish_handler(
-                [&]
+                [&subs]
                 (bool is_dup,
                  MQTT_NS::qos qos_value,
                  bool is_retain,
@@ -256,7 +258,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                     std::cout << "[server] publish received."
                               << " dup: " << std::boolalpha << is_dup
                               << " qos: " << qos_value
-                              << " retain: " << is_retain << std::endl;
+                              << " retain: " << std::boolalpha << is_retain << std::endl;
                     if (packet_id)
                         std::cout << "[server] packet_id: " << *packet_id << std::endl;
                     std::cout << "[server] topic_name: " << topic_name << std::endl;
@@ -275,7 +277,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                     return true;
                 });
             ep.set_subscribe_handler(
-                [&]
+                [&subs, wp]
                 (packet_id_t packet_id,
                  std::vector<std::tuple<MQTT_NS::buffer, MQTT_NS::subscribe_options>> entries) {
                     std::cout << "[server]subscribe received. packet_id: " << packet_id << std::endl;
@@ -286,21 +288,21 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                         MQTT_NS::qos qos_value = std::get<1>(e).get_qos();
                         std::cout << "[server] topic: " << topic  << " qos: " << qos_value << std::endl;
                         res.emplace_back(static_cast<MQTT_NS::suback_reason_code>(qos_value));
-                        subs.emplace(std::move(topic), ep.shared_from_this(), qos_value);
+                        subs.emplace(std::move(topic), wp.lock(), qos_value);
                     }
-                    ep.suback(packet_id, res);
+                    wp.lock()->suback(packet_id, res);
                     return true;
                 }
             );
             ep.set_unsubscribe_handler(
-                [&]
+                [&subs, wp]
                 (packet_id_t packet_id,
                  std::vector<MQTT_NS::buffer> topics) {
                     std::cout << "[server]unsubscribe received. packet_id: " << packet_id << std::endl;
                     for (auto const& topic : topics) {
                         subs.erase(topic);
                     }
-                    ep.unsuback(packet_id);
+                    wp.lock()->unsuback(packet_id);
                     return true;
                 }
             );

--- a/example/tls_ws_both.cpp
+++ b/example/tls_ws_both.cpp
@@ -181,6 +181,9 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                     s.close();
                 }
             );
+            // Pass spep to keep lifetime.
+            // It makes sure wp.lock() never return nullptr in the handlers below
+            // including close_handler and error_handler.
             ep.start_session(std::make_tuple(std::move(spep), std::move(g)));
 
             // set connection (lower than MQTT) level handlers
@@ -188,13 +191,17 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                 [&connections, &subs, wp]
                 (){
                     std::cout << "[server] closed." << std::endl;
-                    close_proc(connections, subs, wp.lock());
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    close_proc(connections, subs, sp);
                 });
             ep.set_error_handler(
                 [&connections, &subs, wp]
                 (boost::system::error_code const& ec){
                     std::cout << "[server] error: " << ec.message() << std::endl;
-                    close_proc(connections, subs, wp.lock());
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    close_proc(connections, subs, sp);
                 });
 
             // set MQTT level handlers
@@ -212,8 +219,10 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                     std::cout << "[server] password     : " << (password ? password.value() : "none"_mb) << std::endl;
                     std::cout << "[server] clean_session: " << std::boolalpha << clean_session << std::endl;
                     std::cout << "[server] keep_alive   : " << keep_alive << std::endl;
-                    connections.insert(wp.lock());
-                    wp.lock()->connack(false, MQTT_NS::connect_return_code::accepted);
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    connections.insert(sp);
+                    sp->connack(false, MQTT_NS::connect_return_code::accepted);
                     return true;
                 }
             );
@@ -221,7 +230,9 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                 [&connections, &subs, wp]
                 (){
                     std::cout << "[server] disconnect received." << std::endl;
-                    close_proc(connections, subs, wp.lock());
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    close_proc(connections, subs, sp);
                 });
             ep.set_puback_handler(
                 []
@@ -283,14 +294,16 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                     std::cout << "[server]subscribe received. packet_id: " << packet_id << std::endl;
                     std::vector<MQTT_NS::suback_reason_code> res;
                     res.reserve(entries.size());
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
                     for (auto const& e : entries) {
                         MQTT_NS::buffer topic = std::get<0>(e);
                         MQTT_NS::qos qos_value = std::get<1>(e).get_qos();
                         std::cout << "[server] topic: " << topic  << " qos: " << qos_value << std::endl;
                         res.emplace_back(static_cast<MQTT_NS::suback_reason_code>(qos_value));
-                        subs.emplace(std::move(topic), wp.lock(), qos_value);
+                        subs.emplace(std::move(topic), sp, qos_value);
                     }
-                    wp.lock()->suback(packet_id, res);
+                    sp->suback(packet_id, res);
                     return true;
                 }
             );
@@ -302,7 +315,9 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                     for (auto const& topic : topics) {
                         subs.erase(topic);
                     }
-                    wp.lock()->unsuback(packet_id);
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    sp->unsuback(packet_id);
                     return true;
                 }
             );

--- a/example/tls_ws_server.cpp
+++ b/example/tls_ws_server.cpp
@@ -98,20 +98,27 @@ int main(int argc, char** argv) {
             using packet_id_t = typename std::remove_reference_t<decltype(ep)>::packet_id_t;
             std::cout << "accept" << std::endl;
 
-            ep.start_session(std::move(spep)); // keeping ep's lifetime as sp until session finished
+            // Pass spep to keep lifetime.
+            // It makes sure wp.lock() never return nullptr in the handlers below
+            // including close_handler and error_handler.
+            ep.start_session(std::move(spep));
 
             // set connection (lower than MQTT) level handlers
             ep.set_close_handler(
                 [&connections, &subs, wp]
                 (){
                     std::cout << "[server] closed." << std::endl;
-                    close_proc(connections, subs, wp.lock());
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    close_proc(connections, subs, sp);
                 });
             ep.set_error_handler(
                 [&connections, &subs, wp]
                 (boost::system::error_code const& ec){
                     std::cout << "[server] error: " << ec.message() << std::endl;
-                    close_proc(connections, subs, wp.lock());
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    close_proc(connections, subs, sp);
                 });
 
             // set MQTT level handlers
@@ -129,8 +136,10 @@ int main(int argc, char** argv) {
                     std::cout << "[server] password     : " << (password ? password.value() : "none"_mb) << std::endl;
                     std::cout << "[server] clean_session: " << std::boolalpha << clean_session << std::endl;
                     std::cout << "[server] keep_alive   : " << keep_alive << std::endl;
-                    connections.insert(wp.lock());
-                    wp.lock()->connack(false, MQTT_NS::connect_return_code::accepted);
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    connections.insert(sp);
+                    sp->connack(false, MQTT_NS::connect_return_code::accepted);
                     return true;
                 }
             );
@@ -138,7 +147,9 @@ int main(int argc, char** argv) {
                 [&connections, &subs, wp]
                 (){
                     std::cout << "[server] disconnect received." << std::endl;
-                    close_proc(connections, subs, wp.lock());
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    close_proc(connections, subs, sp);
                 });
             ep.set_puback_handler(
                 []
@@ -200,14 +211,16 @@ int main(int argc, char** argv) {
                     std::cout << "[server]subscribe received. packet_id: " << packet_id << std::endl;
                     std::vector<MQTT_NS::suback_reason_code> res;
                     res.reserve(entries.size());
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
                     for (auto const& e : entries) {
                         MQTT_NS::buffer topic = std::get<0>(e);
                         MQTT_NS::qos qos_value = std::get<1>(e).get_qos();
                         std::cout << "[server] topic: " << topic  << " qos: " << qos_value << std::endl;
                         res.emplace_back(static_cast<MQTT_NS::suback_reason_code>(qos_value));
-                        subs.emplace(std::move(topic), wp.lock(), qos_value);
+                        subs.emplace(std::move(topic), sp, qos_value);
                     }
-                    wp.lock()->suback(packet_id, res);
+                    sp->suback(packet_id, res);
                     return true;
                 }
             );
@@ -219,7 +232,9 @@ int main(int argc, char** argv) {
                     for (auto const& topic : topics) {
                         subs.erase(topic);
                     }
-                    wp.lock()->unsuback(packet_id);
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    sp->unsuback(packet_id);
                     return true;
                 }
             );

--- a/example/tls_ws_server.cpp
+++ b/example/tls_ws_server.cpp
@@ -91,29 +91,32 @@ int main(int argc, char** argv) {
     mi_sub_con subs;
 
     s.set_accept_handler(
-        [&](con_t& ep) {
+        [&connections, &subs](con_sp_t spep) {
+            auto& ep = *spep;
+            std::weak_ptr<con_t> wp(spep);
+
             using packet_id_t = typename std::remove_reference_t<decltype(ep)>::packet_id_t;
             std::cout << "accept" << std::endl;
-            auto sp = ep.shared_from_this();
-            ep.start_session(sp); // keeping ep's lifetime as sp until session finished
+
+            ep.start_session(std::move(spep)); // keeping ep's lifetime as sp until session finished
 
             // set connection (lower than MQTT) level handlers
             ep.set_close_handler(
-                [&]
+                [&connections, &subs, wp]
                 (){
-                    std::cout << "closed." << std::endl;
-                    close_proc(connections, subs, ep.shared_from_this());
+                    std::cout << "[server] closed." << std::endl;
+                    close_proc(connections, subs, wp.lock());
                 });
             ep.set_error_handler(
-                [&]
+                [&connections, &subs, wp]
                 (boost::system::error_code const& ec){
-                    std::cout << "error: " << ec.message() << std::endl;
-                    close_proc(connections, subs, ep.shared_from_this());
+                    std::cout << "[server] error: " << ec.message() << std::endl;
+                    close_proc(connections, subs, wp.lock());
                 });
 
             // set MQTT level handlers
             ep.set_connect_handler(
-                [&]
+                [&connections, wp]
                 (MQTT_NS::buffer client_id,
                  MQTT_NS::optional<MQTT_NS::buffer> username,
                  MQTT_NS::optional<MQTT_NS::buffer> password,
@@ -121,62 +124,62 @@ int main(int argc, char** argv) {
                  bool clean_session,
                  std::uint16_t keep_alive) {
                     using namespace MQTT_NS::literals;
-                    std::cout << "client_id    : " << client_id << std::endl;
-                    std::cout << "username     : " << (username ? username.value() : "none"_mb) << std::endl;
-                    std::cout << "password     : " << (password ? password.value() : "none"_mb) << std::endl;
-                    std::cout << "clean_session: " << std::boolalpha << clean_session << std::endl;
-                    std::cout << "keep_alive   : " << keep_alive << std::endl;
-                    connections.insert(ep.shared_from_this());
-                    ep.connack(false, MQTT_NS::connect_return_code::accepted);
+                    std::cout << "[server] client_id    : " << client_id << std::endl;
+                    std::cout << "[server] username     : " << (username ? username.value() : "none"_mb) << std::endl;
+                    std::cout << "[server] password     : " << (password ? password.value() : "none"_mb) << std::endl;
+                    std::cout << "[server] clean_session: " << std::boolalpha << clean_session << std::endl;
+                    std::cout << "[server] keep_alive   : " << keep_alive << std::endl;
+                    connections.insert(wp.lock());
+                    wp.lock()->connack(false, MQTT_NS::connect_return_code::accepted);
                     return true;
                 }
             );
             ep.set_disconnect_handler(
-                [&]
+                [&connections, &subs, wp]
                 (){
-                    std::cout << "disconnect received." << std::endl;
-                    close_proc(connections, subs, ep.shared_from_this());
+                    std::cout << "[server] disconnect received." << std::endl;
+                    close_proc(connections, subs, wp.lock());
                 });
             ep.set_puback_handler(
-                [&]
+                []
                 (packet_id_t packet_id){
-                    std::cout << "puback received. packet_id: " << packet_id << std::endl;
+                    std::cout << "[server] puback received. packet_id: " << packet_id << std::endl;
                     return true;
                 });
             ep.set_pubrec_handler(
-                [&]
+                []
                 (packet_id_t packet_id){
-                    std::cout << "pubrec received. packet_id: " << packet_id << std::endl;
+                    std::cout << "[server] pubrec received. packet_id: " << packet_id << std::endl;
                     return true;
                 });
             ep.set_pubrel_handler(
-                [&]
+                []
                 (packet_id_t packet_id){
-                    std::cout << "pubrel received. packet_id: " << packet_id << std::endl;
+                    std::cout << "[server] pubrel received. packet_id: " << packet_id << std::endl;
                     return true;
                 });
             ep.set_pubcomp_handler(
-                [&]
+                []
                 (packet_id_t packet_id){
-                    std::cout << "pubcomp received. packet_id: " << packet_id << std::endl;
+                    std::cout << "[server] pubcomp received. packet_id: " << packet_id << std::endl;
                     return true;
                 });
             ep.set_publish_handler(
-                [&]
+                [&subs]
                 (bool is_dup,
                  MQTT_NS::qos qos_value,
                  bool is_retain,
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::buffer topic_name,
                  MQTT_NS::buffer contents){
-                    std::cout << "publish received."
+                    std::cout << "[server] publish received."
                               << " dup: " << std::boolalpha << is_dup
                               << " qos: " << qos_value
-                              << " retain: " << is_retain << std::endl;
+                              << " retain: " << std::boolalpha << is_retain << std::endl;
                     if (packet_id)
-                        std::cout << "packet_id: " << *packet_id << std::endl;
-                    std::cout << "topic_name: " << topic_name << std::endl;
-                    std::cout << "contents: " << contents << std::endl;
+                        std::cout << "[server] packet_id: " << *packet_id << std::endl;
+                    std::cout << "[server] topic_name: " << topic_name << std::endl;
+                    std::cout << "[server] contents: " << contents << std::endl;
                     auto const& idx = subs.get<tag_topic>();
                     auto r = idx.equal_range(topic_name);
                     for (; r.first != r.second; ++r.first) {
@@ -191,32 +194,32 @@ int main(int argc, char** argv) {
                     return true;
                 });
             ep.set_subscribe_handler(
-                [&]
+                [&subs, wp]
                 (packet_id_t packet_id,
                  std::vector<std::tuple<MQTT_NS::buffer, MQTT_NS::subscribe_options>> entries) {
-                    std::cout << "subscribe received. packet_id: " << packet_id << std::endl;
+                    std::cout << "[server]subscribe received. packet_id: " << packet_id << std::endl;
                     std::vector<MQTT_NS::suback_reason_code> res;
                     res.reserve(entries.size());
                     for (auto const& e : entries) {
                         MQTT_NS::buffer topic = std::get<0>(e);
                         MQTT_NS::qos qos_value = std::get<1>(e).get_qos();
-                        std::cout << "topic: " << topic  << " qos: " << qos_value << std::endl;
+                        std::cout << "[server] topic: " << topic  << " qos: " << qos_value << std::endl;
                         res.emplace_back(static_cast<MQTT_NS::suback_reason_code>(qos_value));
-                        subs.emplace(std::move(topic), ep.shared_from_this(), qos_value);
+                        subs.emplace(std::move(topic), wp.lock(), qos_value);
                     }
-                    ep.suback(packet_id, res);
+                    wp.lock()->suback(packet_id, res);
                     return true;
                 }
             );
             ep.set_unsubscribe_handler(
-                [&]
+                [&subs, wp]
                 (packet_id_t packet_id,
                  std::vector<MQTT_NS::buffer> topics) {
-                    std::cout << "unsubscribe received. packet_id: " << packet_id << std::endl;
+                    std::cout << "[server]unsubscribe received. packet_id: " << packet_id << std::endl;
                     for (auto const& topic : topics) {
                         subs.erase(topic);
                     }
-                    ep.unsuback(packet_id);
+                    wp.lock()->unsuback(packet_id);
                     return true;
                 }
             );

--- a/example/v5_no_tls_both.cpp
+++ b/example/v5_no_tls_both.cpp
@@ -201,6 +201,9 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                     s.close();
                 }
             );
+            // Pass spep to keep lifetime.
+            // It makes sure wp.lock() never return nullptr in the handlers below
+            // including close_handler and error_handler.
             ep.start_session(std::make_tuple(std::move(spep), std::move(g)));
 
             // set connection (lower than MQTT) level handlers
@@ -208,13 +211,17 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                 [&connections, &subs, wp]
                 (){
                     std::cout << "[server] closed." << std::endl;
-                    close_proc(connections, subs, wp.lock());
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    close_proc(connections, subs, sp);
                 });
             ep.set_error_handler(
                 [&connections, &subs, wp]
                 (boost::system::error_code const& ec){
                     std::cout << "[server] error: " << ec.message() << std::endl;
-                    close_proc(connections, subs, wp.lock());
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    close_proc(connections, subs, sp);
                 });
 
             // set MQTT level handlers
@@ -233,8 +240,10 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                     std::cout << "[server] password     : " << (password ? password.value() : "none"_mb) << std::endl;
                     std::cout << "[server] clean_session: " << std::boolalpha << clean_session << std::endl;
                     std::cout << "[server] keep_alive   : " << keep_alive << std::endl;
-                    connections.insert(wp.lock());
-                    wp.lock()->connack(false, MQTT_NS::v5::connect_reason_code::success);
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    connections.insert(sp);
+                    sp->connack(false, MQTT_NS::v5::connect_reason_code::success);
                     return true;
                 }
             );
@@ -244,7 +253,9 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                     std::cout <<
                         "[server] disconnect received." <<
                         " reason_code: " << reason_code << std::endl;
-                    close_proc(connections, subs, wp.lock());
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    close_proc(connections, subs, sp);
                 });
             ep.set_v5_puback_handler( // use v5 handler
                 []
@@ -316,14 +327,16 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                     std::cout << "[server] subscribe received. packet_id: " << packet_id << std::endl;
                     std::vector<MQTT_NS::v5::suback_reason_code> res;
                     res.reserve(entries.size());
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
                     for (auto const& e : entries) {
                         MQTT_NS::buffer topic = std::get<0>(e);
                         MQTT_NS::qos qos_value = std::get<1>(e).get_qos();
                         std::cout << "[server] topic: " << topic  << " qos: " << qos_value << std::endl;
                         res.emplace_back(static_cast<MQTT_NS::v5::suback_reason_code>(qos_value));
-                        subs.emplace(std::move(topic), wp.lock(), qos_value);
+                        subs.emplace(std::move(topic), sp, qos_value);
                     }
-                    wp.lock()->suback(packet_id, res);
+                    sp->suback(packet_id, res);
                     return true;
                 }
             );
@@ -336,7 +349,9 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                     for (auto const& topic : topics) {
                         subs.erase(topic);
                     }
-                    wp.lock()->unsuback(packet_id);
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    sp->unsuback(packet_id);
                     return true;
                 }
             );

--- a/example/v5_no_tls_server.cpp
+++ b/example/v5_no_tls_server.cpp
@@ -85,6 +85,9 @@ int main(int argc, char** argv) {
 
             using packet_id_t = typename std::remove_reference_t<decltype(ep)>::packet_id_t;
             std::cout << "[server] accept" << std::endl;
+            // Pass spep to keep lifetime.
+            // It makes sure wp.lock() never return nullptr in the handlers below
+            // including close_handler and error_handler.
             ep.start_session(std::move(spep));
 
             // set connection (lower than MQTT) level handlers
@@ -92,13 +95,17 @@ int main(int argc, char** argv) {
                 [&connections, &subs, wp]
                 (){
                     std::cout << "[server] closed." << std::endl;
-                    close_proc(connections, subs, wp.lock());
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    close_proc(connections, subs, sp);
                 });
             ep.set_error_handler(
                 [&connections, &subs, wp]
                 (boost::system::error_code const& ec){
                     std::cout << "[server] error: " << ec.message() << std::endl;
-                    close_proc(connections, subs, wp.lock());
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    close_proc(connections, subs, sp);
                 });
 
             // set MQTT level handlers
@@ -117,8 +124,10 @@ int main(int argc, char** argv) {
                     std::cout << "[server] password     : " << (password ? password.value() : "none"_mb) << std::endl;
                     std::cout << "[server] clean_session: " << std::boolalpha << clean_session << std::endl;
                     std::cout << "[server] keep_alive   : " << keep_alive << std::endl;
-                    connections.insert(wp.lock());
-                    wp.lock()->connack(false, MQTT_NS::v5::connect_reason_code::success);
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    connections.insert(sp);
+                    sp->connack(false, MQTT_NS::v5::connect_reason_code::success);
                     return true;
                 }
             );
@@ -128,7 +137,9 @@ int main(int argc, char** argv) {
                     std::cout <<
                         "[server] disconnect received." <<
                         " reason_code: " << reason_code << std::endl;
-                    close_proc(connections, subs, wp.lock());
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    close_proc(connections, subs, sp);
                 });
             ep.set_v5_puback_handler( // use v5 handler
                 []
@@ -200,14 +211,16 @@ int main(int argc, char** argv) {
                     std::cout << "[server] subscribe received. packet_id: " << packet_id << std::endl;
                     std::vector<MQTT_NS::v5::suback_reason_code> res;
                     res.reserve(entries.size());
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
                     for (auto const& e : entries) {
                         MQTT_NS::buffer topic = std::get<0>(e);
                         MQTT_NS::qos qos_value = std::get<1>(e).get_qos();
                         std::cout << "[server] topic: " << topic  << " qos: " << qos_value << std::endl;
                         res.emplace_back(static_cast<MQTT_NS::v5::suback_reason_code>(qos_value));
-                        subs.emplace(std::move(topic), wp.lock(), qos_value);
+                        subs.emplace(std::move(topic), sp, qos_value);
                     }
-                    wp.lock()->suback(packet_id, res);
+                    sp->suback(packet_id, res);
                     return true;
                 }
             );
@@ -220,7 +233,9 @@ int main(int argc, char** argv) {
                     for (auto const& topic : topics) {
                         subs.erase(topic);
                     }
-                    wp.lock()->unsuback(packet_id);
+                    auto sp = wp.lock();
+                    BOOST_ASSERT(sp);
+                    sp->unsuback(packet_id);
                     return true;
                 }
             );

--- a/include/mqtt/server.hpp
+++ b/include/mqtt/server.hpp
@@ -47,7 +47,7 @@ public:
      * @brief Accept handler
      * @param ep endpoint of the connecting client
      */
-    using accept_handler = std::function<void(endpoint_t& ep)>;
+    using accept_handler = std::function<void(std::shared_ptr<endpoint_t> ep)>;
 
     /**
      * @brief Error handler
@@ -154,7 +154,7 @@ private:
                     return;
                 }
                 auto sp = std::make_shared<endpoint_t>(force_move(socket), version_);
-                if (h_accept_) h_accept_(*sp);
+                if (h_accept_) h_accept_(force_move(sp));
                 do_accept();
             }
         );
@@ -189,7 +189,7 @@ public:
      * @brief Accept handler
      * @param ep endpoint of the connecting client
      */
-    using accept_handler = std::function<void(endpoint_t& ep)>;
+    using accept_handler = std::function<void(std::shared_ptr<endpoint_t> ep)>;
 
     /**
      * @brief Error handler
@@ -336,7 +336,7 @@ private:
                             return;
                         }
                         auto sp = std::make_shared<endpoint_t>(force_move(socket), version_);
-                        if (h_accept_) h_accept_(*sp);
+                        if (h_accept_) h_accept_(force_move(sp));
                     }
                 );
                 do_accept();
@@ -392,7 +392,7 @@ public:
      * @brief Accept handler
      * @param ep endpoint of the connecting client
      */
-    using accept_handler = std::function<void(endpoint_t& ep)>;
+    using accept_handler = std::function<void(std::shared_ptr<endpoint_t> ep)>;
 
     /**
      * @brief Error handler
@@ -561,7 +561,7 @@ private:
                                     return;
                                 }
                                 auto sp = std::make_shared<endpoint_t>(force_move(socket), version_);
-                                if (h_accept_) h_accept_(*sp);
+                                if (h_accept_) h_accept_(force_move(sp));
                             }
                         );
                     }
@@ -602,7 +602,7 @@ public:
      * @brief Accept handler
      * @param ep endpoint of the connecting client
      */
-    using accept_handler = std::function<void(endpoint_t& ep)>;
+    using accept_handler = std::function<void(std::shared_ptr<endpoint_t> ep)>;
 
     /**
      * @brief Error handler
@@ -784,7 +784,7 @@ private:
                                         // a static assertion that socket is a const object when
                                         // TLS is enabled, and WS is enabled, with Boost 1.70, and gcc 8.3.0
                                         auto sp = std::make_shared<endpoint_t>(socket, version_);
-                                        if (h_accept_) h_accept_(*sp);
+                                        if (h_accept_) h_accept_(force_move(sp));
                                     }
                                 );
                             }

--- a/test/test_server_no_tls.hpp
+++ b/test/test_server_no_tls.hpp
@@ -34,8 +34,8 @@ public:
         );
 
         server_.set_accept_handler(
-            [&](MQTT_NS::server<>::endpoint_t& ep) {
-                b_.handle_accept(ep);
+            [&](std::shared_ptr<MQTT_NS::server<>::endpoint_t> spep) {
+                b_.handle_accept(MQTT_NS::force_move(spep));
             }
         );
 

--- a/test/test_server_no_tls_ws.hpp
+++ b/test/test_server_no_tls_ws.hpp
@@ -34,8 +34,8 @@ public:
         );
 
         server_.set_accept_handler(
-            [&](MQTT_NS::server_ws<>::endpoint_t& ep) {
-                b_.handle_accept(ep);
+            [&](std::shared_ptr<MQTT_NS::server_ws<>::endpoint_t> spep) {
+                b_.handle_accept(MQTT_NS::force_move(spep));
             }
         );
 

--- a/test/test_server_tls.hpp
+++ b/test/test_server_tls.hpp
@@ -43,8 +43,8 @@ public:
         );
 
         server_.set_accept_handler(
-            [&](MQTT_NS::server_tls<>::endpoint_t& ep) {
-                b_.handle_accept(ep);
+            [&](std::shared_ptr<MQTT_NS::server_tls<>::endpoint_t> spep) {
+                b_.handle_accept(MQTT_NS::force_move(spep));
             }
         );
 

--- a/test/test_server_tls_ws.hpp
+++ b/test/test_server_tls_ws.hpp
@@ -44,8 +44,8 @@ public:
         );
 
         server_.set_accept_handler(
-            [&](MQTT_NS::server_tls_ws<>::endpoint_t& ep) {
-                b_.handle_accept(ep);
+            [&](std::shared_ptr<MQTT_NS::server_tls_ws<>::endpoint_t> spep) {
+                b_.handle_accept(MQTT_NS::force_move(spep));
             }
         );
 

--- a/test/underlying_timeout.cpp
+++ b/test/underlying_timeout.cpp
@@ -30,7 +30,7 @@ BOOST_AUTO_TEST_CASE( connect_ws_upg ) {
         ioc);
 
     server.set_accept_handler(
-        [&](MQTT_NS::server_ws<>::endpoint_t& /*ep*/) {
+        [&](std::shared_ptr<MQTT_NS::server_ws<>::endpoint_t> /*spep*/) {
             BOOST_TEST(false);
         }
     );
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE( connect_tls_ws_ashs ) {
         ioc);
 
     server.set_accept_handler(
-        [&](MQTT_NS::server_tls_ws<>::endpoint_t& /*ep*/) {
+        [&](std::shared_ptr<MQTT_NS::server_tls_ws<>::endpoint_t> /*spep*/) {
             BOOST_TEST(false);
         }
     );
@@ -177,7 +177,7 @@ BOOST_AUTO_TEST_CASE( connect_tls_ws_upg ) {
         ioc);
 
     server.set_accept_handler(
-        [&](MQTT_NS::server_tls_ws<>::endpoint_t& /*ep*/) {
+        [&](std::shared_ptr<MQTT_NS::server_tls_ws<>::endpoint_t> /*spep*/) {
             BOOST_TEST(false);
         }
     );
@@ -268,7 +268,7 @@ BOOST_AUTO_TEST_CASE( connect_tls_ashs ) {
         ioc);
 
     server.set_accept_handler(
-        [&](MQTT_NS::server_tls<>::endpoint_t& /*ep*/) {
+        [&](std::shared_ptr<MQTT_NS::server_tls<>::endpoint_t> /*spep*/) {
             BOOST_TEST(false);
         }
     );


### PR DESCRIPTION
…:shared_ptr<endpoint_t>.

For `set_*_handler()`, capture `std::weak_ptr<endpoint_t>` at
test_broker and examples.

I think that `weak_ptr` is redundant. Reference is good enough because
`shared_ptr` lifetime is kept by `start_session(life_keeper)`.

However, `wp.lock()` is easy to detect if the lifetime is over unexpectedly.