### PR TITLE
Fixed #448.

### DIFF
--- a/example/no_tls_both.cpp
+++ b/example/no_tls_both.cpp
@@ -77,7 +77,7 @@ void client_proc(
         });
     c->set_suback_handler(
         [&]
-        (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results){
+        (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results){
             std::cout << "[client] suback received. packet_id: " << packet_id << std::endl;
             for (auto const& e : results) {
                 std::cout << "[client] subscribe result: " << e << std::endl;
@@ -292,7 +292,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                 (packet_id_t packet_id,
                  std::vector<std::tuple<MQTT_NS::buffer, MQTT_NS::subscribe_options>> entries) {
                     std::cout << "[server]subscribe received. packet_id: " << packet_id << std::endl;
-                    std::vector<MQTT_NS::suback_reason_code> res;
+                    std::vector<MQTT_NS::suback_return_code> res;
                     res.reserve(entries.size());
                     auto sp = wp.lock();
                     BOOST_ASSERT(sp);
@@ -300,7 +300,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                         MQTT_NS::buffer topic = std::get<0>(e);
                         MQTT_NS::qos qos_value = std::get<1>(e).get_qos();
                         std::cout << "[server] topic: " << topic  << " qos: " << qos_value << std::endl;
-                        res.emplace_back(static_cast<MQTT_NS::suback_reason_code>(qos_value));
+                        res.emplace_back(static_cast<MQTT_NS::suback_return_code>(qos_value));
                         subs.emplace(std::move(topic), sp, qos_value);
                     }
                     sp->suback(packet_id, res);

--- a/example/no_tls_client.cpp
+++ b/example/no_tls_client.cpp
@@ -85,7 +85,7 @@ int main(int argc, char** argv) {
         });
     c->set_suback_handler(
         [&]
-        (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results){
+        (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results){
             std::cout << "suback received. packet_id: " << packet_id << std::endl;
             for (auto const& e : results) {
                 std::cout << "[client] subscribe result: " << e << std::endl;

--- a/example/no_tls_server.cpp
+++ b/example/no_tls_server.cpp
@@ -197,7 +197,7 @@ int main(int argc, char** argv) {
                 (packet_id_t packet_id,
                  std::vector<std::tuple<MQTT_NS::buffer, MQTT_NS::subscribe_options>> entries) {
                     std::cout << "[server]subscribe received. packet_id: " << packet_id << std::endl;
-                    std::vector<MQTT_NS::suback_reason_code> res;
+                    std::vector<MQTT_NS::suback_return_code> res;
                     res.reserve(entries.size());
                     auto sp = wp.lock();
                     BOOST_ASSERT(sp);
@@ -205,7 +205,7 @@ int main(int argc, char** argv) {
                         MQTT_NS::buffer topic = std::get<0>(e);
                         MQTT_NS::qos qos_value = std::get<1>(e).get_qos();
                         std::cout << "[server] topic: " << topic  << " qos: " << qos_value << std::endl;
-                        res.emplace_back(static_cast<MQTT_NS::suback_reason_code>(qos_value));
+                        res.emplace_back(static_cast<MQTT_NS::suback_return_code>(qos_value));
                         subs.emplace(std::move(topic), sp, qos_value);
                     }
                     sp->suback(packet_id, res);

--- a/example/no_tls_ws_both.cpp
+++ b/example/no_tls_ws_both.cpp
@@ -77,7 +77,7 @@ void client_proc(
         });
     c->set_suback_handler(
         [&]
-        (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results){
+        (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results){
             std::cout << "[client] suback received. packet_id: " << packet_id << std::endl;
             for (auto const& e : results) {
                 std::cout << "[client] subscribe result: " << e << std::endl;
@@ -291,7 +291,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                 (packet_id_t packet_id,
                  std::vector<std::tuple<MQTT_NS::buffer, MQTT_NS::subscribe_options>> entries) {
                     std::cout << "[server]subscribe received. packet_id: " << packet_id << std::endl;
-                    std::vector<MQTT_NS::suback_reason_code> res;
+                    std::vector<MQTT_NS::suback_return_code> res;
                     res.reserve(entries.size());
                     auto sp = wp.lock();
                     BOOST_ASSERT(sp);
@@ -299,7 +299,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                         MQTT_NS::buffer topic = std::get<0>(e);
                         MQTT_NS::qos qos_value = std::get<1>(e).get_qos();
                         std::cout << "[server] topic: " << topic  << " qos: " << qos_value << std::endl;
-                        res.emplace_back(static_cast<MQTT_NS::suback_reason_code>(qos_value));
+                        res.emplace_back(static_cast<MQTT_NS::suback_return_code>(qos_value));
                         subs.emplace(std::move(topic), sp, qos_value);
                     }
                     sp->suback(packet_id, res);

--- a/example/no_tls_ws_client.cpp
+++ b/example/no_tls_ws_client.cpp
@@ -85,7 +85,7 @@ int main(int argc, char** argv) {
         });
     c->set_suback_handler(
         [&]
-        (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results){
+        (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results){
             std::cout << "suback received. packet_id: " << packet_id << std::endl;
             for (auto const& e : results) {
                 std::cout << "[client] subscribe result: " << e << std::endl;

--- a/example/no_tls_ws_server.cpp
+++ b/example/no_tls_ws_server.cpp
@@ -197,7 +197,7 @@ int main(int argc, char** argv) {
                 (packet_id_t packet_id,
                  std::vector<std::tuple<MQTT_NS::buffer, MQTT_NS::subscribe_options>> entries) {
                     std::cout << "[server]subscribe received. packet_id: " << packet_id << std::endl;
-                    std::vector<MQTT_NS::suback_reason_code> res;
+                    std::vector<MQTT_NS::suback_return_code> res;
                     res.reserve(entries.size());
                     auto sp = wp.lock();
                     BOOST_ASSERT(sp);
@@ -205,7 +205,7 @@ int main(int argc, char** argv) {
                         MQTT_NS::buffer topic = std::get<0>(e);
                         MQTT_NS::qos qos_value = std::get<1>(e).get_qos();
                         std::cout << "[server] topic: " << topic  << " qos: " << qos_value << std::endl;
-                        res.emplace_back(static_cast<MQTT_NS::suback_reason_code>(qos_value));
+                        res.emplace_back(static_cast<MQTT_NS::suback_return_code>(qos_value));
                         subs.emplace(std::move(topic), sp, qos_value);
                     }
                     sp->suback(packet_id, res);

--- a/example/tls_both.cpp
+++ b/example/tls_both.cpp
@@ -78,7 +78,7 @@ void client_proc(
         });
     c->set_suback_handler(
         [&]
-        (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results){
+        (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results){
             std::cout << "[client] suback received. packet_id: " << packet_id << std::endl;
             for (auto const& e : results) {
                 std::cout << "[client] subscribe result: " << e << std::endl;
@@ -293,7 +293,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                 (packet_id_t packet_id,
                  std::vector<std::tuple<MQTT_NS::buffer, MQTT_NS::subscribe_options>> entries) {
                     std::cout << "[server]subscribe received. packet_id: " << packet_id << std::endl;
-                    std::vector<MQTT_NS::suback_reason_code> res;
+                    std::vector<MQTT_NS::suback_return_code> res;
                     res.reserve(entries.size());
                     auto sp = wp.lock();
                     BOOST_ASSERT(sp);
@@ -301,7 +301,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                         MQTT_NS::buffer topic = std::get<0>(e);
                         MQTT_NS::qos qos_value = std::get<1>(e).get_qos();
                         std::cout << "[server] topic: " << topic  << " qos: " << qos_value << std::endl;
-                        res.emplace_back(static_cast<MQTT_NS::suback_reason_code>(qos_value));
+                        res.emplace_back(static_cast<MQTT_NS::suback_return_code>(qos_value));
                         subs.emplace(std::move(topic), sp, qos_value);
                     }
                     sp->suback(packet_id, res);

--- a/example/tls_client.cpp
+++ b/example/tls_client.cpp
@@ -101,7 +101,7 @@ int main(int argc, char** argv) {
         });
     c->set_suback_handler(
         [&]
-        (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results){
+        (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results){
             std::cout << "suback received. packet_id: " << packet_id << std::endl;
             for (auto const& e : results) {
                 std::cout << "[client] subscribe result: " << e << std::endl;

--- a/example/tls_server.cpp
+++ b/example/tls_server.cpp
@@ -209,7 +209,7 @@ int main(int argc, char** argv) {
                 (packet_id_t packet_id,
                  std::vector<std::tuple<MQTT_NS::buffer, MQTT_NS::subscribe_options>> entries) {
                     std::cout << "[server]subscribe received. packet_id: " << packet_id << std::endl;
-                    std::vector<MQTT_NS::suback_reason_code> res;
+                    std::vector<MQTT_NS::suback_return_code> res;
                     res.reserve(entries.size());
                     auto sp = wp.lock();
                     BOOST_ASSERT(sp);
@@ -217,7 +217,7 @@ int main(int argc, char** argv) {
                         MQTT_NS::buffer topic = std::get<0>(e);
                         MQTT_NS::qos qos_value = std::get<1>(e).get_qos();
                         std::cout << "[server] topic: " << topic  << " qos: " << qos_value << std::endl;
-                        res.emplace_back(static_cast<MQTT_NS::suback_reason_code>(qos_value));
+                        res.emplace_back(static_cast<MQTT_NS::suback_return_code>(qos_value));
                         subs.emplace(std::move(topic), sp, qos_value);
                     }
                     sp->suback(packet_id, res);

--- a/example/tls_ws_both.cpp
+++ b/example/tls_ws_both.cpp
@@ -77,7 +77,7 @@ void client_proc(
         });
     c->set_suback_handler(
         [&]
-        (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results){
+        (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results){
             std::cout << "[client] suback received. packet_id: " << packet_id << std::endl;
             for (auto const& e : results) {
                 std::cout << "[client] subscribe result: " << e << std::endl;
@@ -292,7 +292,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                 (packet_id_t packet_id,
                  std::vector<std::tuple<MQTT_NS::buffer, MQTT_NS::subscribe_options>> entries) {
                     std::cout << "[server]subscribe received. packet_id: " << packet_id << std::endl;
-                    std::vector<MQTT_NS::suback_reason_code> res;
+                    std::vector<MQTT_NS::suback_return_code> res;
                     res.reserve(entries.size());
                     auto sp = wp.lock();
                     BOOST_ASSERT(sp);
@@ -300,7 +300,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                         MQTT_NS::buffer topic = std::get<0>(e);
                         MQTT_NS::qos qos_value = std::get<1>(e).get_qos();
                         std::cout << "[server] topic: " << topic  << " qos: " << qos_value << std::endl;
-                        res.emplace_back(static_cast<MQTT_NS::suback_reason_code>(qos_value));
+                        res.emplace_back(static_cast<MQTT_NS::suback_return_code>(qos_value));
                         subs.emplace(std::move(topic), sp, qos_value);
                     }
                     sp->suback(packet_id, res);

--- a/example/tls_ws_client.cpp
+++ b/example/tls_ws_client.cpp
@@ -91,7 +91,7 @@ int main(int argc, char** argv) {
         });
     c->set_suback_handler(
         [&]
-        (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results){
+        (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results){
             std::cout << "suback received. packet_id: " << packet_id << std::endl;
             for (auto const& e : results) {
                 std::cout << "[client] subscribe result: " << e << std::endl;

--- a/example/tls_ws_server.cpp
+++ b/example/tls_ws_server.cpp
@@ -209,7 +209,7 @@ int main(int argc, char** argv) {
                 (packet_id_t packet_id,
                  std::vector<std::tuple<MQTT_NS::buffer, MQTT_NS::subscribe_options>> entries) {
                     std::cout << "[server]subscribe received. packet_id: " << packet_id << std::endl;
-                    std::vector<MQTT_NS::suback_reason_code> res;
+                    std::vector<MQTT_NS::suback_return_code> res;
                     res.reserve(entries.size());
                     auto sp = wp.lock();
                     BOOST_ASSERT(sp);
@@ -217,7 +217,7 @@ int main(int argc, char** argv) {
                         MQTT_NS::buffer topic = std::get<0>(e);
                         MQTT_NS::qos qos_value = std::get<1>(e).get_qos();
                         std::cout << "[server] topic: " << topic  << " qos: " << qos_value << std::endl;
-                        res.emplace_back(static_cast<MQTT_NS::suback_reason_code>(qos_value));
+                        res.emplace_back(static_cast<MQTT_NS::suback_return_code>(qos_value));
                         subs.emplace(std::move(topic), sp, qos_value);
                     }
                     sp->suback(packet_id, res);

--- a/include/mqtt/callable_overlay.hpp
+++ b/include/mqtt/callable_overlay.hpp
@@ -237,7 +237,7 @@ struct callable_overlay final : public Impl
      * @return if the handler returns true, then continue receiving, otherwise quit.
      */
     MQTT_ALWAYS_INLINE bool on_suback(packet_id_t packet_id,
-                                          std::vector<MQTT_NS::suback_reason_code> reasons) override final {
+                                          std::vector<MQTT_NS::suback_return_code> reasons) override final {
         return    ! h_suback_
                || h_suback_(packet_id, MQTT_NS::force_move(reasons));
     }
@@ -915,7 +915,7 @@ struct callable_overlay final : public Impl
      * @return if the handler returns true, then continue receiving, otherwise quit.
      */
     using suback_handler = std::function<bool(packet_id_t packet_id,
-                                              std::vector<MQTT_NS::suback_reason_code> qoss)>;
+                                              std::vector<MQTT_NS::suback_return_code> qoss)>;
 
     /**
      * @brief Unsubscribe handler

--- a/include/mqtt/message.hpp
+++ b/include/mqtt/message.hpp
@@ -857,7 +857,7 @@ template <std::size_t PacketIdBytes>
 class basic_suback_message {
 public:
     basic_suback_message(
-        std::vector<suback_reason_code> params,
+        std::vector<suback_return_code> params,
         typename packet_id_type<PacketIdBytes>::type packet_id
     )
         : fixed_header_(make_fixed_header(control_packet_type::suback, 0b0000)),

--- a/include/mqtt/reason_code.hpp
+++ b/include/mqtt/reason_code.hpp
@@ -12,29 +12,29 @@
 
 namespace MQTT_NS {
 
-enum class suback_reason_code : std::uint8_t {
-    granted_qos_0                          = 0x00,
-    granted_qos_1                          = 0x01,
-    granted_qos_2                          = 0x02,
-    unspecified_error                      = 0x80,
+enum class suback_return_code : std::uint8_t {
+    success_maximum_qos_0                  = 0x00,
+    success_maximum_qos_1                  = 0x01,
+    success_maximum_qos_2                  = 0x02,
+    failure                                = 0x80,
 };
 
 constexpr
-char const* suback_reason_code_to_str(suback_reason_code v) {
+char const* suback_return_code_to_str(suback_return_code v) {
     switch(v)
     {
-    case suback_reason_code::granted_qos_0:                          return "granted_qos_0";
-    case suback_reason_code::granted_qos_1:                          return "granted_qos_1";
-    case suback_reason_code::granted_qos_2:                          return "granted_qos_2";
-    case suback_reason_code::unspecified_error:                      return "unspecified_error";
-    default:                                                         return "unknown_suback_reason_code";
+    case suback_return_code::success_maximum_qos_0: return "success_maximum_qos_0";
+    case suback_return_code::success_maximum_qos_1: return "success_maximum_qos_1";
+    case suback_return_code::success_maximum_qos_2: return "success_maximum_qos_2";
+    case suback_return_code::failure:               return "failure";
+    default:                                        return "unknown_suback_return_code";
     }
 }
 
 template<typename Stream>
-Stream & operator<<(Stream & os, suback_reason_code val)
+Stream & operator<<(Stream & os, suback_return_code val)
 {
-    os << suback_reason_code_to_str(val);
+    os << suback_return_code_to_str(val);
     return os;
 }
 

--- a/test/as_buffer_async_pubsub_1.cpp
+++ b/test/as_buffer_async_pubsub_1.cpp
@@ -71,11 +71,11 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_0);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
                     c->async_publish(
                         as::buffer("topic1", sizeof("topic1") - 1),
                         as::buffer("topic1_contents", sizeof("topic1_contents") - 1),
@@ -291,11 +291,11 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_pub, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_0);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
                     auto topic1 = std::make_shared<std::string>("topic1");
                     auto contents = std::make_shared<std::string>("topic1_contents");
                     pid_pub = c->async_publish(
@@ -511,11 +511,11 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == 1);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_0);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
                     auto topic1 = std::make_shared<std::string>("topic1");
                     auto contents = std::make_shared<std::string>("topic1_contents");
                     pid_pub = c->async_publish(
@@ -721,11 +721,11 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_1);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
                     c->async_publish(
                         as::buffer("topic1", sizeof("topic1") - 1),
                         as::buffer("topic1_contents", sizeof("topic1_contents") - 1),
@@ -949,11 +949,11 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_1);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
                     auto topic1 = std::make_shared<std::string>("topic1");
                     auto contents = std::make_shared<std::string>("topic1_contents");
                     pid_pub = c->async_publish(
@@ -1169,11 +1169,11 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_1);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
                     auto topic1 = std::make_shared<std::string>("topic1");
                     auto contents = std::make_shared<std::string>("topic1_contents");
                     pid_pub = c->async_publish(

--- a/test/as_buffer_async_pubsub_2.cpp
+++ b/test/as_buffer_async_pubsub_2.cpp
@@ -72,11 +72,11 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_2);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_2);
                     auto topic1 = std::make_shared<std::string>("topic1");
                     auto contents = std::make_shared<std::string>("topic1_contents");
                     c->async_publish(
@@ -305,11 +305,11 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_2);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_2);
                     auto topic1 = std::make_shared<std::string>("topic1");
                     auto contents = std::make_shared<std::string>("topic1_contents");
                     pid_pub = c->async_publish(
@@ -532,11 +532,11 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_2);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_2);
                     auto topic1 = std::make_shared<std::string>("topic1");
                     auto contents = std::make_shared<std::string>("topic1_contents");
                     pid_pub = c->async_publish(
@@ -740,11 +740,11 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_0);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
                     auto topic1 = std::make_shared<std::string>("topic1");
                     auto contents = std::make_shared<std::string>("topic1_contents");
                     c->async_publish(
@@ -949,11 +949,11 @@ BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_0);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
                     auto topic1 = MQTT_NS::allocate_buffer("topic1");
                     auto contents = MQTT_NS::allocate_buffer("topic1_contents");
                     c->async_publish(
@@ -1163,11 +1163,11 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_1);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
                     auto topic1 = std::make_shared<std::string>("topic1");
                     auto contents = std::make_shared<std::string>("topic1_contents");
                     auto ret = c->async_publish_dup(

--- a/test/as_buffer_pubsub.cpp
+++ b/test/as_buffer_pubsub.cpp
@@ -64,11 +64,11 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_0);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
                     c->publish("topic1", "topic1_contents", MQTT_NS::qos::at_most_once);
                     return true;
                 });
@@ -254,11 +254,11 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_pub, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_0);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
                     pid_pub = c->publish("topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
                     return true;
                 });
@@ -448,11 +448,11 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == 1);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_0);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
                     pid_pub = c->publish("topic1", "topic1_contents", MQTT_NS::qos::exactly_once);
                     return true;
                 });
@@ -632,11 +632,11 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_1);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
                     c->publish("topic1", "topic1_contents", MQTT_NS::qos::at_most_once);
                     return true;
                 });
@@ -831,11 +831,11 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_1);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
                     pid_pub = c->publish("topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
                     return true;
                 });
@@ -1030,11 +1030,11 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_1);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
                     pid_pub = c->publish("topic1", "topic1_contents", MQTT_NS::qos::exactly_once);
                     return true;
                 });
@@ -1212,11 +1212,11 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_2);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_2);
                     c->publish("topic1", "topic1_contents", MQTT_NS::qos::at_most_once);
                     return true;
                 });
@@ -1411,11 +1411,11 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_2);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_2);
                     pid_pub = c->publish("topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
                     return true;
                 });
@@ -1610,11 +1610,11 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_2);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_2);
                     pid_pub = c->publish("topic1", "topic1_contents", MQTT_NS::qos::exactly_once);
                     return true;
                 });
@@ -1792,11 +1792,11 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_0);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
                     c->publish("topic1", "topic1_contents", MQTT_NS::qos::at_most_once);
                     return true;
                 });
@@ -1973,11 +1973,11 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_1);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
                     auto ret = c->publish_dup(1, "topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
                     BOOST_TEST(ret == true);
                     return true;

--- a/test/as_buffer_sub.cpp
+++ b/test/as_buffer_sub.cpp
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_single ) {
                 });
             c->set_suback_handler(
                 [&chk, &c]
-                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::suback_reason_code> /*results*/) {
+                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::suback_return_code> /*results*/) {
                     MQTT_CHK("h_suback");
                     c->unsubscribe("topic1");
                     return true;
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg ) {
                 });
             c->set_suback_handler(
                 [&chk, &c]
-                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::suback_reason_code> /*results*/) {
+                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::suback_return_code> /*results*/) {
                     MQTT_CHK("h_suback");
                     c->unsubscribe({"topic1"s, "topic2"s});
                     return true;
@@ -241,7 +241,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec ) {
                 });
             c->set_suback_handler(
                 [&chk, &c]
-                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::suback_reason_code> /*results*/) {
+                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::suback_return_code> /*results*/) {
                     MQTT_CHK("h_suback");
                     c->unsubscribe(std::vector<MQTT_NS::string_view>{"topic1", "topic2"});
                     return true;
@@ -340,7 +340,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_single_async ) {
                 });
             c->set_suback_handler(
                 [&chk, &c]
-                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::suback_reason_code> /*results*/) {
+                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::suback_return_code> /*results*/) {
                     MQTT_CHK("h_suback");
                     auto topic = std::make_shared<std::string>("topic1");
                     c->async_unsubscribe(
@@ -449,7 +449,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg_async ) {
                 });
             c->set_suback_handler(
                 [&chk, &c]
-                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::suback_reason_code> /*results*/) {
+                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::suback_return_code> /*results*/) {
                     MQTT_CHK("h_suback");
                     auto topic1 = std::make_shared<std::string>("topic1");
                     auto topic2 = std::make_shared<std::string>("topic2");
@@ -574,7 +574,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec_async ) {
                 });
             c->set_suback_handler(
                 [&chk, &c]
-                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::suback_reason_code> /*results*/) {
+                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::suback_return_code> /*results*/) {
                     MQTT_CHK("h_suback");
                     auto topic1 = std::make_shared<std::string>("topic1");
                     auto topic2 = std::make_shared<std::string>("topic2");

--- a/test/async_pubsub_1.cpp
+++ b/test/async_pubsub_1.cpp
@@ -49,11 +49,11 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_0);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
                     c->async_publish("topic1", "topic1_contents", MQTT_NS::qos::at_most_once);
                     return true;
                 });
@@ -259,11 +259,11 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_pub, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_0);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
                     pid_pub = c->async_publish("topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
                     return true;
                 });
@@ -453,11 +453,11 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == 1);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_0);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
                     pid_pub = c->async_publish("topic1", "topic1_contents", MQTT_NS::qos::exactly_once);
                     return true;
                 });
@@ -637,11 +637,11 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_1);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
                     c->async_publish("topic1", "topic1_contents", MQTT_NS::qos::at_most_once);
                     return true;
                 });
@@ -833,11 +833,11 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_1);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
                     pid_pub = c->async_publish("topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
                     return true;
                 });
@@ -1027,11 +1027,11 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_1);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
                     pid_pub = c->async_publish("topic1", "topic1_contents", MQTT_NS::qos::exactly_once);
                     return true;
                 });

--- a/test/async_pubsub_2.cpp
+++ b/test/async_pubsub_2.cpp
@@ -69,11 +69,11 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_2);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_2);
                     c->async_publish("topic1", "topic1_contents", MQTT_NS::qos::at_most_once);
                     return true;
                 });
@@ -265,11 +265,11 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_2);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_2);
                     pid_pub = c->async_publish("topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
                     return true;
                 });
@@ -461,11 +461,11 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_2);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_2);
                     pid_pub = c->async_publish("topic1", "topic1_contents", MQTT_NS::qos::exactly_once);
                     return true;
                 });
