### PR TITLE
Implemented #471.

### DIFF
--- a/example/tls_both.cpp
+++ b/example/tls_both.cpp
@@ -366,7 +366,7 @@ int main(int argc, char** argv) {
     std::uint16_t pid_sub2;
 
     auto c = MQTT_NS::make_tls_sync_client(ioc, "localhost", port);
-    c->set_ca_cert_file(base + "cacert.pem");
+    c->get_context().load_verify_file(base + "cacert.pem");
 
     int count = 0;
     auto disconnect = [&] {

--- a/example/tls_both.cpp
+++ b/example/tls_both.cpp
@@ -366,7 +366,7 @@ int main(int argc, char** argv) {
     std::uint16_t pid_sub2;
 
     auto c = MQTT_NS::make_tls_sync_client(ioc, "localhost", port);
-    c->get_context().load_verify_file(base + "cacert.pem");
+    c->get_ssl_context().load_verify_file(base + "cacert.pem");
 
     int count = 0;
     auto disconnect = [&] {

--- a/example/tls_client.cpp
+++ b/example/tls_client.cpp
@@ -37,11 +37,12 @@ int main(int argc, char** argv) {
     // Setup client
     c->set_client_id("cid1");
     c->set_clean_session(true);
-    c->set_ca_cert_file(cacert);
+    c->get_context().load_verify_file(cacert);
 
 #if OPENSSL_VERSION_NUMBER >= 0x10101000L
 
-    c->set_ssl_keylog_callback(
+    SSL_CTX_set_keylog_callback(
+        c->get_context().native_handle(),
         [](SSL const*, char const* line) {
             std::cout << line << std::endl;
         }

--- a/example/tls_client.cpp
+++ b/example/tls_client.cpp
@@ -37,12 +37,12 @@ int main(int argc, char** argv) {
     // Setup client
     c->set_client_id("cid1");
     c->set_clean_session(true);
-    c->get_context().load_verify_file(cacert);
+    c->get_ssl_context().load_verify_file(cacert);
 
 #if OPENSSL_VERSION_NUMBER >= 0x10101000L
 
     SSL_CTX_set_keylog_callback(
-        c->get_context().native_handle(),
+        c->get_ssl_context().native_handle(),
         [](SSL const*, char const* line) {
             std::cout << line << std::endl;
         }

--- a/example/tls_ws_both.cpp
+++ b/example/tls_ws_both.cpp
@@ -365,7 +365,7 @@ int main(int argc, char** argv) {
     std::uint16_t pid_sub2;
 
     auto c = MQTT_NS::make_tls_sync_client_ws(ioc, "localhost", port);
-    c->get_context().load_verify_file(base + "cacert.pem");
+    c->get_ssl_context().load_verify_file(base + "cacert.pem");
 
     int count = 0;
     auto disconnect = [&] {

--- a/example/tls_ws_both.cpp
+++ b/example/tls_ws_both.cpp
@@ -365,7 +365,7 @@ int main(int argc, char** argv) {
     std::uint16_t pid_sub2;
 
     auto c = MQTT_NS::make_tls_sync_client_ws(ioc, "localhost", port);
-    c->set_ca_cert_file(base + "cacert.pem");
+    c->get_context().load_verify_file(base + "cacert.pem");
 
     int count = 0;
     auto disconnect = [&] {

--- a/example/tls_ws_client.cpp
+++ b/example/tls_ws_client.cpp
@@ -38,7 +38,7 @@ int main(int argc, char** argv) {
     // Setup client
     c->set_client_id("cid1");
     c->set_clean_session(true);
-    c->set_ca_cert_file(cacert);
+    c->get_context().load_verify_file(cacert);
 
     // Setup handlers
     c->set_connack_handler(

--- a/example/tls_ws_client.cpp
+++ b/example/tls_ws_client.cpp
@@ -38,7 +38,7 @@ int main(int argc, char** argv) {
     // Setup client
     c->set_client_id("cid1");
     c->set_clean_session(true);
-    c->get_context().load_verify_file(cacert);
+    c->get_ssl_context().load_verify_file(cacert);
 
     // Setup handlers
     c->set_connack_handler(

--- a/include/mqtt/client.hpp
+++ b/include/mqtt/client.hpp
@@ -315,10 +315,28 @@ public:
     }
 
 #if defined(MQTT_USE_TLS)
+
+    /**
+     * @brief Get boost asio ssl context.
+     * @return ssl context
+     */
+    as::ssl::context& get_context() {
+        return ctx_;
+    }
+
+    /**
+     * @brief Get boost asio ssl context.
+     * @return ssl context
+     */
+    as::ssl::context const& get_context() const {
+        return ctx_;
+    }
+
     /**
      * @brief Call boost::asio::context::set_default_verify_paths
      * See http://www.boost.org/doc/html/boost_asio/reference/ssl__context/set_default_verify_paths.html
      */
+    MQTT_DEPRECATED("Use get_context().set_default_verify_paths()")
     void set_default_verify_paths() {
         ctx_.set_default_verify_paths();
     }
@@ -329,6 +347,7 @@ public:
      * @param file ca cert file path
      * See http://www.boost.org/doc/html/boost_asio/reference/ssl__context/load_verify_file.html
      */
+    MQTT_DEPRECATED("Use get_context().load_verify_file()")
     void set_ca_cert_file(std::string file) {
         ctx_.load_verify_file(force_move(file));
     }
@@ -343,6 +362,7 @@ public:
      * See https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_keylog_callback.html
      * See https://wiki.wireshark.org/SSL
      */
+    MQTT_DEPRECATED("Use SSL_CTX_set_keylog_callback(client->get_context().native_handle(), callback")
     void set_ssl_keylog_callback(void (*cb)(SSL const* ssl, char const* line)) {
         SSL_CTX* ssl_ctx = ctx_.native_handle();
         SSL_CTX_set_keylog_callback(ssl_ctx, cb);
@@ -355,6 +375,7 @@ public:
      * @param path the path contains ca cert files
      * See http://www.boost.org/doc/html/boost_asio/reference/ssl__context/add_verify_path.html
      */
+    MQTT_DEPRECATED("Use get_context().add_verify_path()")
     void add_verify_path(std::string path) {
         ctx_.add_verify_path(path);
     }
@@ -364,6 +385,7 @@ public:
      * @param depth maximum depth for the certificate chain verificatrion that shall be allowed
      * See http://www.boost.org/doc/html/boost_asio/reference/ssl__context/set_verify_depth.html
      */
+    MQTT_DEPRECATED("Use get_context().set_verify_depth()")
     void set_verify_depth(int depth) {
         ctx_.set_verify_depth(depth);
     }
@@ -374,6 +396,7 @@ public:
      * @param file client certificate file path
      * See http://www.boost.org/doc/html/boost_asio/reference/ssl__context/load_verify_file.html
      */
+    MQTT_DEPRECATED("Use get_context().use_certificate_file()")
     void set_client_cert_file(std::string file) {
         ctx_.use_certificate_file(force_move(file), as::ssl::context::pem);
     }
@@ -384,6 +407,7 @@ public:
      * @param file client certificate key file path
      * See http://www.boost.org/doc/html/boost_asio/reference/ssl__context/use_private_key_file.html
      */
+    MQTT_DEPRECATED("Use get_context().use_private_key_file()")
     void set_client_key_file(std::string file) {
         ctx_.use_private_key_file(force_move(file), as::ssl::context::pem);
     }
@@ -393,6 +417,7 @@ public:
      * @param mode See http://www.boost.org/doc/html/boost_asio/reference/ssl__verify_mode.html
      * See http://www.boost.org/doc/html/boost_asio/reference/ssl__context/set_verify_mode.html
      */
+    MQTT_DEPRECATED("Use get_context().set_verify_mode()")
     void set_verify_mode(as::ssl::verify_mode mode) {
         ctx_.set_verify_mode(mode);
     }
@@ -403,6 +428,7 @@ public:
      * See http://www.boost.org/doc/html/boost_asio/reference/ssl__context/set_verify_callback.html
      */
     template <typename VerifyCallback>
+    MQTT_DEPRECATED("Use get_context().set_verify_callback()")
     void set_verify_callback(VerifyCallback&& callback) {
         ctx_.set_verify_callback(std::forward<VerifyCallback>(callback));
     }

--- a/include/mqtt/client.hpp
+++ b/include/mqtt/client.hpp
@@ -320,7 +320,7 @@ public:
      * @brief Get boost asio ssl context.
      * @return ssl context
      */
-    as::ssl::context& get_context() {
+    as::ssl::context& get_ssl_context() {
         return ctx_;
     }
 
@@ -328,7 +328,7 @@ public:
      * @brief Get boost asio ssl context.
      * @return ssl context
      */
-    as::ssl::context const& get_context() const {
+    as::ssl::context const& get_ssl_context() const {
         return ctx_;
     }
 
@@ -336,7 +336,7 @@ public:
      * @brief Call boost::asio::context::set_default_verify_paths
      * See http://www.boost.org/doc/html/boost_asio/reference/ssl__context/set_default_verify_paths.html
      */
-    MQTT_DEPRECATED("Use get_context().set_default_verify_paths()")
+    MQTT_DEPRECATED("Use get_ssl_context().set_default_verify_paths()")
     void set_default_verify_paths() {
         ctx_.set_default_verify_paths();
     }
@@ -347,7 +347,7 @@ public:
      * @param file ca cert file path
      * See http://www.boost.org/doc/html/boost_asio/reference/ssl__context/load_verify_file.html
      */
-    MQTT_DEPRECATED("Use get_context().load_verify_file()")
+    MQTT_DEPRECATED("Use get_ssl_context().load_verify_file()")
     void set_ca_cert_file(std::string file) {
         ctx_.load_verify_file(force_move(file));
     }
@@ -362,7 +362,7 @@ public:
      * See https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_keylog_callback.html
      * See https://wiki.wireshark.org/SSL
      */
-    MQTT_DEPRECATED("Use SSL_CTX_set_keylog_callback(client->get_context().native_handle(), callback")
+    MQTT_DEPRECATED("Use SSL_CTX_set_keylog_callback(client->get_ssl_context().native_handle(), callback")
     void set_ssl_keylog_callback(void (*cb)(SSL const* ssl, char const* line)) {
         SSL_CTX* ssl_ctx = ctx_.native_handle();
         SSL_CTX_set_keylog_callback(ssl_ctx, cb);
@@ -375,7 +375,7 @@ public:
      * @param path the path contains ca cert files
      * See http://www.boost.org/doc/html/boost_asio/reference/ssl__context/add_verify_path.html
      */
-    MQTT_DEPRECATED("Use get_context().add_verify_path()")
+    MQTT_DEPRECATED("Use get_ssl_context().add_verify_path()")
     void add_verify_path(std::string path) {
         ctx_.add_verify_path(path);
     }
@@ -385,7 +385,7 @@ public:
      * @param depth maximum depth for the certificate chain verificatrion that shall be allowed
      * See http://www.boost.org/doc/html/boost_asio/reference/ssl__context/set_verify_depth.html
      */
-    MQTT_DEPRECATED("Use get_context().set_verify_depth()")
+    MQTT_DEPRECATED("Use get_ssl_context().set_verify_depth()")
     void set_verify_depth(int depth) {
         ctx_.set_verify_depth(depth);
     }
@@ -396,7 +396,7 @@ public:
      * @param file client certificate file path
      * See http://www.boost.org/doc/html/boost_asio/reference/ssl__context/load_verify_file.html
      */
-    MQTT_DEPRECATED("Use get_context().use_certificate_file()")
+    MQTT_DEPRECATED("Use get_ssl_context().use_certificate_file()")
     void set_client_cert_file(std::string file) {
         ctx_.use_certificate_file(force_move(file), as::ssl::context::pem);
     }
@@ -407,7 +407,7 @@ public:
      * @param file client certificate key file path
      * See http://www.boost.org/doc/html/boost_asio/reference/ssl__context/use_private_key_file.html
      */
-    MQTT_DEPRECATED("Use get_context().use_private_key_file()")
+    MQTT_DEPRECATED("Use get_ssl_context().use_private_key_file()")
     void set_client_key_file(std::string file) {
         ctx_.use_private_key_file(force_move(file), as::ssl::context::pem);
     }
@@ -417,7 +417,7 @@ public:
      * @param mode See http://www.boost.org/doc/html/boost_asio/reference/ssl__verify_mode.html
      * See http://www.boost.org/doc/html/boost_asio/reference/ssl__context/set_verify_mode.html
      */
-    MQTT_DEPRECATED("Use get_context().set_verify_mode()")
+    MQTT_DEPRECATED("Use get_ssl_context().set_verify_mode()")
     void set_verify_mode(as::ssl::verify_mode mode) {
         ctx_.set_verify_mode(mode);
     }
@@ -428,7 +428,7 @@ public:
      * See http://www.boost.org/doc/html/boost_asio/reference/ssl__context/set_verify_callback.html
      */
     template <typename VerifyCallback>
-    MQTT_DEPRECATED("Use get_context().set_verify_callback()")
+    MQTT_DEPRECATED("Use get_ssl_context().set_verify_callback()")
     void set_verify_callback(VerifyCallback&& callback) {
         ctx_.set_verify_callback(std::forward<VerifyCallback>(callback));
     }

--- a/include/mqtt/deprecated_msg.hpp
+++ b/include/mqtt/deprecated_msg.hpp
@@ -82,4 +82,5 @@
 ")\n"
 
 
+
 #endif // MQTT_DEPRECATED_MSG_HPP

--- a/include/mqtt/server.hpp
+++ b/include/mqtt/server.hpp
@@ -300,6 +300,22 @@ public:
         underlying_connect_timeout_ = force_move(timeout);
     }
 
+    /**
+     * @brief Get boost asio ssl context.
+     * @return ssl context
+     */
+    as::ssl::context& get_context() {
+        return ctx_;
+    }
+
+    /**
+     * @brief Get boost asio ssl context.
+     * @return ssl context
+     */
+    as::ssl::context const& get_context() const {
+        return ctx_;
+    }
+
 private:
     void do_accept() {
         if (close_request_) return;
@@ -711,6 +727,22 @@ public:
      */
     void set_underlying_connect_timeout(boost::posix_time::time_duration timeout) {
         underlying_connect_timeout_ = force_move(timeout);
+    }
+
+    /**
+     * @brief Get boost asio ssl context.
+     * @return ssl context
+     */
+    as::ssl::context& get_context() {
+        return ctx_;
+    }
+
+    /**
+     * @brief Get boost asio ssl context.
+     * @return ssl context
+     */
+    as::ssl::context const& get_context() const {
+        return ctx_;
     }
 
 private:

--- a/include/mqtt/server.hpp
+++ b/include/mqtt/server.hpp
@@ -304,7 +304,7 @@ public:
      * @brief Get boost asio ssl context.
      * @return ssl context
      */
-    as::ssl::context& get_context() {
+    as::ssl::context& get_ssl_context() {
         return ctx_;
     }
 
@@ -312,7 +312,7 @@ public:
      * @brief Get boost asio ssl context.
      * @return ssl context
      */
-    as::ssl::context const& get_context() const {
+    as::ssl::context const& get_ssl_context() const {
         return ctx_;
     }
 
@@ -733,7 +733,7 @@ public:
      * @brief Get boost asio ssl context.
      * @return ssl context
      */
-    as::ssl::context& get_context() {
+    as::ssl::context& get_ssl_context() {
         return ctx_;
     }
 
@@ -741,7 +741,7 @@ public:
      * @brief Get boost asio ssl context.
      * @return ssl context
      */
-    as::ssl::context const& get_context() const {
+    as::ssl::context const& get_ssl_context() const {
         return ctx_;
     }
 

--- a/test/combi_test.hpp
+++ b/test/combi_test.hpp
@@ -52,7 +52,7 @@ inline void do_combi_test(Test const& test) {
         std::string path = boost::unit_test::framework::master_test_suite().argv[0];
         std::size_t pos = path.find_last_of("/\\");
         std::string base = (pos == std::string::npos) ? "" : path.substr(0, pos + 1);
-        c->get_context().load_verify_file(base + "cacert.pem");
+        c->get_ssl_context().load_verify_file(base + "cacert.pem");
         test(ioc, c, s, b);
     }
     {
@@ -63,7 +63,7 @@ inline void do_combi_test(Test const& test) {
         std::string path = boost::unit_test::framework::master_test_suite().argv[0];
         std::size_t pos = path.find_last_of("/\\");
         std::string base = (pos == std::string::npos) ? "" : path.substr(0, pos + 1);
-        c->get_context().load_verify_file(base + "cacert.pem");
+        c->get_ssl_context().load_verify_file(base + "cacert.pem");
         test(ioc, c, s, b);
     }
 #endif // defined(MQTT_USE_TLS)
@@ -91,7 +91,7 @@ inline void do_combi_test(Test const& test) {
         std::string path = boost::unit_test::framework::master_test_suite().argv[0];
         std::size_t pos = path.find_last_of("/\\");
         std::string base = (pos == std::string::npos) ? "" : path.substr(0, pos + 1);
-        c->get_context().load_verify_file(base + "cacert.pem");
+        c->get_ssl_context().load_verify_file(base + "cacert.pem");
         test(ioc, c, s, b);
     }
     {
@@ -102,7 +102,7 @@ inline void do_combi_test(Test const& test) {
         std::string path = boost::unit_test::framework::master_test_suite().argv[0];
         std::size_t pos = path.find_last_of("/\\");
         std::string base = (pos == std::string::npos) ? "" : path.substr(0, pos + 1);
-        c->get_context().load_verify_file(base + "cacert.pem");
+        c->get_ssl_context().load_verify_file(base + "cacert.pem");
         test(ioc, c, s, b);
     }
 #endif // defined(MQTT_USE_TLS)
@@ -134,7 +134,7 @@ inline void do_combi_test_sync(Test const& test) {
         std::string path = boost::unit_test::framework::master_test_suite().argv[0];
         std::size_t pos = path.find_last_of("/\\");
         std::string base = (pos == std::string::npos) ? "" : path.substr(0, pos + 1);
-        c->get_context().load_verify_file(base + "cacert.pem");
+        c->get_ssl_context().load_verify_file(base + "cacert.pem");
         test(ioc, c, s, b);
     }
     {
@@ -145,7 +145,7 @@ inline void do_combi_test_sync(Test const& test) {
         std::string path = boost::unit_test::framework::master_test_suite().argv[0];
         std::size_t pos = path.find_last_of("/\\");
         std::string base = (pos == std::string::npos) ? "" : path.substr(0, pos + 1);
-        c->get_context().load_verify_file(base + "cacert.pem");
+        c->get_ssl_context().load_verify_file(base + "cacert.pem");
         test(ioc, c, s, b);
     }
 #endif // defined(MQTT_USE_TLS)
@@ -173,7 +173,7 @@ inline void do_combi_test_sync(Test const& test) {
         std::string path = boost::unit_test::framework::master_test_suite().argv[0];
         std::size_t pos = path.find_last_of("/\\");
         std::string base = (pos == std::string::npos) ? "" : path.substr(0, pos + 1);
-        c->get_context().load_verify_file(base + "cacert.pem");
+        c->get_ssl_context().load_verify_file(base + "cacert.pem");
         test(ioc, c, s, b);
     }
     {
@@ -184,7 +184,7 @@ inline void do_combi_test_sync(Test const& test) {
         std::string path = boost::unit_test::framework::master_test_suite().argv[0];
         std::size_t pos = path.find_last_of("/\\");
         std::string base = (pos == std::string::npos) ? "" : path.substr(0, pos + 1);
-        c->get_context().load_verify_file(base + "cacert.pem");
+        c->get_ssl_context().load_verify_file(base + "cacert.pem");
         test(ioc, c, s, b);
     }
 #endif // defined(MQTT_USE_TLS)
@@ -216,7 +216,7 @@ inline void do_combi_test_async(Test const& test) {
         std::string path = boost::unit_test::framework::master_test_suite().argv[0];
         std::size_t pos = path.find_last_of("/\\");
         std::string base = (pos == std::string::npos) ? "" : path.substr(0, pos + 1);
-        c->get_context().load_verify_file(base + "cacert.pem");
+        c->get_ssl_context().load_verify_file(base + "cacert.pem");
         test(ioc, c, s, b);
     }
     {
@@ -227,7 +227,7 @@ inline void do_combi_test_async(Test const& test) {
         std::string path = boost::unit_test::framework::master_test_suite().argv[0];
         std::size_t pos = path.find_last_of("/\\");
         std::string base = (pos == std::string::npos) ? "" : path.substr(0, pos + 1);
-        c->get_context().load_verify_file(base + "cacert.pem");
+        c->get_ssl_context().load_verify_file(base + "cacert.pem");
         test(ioc, c, s, b);
     }
 #endif // defined(MQTT_USE_TLS)
@@ -255,7 +255,7 @@ inline void do_combi_test_async(Test const& test) {
         std::string path = boost::unit_test::framework::master_test_suite().argv[0];
         std::size_t pos = path.find_last_of("/\\");
         std::string base = (pos == std::string::npos) ? "" : path.substr(0, pos + 1);
-        c->get_context().load_verify_file(base + "cacert.pem");
+        c->get_ssl_context().load_verify_file(base + "cacert.pem");
         test(ioc, c, s, b);
     }
     {
@@ -266,7 +266,7 @@ inline void do_combi_test_async(Test const& test) {
         std::string path = boost::unit_test::framework::master_test_suite().argv[0];
         std::size_t pos = path.find_last_of("/\\");
         std::string base = (pos == std::string::npos) ? "" : path.substr(0, pos + 1);
-        c->get_context().load_verify_file(base + "cacert.pem");
+        c->get_ssl_context().load_verify_file(base + "cacert.pem");
         test(ioc, c, s, b);
     }
 #endif // defined(MQTT_USE_TLS)

--- a/test/combi_test.hpp
+++ b/test/combi_test.hpp
@@ -52,7 +52,7 @@ inline void do_combi_test(Test const& test) {
         std::string path = boost::unit_test::framework::master_test_suite().argv[0];
         std::size_t pos = path.find_last_of("/\\");
         std::string base = (pos == std::string::npos) ? "" : path.substr(0, pos + 1);
-        c->set_ca_cert_file(base + "cacert.pem");
+        c->get_context().load_verify_file(base + "cacert.pem");
         test(ioc, c, s, b);
     }
     {
@@ -63,7 +63,7 @@ inline void do_combi_test(Test const& test) {
         std::string path = boost::unit_test::framework::master_test_suite().argv[0];
         std::size_t pos = path.find_last_of("/\\");
         std::string base = (pos == std::string::npos) ? "" : path.substr(0, pos + 1);
-        c->set_ca_cert_file(base + "cacert.pem");
+        c->get_context().load_verify_file(base + "cacert.pem");
         test(ioc, c, s, b);
     }
 #endif // defined(MQTT_USE_TLS)
@@ -91,7 +91,7 @@ inline void do_combi_test(Test const& test) {
         std::string path = boost::unit_test::framework::master_test_suite().argv[0];
         std::size_t pos = path.find_last_of("/\\");
         std::string base = (pos == std::string::npos) ? "" : path.substr(0, pos + 1);
-        c->set_ca_cert_file(base + "cacert.pem");
+        c->get_context().load_verify_file(base + "cacert.pem");
         test(ioc, c, s, b);
     }
     {
@@ -102,7 +102,7 @@ inline void do_combi_test(Test const& test) {
         std::string path = boost::unit_test::framework::master_test_suite().argv[0];
         std::size_t pos = path.find_last_of("/\\");
         std::string base = (pos == std::string::npos) ? "" : path.substr(0, pos + 1);
-        c->set_ca_cert_file(base + "cacert.pem");
+        c->get_context().load_verify_file(base + "cacert.pem");
         test(ioc, c, s, b);
     }
 #endif // defined(MQTT_USE_TLS)
@@ -134,7 +134,7 @@ inline void do_combi_test_sync(Test const& test) {
         std::string path = boost::unit_test::framework::master_test_suite().argv[0];
         std::size_t pos = path.find_last_of("/\\");
         std::string base = (pos == std::string::npos) ? "" : path.substr(0, pos + 1);
-        c->set_ca_cert_file(base + "cacert.pem");
+        c->get_context().load_verify_file(base + "cacert.pem");
         test(ioc, c, s, b);
     }
     {
@@ -145,7 +145,7 @@ inline void do_combi_test_sync(Test const& test) {
         std::string path = boost::unit_test::framework::master_test_suite().argv[0];
         std::size_t pos = path.find_last_of("/\\");
         std::string base = (pos == std::string::npos) ? "" : path.substr(0, pos + 1);
-        c->set_ca_cert_file(base + "cacert.pem");
+        c->get_context().load_verify_file(base + "cacert.pem");
         test(ioc, c, s, b);
     }
 #endif // defined(MQTT_USE_TLS)
@@ -173,7 +173,7 @@ inline void do_combi_test_sync(Test const& test) {
         std::string path = boost::unit_test::framework::master_test_suite().argv[0];
         std::size_t pos = path.find_last_of("/\\");
         std::string base = (pos == std::string::npos) ? "" : path.substr(0, pos + 1);
-        c->set_ca_cert_file(base + "cacert.pem");
+        c->get_context().load_verify_file(base + "cacert.pem");
         test(ioc, c, s, b);
     }
     {
@@ -184,7 +184,7 @@ inline void do_combi_test_sync(Test const& test) {
         std::string path = boost::unit_test::framework::master_test_suite().argv[0];
         std::size_t pos = path.find_last_of("/\\");
         std::string base = (pos == std::string::npos) ? "" : path.substr(0, pos + 1);
-        c->set_ca_cert_file(base + "cacert.pem");
+        c->get_context().load_verify_file(base + "cacert.pem");
         test(ioc, c, s, b);
     }
 #endif // defined(MQTT_USE_TLS)
@@ -216,7 +216,7 @@ inline void do_combi_test_async(Test const& test) {
         std::string path = boost::unit_test::framework::master_test_suite().argv[0];
         std::size_t pos = path.find_last_of("/\\");
         std::string base = (pos == std::string::npos) ? "" : path.substr(0, pos + 1);
-        c->set_ca_cert_file(base + "cacert.pem");
+        c->get_context().load_verify_file(base + "cacert.pem");
         test(ioc, c, s, b);
     }
     {
@@ -227,7 +227,7 @@ inline void do_combi_test_async(Test const& test) {
         std::string path = boost::unit_test::framework::master_test_suite().argv[0];
         std::size_t pos = path.find_last_of("/\\");
         std::string base = (pos == std::string::npos) ? "" : path.substr(0, pos + 1);
-        c->set_ca_cert_file(base + "cacert.pem");
+        c->get_context().load_verify_file(base + "cacert.pem");
         test(ioc, c, s, b);
     }
 #endif // defined(MQTT_USE_TLS)
@@ -255,7 +255,7 @@ inline void do_combi_test_async(Test const& test) {
         std::string path = boost::unit_test::framework::master_test_suite().argv[0];
         std::size_t pos = path.find_last_of("/\\");
         std::string base = (pos == std::string::npos) ? "" : path.substr(0, pos + 1);
-        c->set_ca_cert_file(base + "cacert.pem");
+        c->get_context().load_verify_file(base + "cacert.pem");
         test(ioc, c, s, b);
     }
     {
@@ -266,7 +266,7 @@ inline void do_combi_test_async(Test const& test) {
         std::string path = boost::unit_test::framework::master_test_suite().argv[0];
         std::size_t pos = path.find_last_of("/\\");
         std::string base = (pos == std::string::npos) ? "" : path.substr(0, pos + 1);
-        c->set_ca_cert_file(base + "cacert.pem");
+        c->get_context().load_verify_file(base + "cacert.pem");
         test(ioc, c, s, b);
     }
 #endif // defined(MQTT_USE_TLS)


### PR DESCRIPTION
Added get_context().
Marked as deperecated wrapper functions for asio::ssl::context.