@@ -642,11 +642,11 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_0);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
                     c->async_publish("topic1", "topic1_contents", MQTT_NS::qos::at_most_once);
                     return true;
                 });
@@ -823,11 +823,11 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_1);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
                     auto ret =
                         c->async_publish_dup(1, "topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
                     BOOST_TEST(ret == true);
@@ -1008,11 +1008,11 @@ BOOST_AUTO_TEST_CASE( publish_dup_function_buffer ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_1);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
                     auto ret =
                         c->async_publish_dup(1, "topic1"_mb, "topic1_contents"_mb, MQTT_NS::qos::at_least_once);
                     BOOST_TEST(ret == true);

--- a/test/length_check.cpp
+++ b/test/length_check.cpp
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
             });
         c->set_suback_handler(
             [&chk, &c]
-            (packet_id_t /*packet_id*/, std::vector<MQTT_NS::suback_reason_code> /*results*/) {
+            (packet_id_t /*packet_id*/, std::vector<MQTT_NS::suback_return_code> /*results*/) {
                 MQTT_CHK("h_suback");
                 c->publish("topic1", "topic1_contents", MQTT_NS::qos::at_most_once);
                 return true;

--- a/test/manual_publish.cpp
+++ b/test/manual_publish.cpp
@@ -86,11 +86,11 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == 1);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_0);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
                     BOOST_TEST(c->publish(
                                    0,
                                    "topic1",

--- a/test/message.cpp
+++ b/test/message.cpp
@@ -310,7 +310,7 @@ BOOST_AUTO_TEST_CASE( subscribe_cbuf ) {
 }
 
 BOOST_AUTO_TEST_CASE( suback_cbuf ) {
-    auto m = MQTT_NS::suback_message(std::vector<MQTT_NS::suback_reason_code>{MQTT_NS::suback_reason_code::granted_qos_1}, 2);
+    auto m = MQTT_NS::suback_message(std::vector<MQTT_NS::suback_return_code>{MQTT_NS::suback_return_code::success_maximum_qos_1}, 2);
     std::string expected {
         static_cast<char>(0b1001'0000u),
         3,

--- a/test/multi_sub.cpp
+++ b/test/multi_sub.cpp
@@ -85,12 +85,12 @@ BOOST_AUTO_TEST_CASE( multi_channel ) {
             });
         c->set_suback_handler(
             [&chk, &c, &pid_sub]
-            (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+            (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                 MQTT_CHK("h_suback");
                 BOOST_TEST(packet_id == pid_sub);
                 BOOST_TEST(results.size() == 2U);
-                BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_0);
-                BOOST_TEST(results[1] == MQTT_NS::suback_reason_code::granted_qos_0);
+                BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
+                BOOST_TEST(results[1] == MQTT_NS::suback_return_code::success_maximum_qos_0);
                 c->publish("topic1", "topic1_contents", MQTT_NS::qos::at_most_once);
                 return true;
             });
@@ -227,11 +227,11 @@ BOOST_AUTO_TEST_CASE( multi_client_qos0 ) {
         });
     c1->set_suback_handler(
         [&chk, &c1, &sub_count, &pid_sub1]
-        (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+        (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
             MQTT_CHK("h_suback_1");
             BOOST_TEST(packet_id == pid_sub1);
             BOOST_TEST(results.size() == 1U);
-            BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_0);
+            BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
             if (++sub_count == 2)
                 c1->publish("topic1", "topic1_contents", MQTT_NS::qos::at_most_once);
             return true;
@@ -310,11 +310,11 @@ BOOST_AUTO_TEST_CASE( multi_client_qos0 ) {
         });
     c2->set_suback_handler(
         [&chk, &c2, &sub_count, &pid_sub2]
-        (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+        (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
             MQTT_CHK("h_suback_2");
             BOOST_TEST(packet_id == pid_sub2);
             BOOST_TEST(results.size() == 1U);
-            BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_0);
+            BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
             if (++sub_count == 2)
                 c2->publish("topic1", "topic1_contents", MQTT_NS::qos::at_most_once);
             return true;
@@ -433,11 +433,11 @@ BOOST_AUTO_TEST_CASE( multi_client_qos1 ) {
         });
     c1->set_suback_handler(
         [&chk, &c1ready, &c2ready, &c3ready, &c3, &pid_sub1, &pid_pub3]
-        (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+        (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
             MQTT_CHK("h_suback_1");
             BOOST_TEST(packet_id == pid_sub1);
             BOOST_TEST(results.size() == 1U);
-            BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_1);
+            BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
 
             c1ready = true;
             if (c1ready && c2ready && c3ready) {
@@ -497,11 +497,11 @@ BOOST_AUTO_TEST_CASE( multi_client_qos1 ) {
         });
     c2->set_suback_handler(
         [&chk, &c1ready, &c2ready, &c3ready, &c3, &pid_sub2, &pid_pub3]
-        (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+        (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
             MQTT_CHK("h_suback_2");
             BOOST_TEST(packet_id == pid_sub2);
             BOOST_TEST(results.size() == 1U);
-            BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_1);
+            BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
 
             c2ready = true;
             if (c1ready && c2ready && c3ready) {

--- a/test/pubsub.cpp
+++ b/test/pubsub.cpp
@@ -65,11 +65,11 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_0);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
                     c->publish("topic1", "topic1_contents", MQTT_NS::qos::at_most_once);
                     return true;
                 });
@@ -259,11 +259,11 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_pub, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_0);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
                     pid_pub = c->publish("topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
                     return true;
                 });
@@ -457,11 +457,11 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == 1);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_0);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
                     pid_pub = c->publish("topic1", "topic1_contents", MQTT_NS::qos::exactly_once);
                     return true;
                 });
@@ -641,11 +641,11 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_1);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
                     c->publish("topic1", "topic1_contents", MQTT_NS::qos::at_most_once);
                     return true;
                 });
@@ -839,11 +839,11 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_1);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
                     pid_pub = c->publish("topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
                     return true;
                 });
@@ -1037,11 +1037,11 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_1);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
                     pid_pub = c->publish("topic1", "topic1_contents", MQTT_NS::qos::exactly_once);
                     return true;
                 });
@@ -1225,11 +1225,11 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_2);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_2);
                     c->publish("topic1", "topic1_contents", MQTT_NS::qos::at_most_once);
                     return true;
                 });
@@ -1419,11 +1419,11 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_2);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_2);
                     pid_pub = c->publish("topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
                     return true;
                 });
@@ -1618,11 +1618,11 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_2);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_2);
                     pid_pub = c->publish("topic1", "topic1_contents", MQTT_NS::qos::exactly_once);
                     return true;
                 });
@@ -1800,11 +1800,11 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_0);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
                     c->publish("topic1", "topic1_contents", MQTT_NS::qos::at_most_once);
                     return true;
                 });
@@ -1978,11 +1978,11 @@ BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_0);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
                     c->publish("topic1"_mb, "topic1_contents"_mb, MQTT_NS::qos::at_most_once);
                     return true;
                 });
@@ -2159,11 +2159,11 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_1);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
                     auto ret =
                         c->publish_dup(1, "topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
                     BOOST_TEST(ret == true);
@@ -2344,11 +2344,11 @@ BOOST_AUTO_TEST_CASE( publish_dup_function_buffer ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_1);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
                     auto ret =
                         c->publish_dup(1, "topic1"_mb, "topic1_contents"_mb, MQTT_NS::qos::at_least_once);
                     BOOST_TEST(ret == true);

--- a/test/pubsub_no_strand.cpp
+++ b/test/pubsub_no_strand.cpp
@@ -81,11 +81,11 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
         });
     c->set_suback_handler(
         [&chk, &c, &pid_sub]
-        (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+        (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
             MQTT_CHK("h_suback");
             BOOST_TEST(packet_id == pid_sub);
             BOOST_TEST(results.size() == 1U);
-            BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_0);
+            BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
             c->publish("topic1", "topic1_contents", MQTT_NS::qos::at_most_once);
             return true;
         });
@@ -188,11 +188,11 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
         });
     c->set_suback_handler(
         [&chk, &c, &pid_pub, &pid_sub]
-        (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+        (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
             MQTT_CHK("h_suback");
             BOOST_TEST(packet_id == pid_sub);
             BOOST_TEST(results.size() == 1U);
-            BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_0);
+            BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
             pid_pub = c->publish("topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
             return true;
         });
@@ -296,11 +296,11 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
         });
     c->set_suback_handler(
         [&chk, &c, &pid_pub]
-        (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+        (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
             MQTT_CHK("h_suback");
             BOOST_TEST(packet_id == 1);
             BOOST_TEST(results.size() == 1U);
-            BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_0);
+            BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
             pid_pub = c->publish("topic1", "topic1_contents", MQTT_NS::qos::exactly_once);
             return true;
         });
@@ -398,11 +398,11 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
         });
     c->set_suback_handler(
         [&chk, &c, &pid_sub]
-        (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+        (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
             MQTT_CHK("h_suback");
             BOOST_TEST(packet_id == pid_sub);
             BOOST_TEST(results.size() == 1U);
-            BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_1);
+            BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
             c->publish("topic1", "topic1_contents", MQTT_NS::qos::at_most_once);
             return true;
         });
@@ -513,11 +513,11 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
         });
     c->set_suback_handler(
         [&chk, &c, &pid_sub, &pid_pub]
-        (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+        (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
             MQTT_CHK("h_suback");
             BOOST_TEST(packet_id == pid_sub);
             BOOST_TEST(results.size() == 1U);
-            BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_1);
+            BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
             pid_pub = c->publish("topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
             return true;
         });
@@ -630,11 +630,11 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
         });
     c->set_suback_handler(
         [&chk, &c, &pid_sub, &pid_pub]
-        (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+        (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
             MQTT_CHK("h_suback");
             BOOST_TEST(packet_id == pid_sub);
             BOOST_TEST(results.size() == 1U);
-            BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_1);
+            BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
             pid_pub = c->publish("topic1", "topic1_contents", MQTT_NS::qos::exactly_once);
             return true;
         });
@@ -733,11 +733,11 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
         });
     c->set_suback_handler(
         [&chk, &c, &pid_sub]
-        (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+        (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
             MQTT_CHK("h_suback");
             BOOST_TEST(packet_id == pid_sub);
             BOOST_TEST(results.size() == 1U);
-            BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_2);
+            BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_2);
             c->publish("topic1", "topic1_contents", MQTT_NS::qos::at_most_once);
             return true;
         });
@@ -848,11 +848,11 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
         });
     c->set_suback_handler(
         [&chk, &c, &pid_sub, &pid_pub]
-        (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+        (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
             MQTT_CHK("h_suback");
             BOOST_TEST(packet_id == pid_sub);
             BOOST_TEST(results.size() == 1U);
-            BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_2);
+            BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_2);
             pid_pub = c->publish("topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
             return true;
         });
@@ -965,11 +965,11 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
         });
     c->set_suback_handler(
         [&chk, &c, &pid_sub, &pid_pub]
-        (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+        (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
             MQTT_CHK("h_suback");
             BOOST_TEST(packet_id == pid_sub);
             BOOST_TEST(results.size() == 1U);
-            BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_2);
+            BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_2);
             pid_pub = c->publish("topic1", "topic1_contents", MQTT_NS::qos::exactly_once);
             return true;
         });
@@ -1068,11 +1068,11 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
         });
     c->set_suback_handler(
         [&chk, &c, &pid_sub]
-        (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+        (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
             MQTT_CHK("h_suback");
             BOOST_TEST(packet_id == pid_sub);
             BOOST_TEST(results.size() == 1U);
-            BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_0);
+            BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
             c->publish("topic1", "topic1_contents", MQTT_NS::qos::at_most_once);
             return true;
         });

--- a/test/remaining_length.cpp
+++ b/test/remaining_length.cpp
@@ -80,11 +80,11 @@ BOOST_AUTO_TEST_CASE( pub_sub_over_127 ) {
             });
         c->set_suback_handler(
             [&chk, &c, &pid_sub, &test_contents]
-            (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+            (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                 MQTT_CHK("h_suback");
                 BOOST_TEST(packet_id == pid_sub);
                 BOOST_TEST(results.size() == 1U);
-                BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_0);
+                BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
                 c->publish("topic1", test_contents, MQTT_NS::qos::at_most_once);
                 return true;
             });
@@ -189,11 +189,11 @@ BOOST_AUTO_TEST_CASE( pub_sub_over_16384 ) {
             });
         c->set_suback_handler(
             [&chk, &c, &pid_sub, &test_contents]
-            (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+            (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                 MQTT_CHK("h_suback");
                 BOOST_TEST(packet_id == pid_sub);
                 BOOST_TEST(results.size() == 1U);
-                BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_0);
+                BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
                 c->publish("topic1", test_contents, MQTT_NS::qos::at_most_once);
                 return true;
             });
@@ -300,11 +300,11 @@ BOOST_AUTO_TEST_CASE( pub_sub_over_2097152 ) {
             });
         c->set_suback_handler(
             [&chk, &c, &pid_sub, &test_contents]
-            (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+            (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                 MQTT_CHK("h_suback");
                 BOOST_TEST(packet_id == pid_sub);
                 BOOST_TEST(results.size() == 1U);
-                BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_0);
+                BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
                 c->publish("topic1", test_contents, MQTT_NS::qos::at_most_once);
                 return true;
             });

--- a/test/retain.cpp
+++ b/test/retain.cpp
@@ -69,11 +69,11 @@ BOOST_AUTO_TEST_CASE( simple ) {
                 });
             c->set_suback_handler(
                 [&chk, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_0);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
                     return true;
                 });
             c->set_unsuback_handler(
@@ -255,11 +255,11 @@ BOOST_AUTO_TEST_CASE( overwrite ) {
                 });
             c->set_suback_handler(
                 [&chk, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_0);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
                     return true;
                 });
             c->set_unsuback_handler(
@@ -442,10 +442,10 @@ BOOST_AUTO_TEST_CASE( retain_and_publish ) {
                 });
             c->set_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
-                    BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_0);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
                     auto ret = chk.match(
                         "h_connack",
                         [&] {

--- a/test/sub.cpp
+++ b/test/sub.cpp
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_single ) {
                 });
             c->set_suback_handler(
                 [&chk, &c]
-                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::suback_reason_code> /*results*/) {
+                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::suback_return_code> /*results*/) {
                     MQTT_CHK("h_suback");
                     c->unsubscribe("topic1");
                     return true;
@@ -137,7 +137,7 @@ BOOST_AUTO_TEST_CASE( sub_v5_options ) {
                 });
             c->set_suback_handler(
                 [&chk, &c]
-                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::suback_reason_code> /*results*/) {
+                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::suback_return_code> /*results*/) {
                     MQTT_CHK("h_suback");
                     c->unsubscribe("topic1");
                     return true;
@@ -236,7 +236,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg ) {
                 });
             c->set_suback_handler(
                 [&chk, &c]
-                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::suback_reason_code> /*results*/) {
+                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::suback_return_code> /*results*/) {
                     MQTT_CHK("h_suback");
                     c->unsubscribe( { MQTT_NS::string_view{"topic1"}, MQTT_NS::string_view{"topic2"} } );
                     return true;
@@ -335,7 +335,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec ) {
                 });
             c->set_suback_handler(
                 [&chk, &c]
-                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::suback_reason_code> /*results*/) {
+                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::suback_return_code> /*results*/) {
                     MQTT_CHK("h_suback");
                     std::vector<MQTT_NS::string_view> v
                         {
@@ -439,7 +439,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_single_async ) {
                 });
             c->set_suback_handler(
                 [&chk, &c]
-                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::suback_reason_code> /*results*/) {
+                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::suback_return_code> /*results*/) {
                     MQTT_CHK("h_suback");
                     c->async_unsubscribe("topic1", [](boost::system::error_code const&) {});
                     return true;
@@ -536,7 +536,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg_async ) {
                 });
             c->set_suback_handler(
                 [&chk, &c]
-                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::suback_reason_code> /*results*/) {
+                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::suback_return_code> /*results*/) {
                     MQTT_CHK("h_suback");
                     c->async_unsubscribe(
                         std::vector<std::string> {
@@ -651,7 +651,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec_async ) {
                 });
             c->set_suback_handler(
                 [&chk, &c]
-                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::suback_reason_code> /*results*/) {
+                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::suback_return_code> /*results*/) {
                     MQTT_CHK("h_suback");
                     std::vector<std::string> v
                         {

--- a/test/test_broker.hpp
+++ b/test/test_broker.hpp
@@ -711,12 +711,12 @@ private:
         switch (ep.get_protocol_version()) {
         case MQTT_NS::protocol_version::v3_1_1:
         {
-            std::vector<MQTT_NS::suback_reason_code> res;
+            std::vector<MQTT_NS::suback_return_code> res;
             res.reserve(entries.size());
             for (auto const& e : entries) {
                 MQTT_NS::buffer topic = std::get<0>(e);
                 MQTT_NS::qos qos_value = std::get<1>(e).get_qos();
-                res.emplace_back(static_cast<MQTT_NS::suback_reason_code>(qos_value)); // converts to granted_qos_x
+                res.emplace_back(static_cast<MQTT_NS::suback_return_code>(qos_value)); // converts to granted_qos_x
                 // TODO: This doesn't handle situations where we receive a new subscription for the same topic.
                 // MQTT 3.1.1 - 3.8.4 Response - paragraph 3.
                 subs_.emplace(std::move(topic), spep, qos_value);

--- a/test/will.cpp
+++ b/test/will.cpp
@@ -106,11 +106,11 @@ BOOST_AUTO_TEST_CASE( will_qos0 ) {
         });
     c2->set_suback_handler(
         [&chk, &c1_force_disconnect, &pid_sub2]
-        (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+        (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
             MQTT_CHK("h_suback_2");
             BOOST_TEST(packet_id == pid_sub2);
             BOOST_TEST(results.size() == 1U);
-            BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_0);
+            BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
             c1_force_disconnect();
             return true;
         });
@@ -233,11 +233,11 @@ BOOST_AUTO_TEST_CASE( will_qos1 ) {
         });
     c2->set_suback_handler(
         [&chk, &c1_force_disconnect, &pid_sub2]
-        (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+        (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
             MQTT_CHK("h_suback_2");
             BOOST_TEST(packet_id == pid_sub2);
             BOOST_TEST(results.size() == 1U);
-            BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_1);
+            BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
             c1_force_disconnect();
             return true;
         });
@@ -362,11 +362,11 @@ BOOST_AUTO_TEST_CASE( will_qos2 ) {
         });
     c2->set_suback_handler(
         [&chk, &c1_force_disconnect, &pid_sub2]
-        (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+        (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
             MQTT_CHK("h_suback_2");
             BOOST_TEST(packet_id == pid_sub2);
             BOOST_TEST(results.size() == 1U);
-            BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_2);
+            BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_2);
             c1_force_disconnect();
             return true;
         });
@@ -499,10 +499,10 @@ BOOST_AUTO_TEST_CASE( will_retain ) {
         });
     c2->set_suback_handler(
         [&chk, &c1_force_disconnect, &pid_sub2]
-        (packet_id_t packet_id, std::vector<MQTT_NS::suback_reason_code> results) {
+        (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
             BOOST_TEST(packet_id == pid_sub2);
             BOOST_TEST(results.size() == 1U);
-            BOOST_TEST(results[0] == MQTT_NS::suback_reason_code::granted_qos_0);
+            BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
             auto ret = chk.match(
                 "h_connack_2",
                 [&] {


### PR DESCRIPTION
Use suback_return_code on MQTT v3.1.1.
Use suback_return_code::success_maximum_qos0..2 on MQTT v3.1.1.
Use suback_return_code::failure on MQTT v3.1.1.