### PR TITLE
Implemented #499.

### DIFF
--- a/include/mqtt/deprecated.hpp
+++ b/include/mqtt/deprecated.hpp
@@ -7,11 +7,11 @@
 #if !defined(MQTT_DEPRECATED_HPP)
 #define MQTT_DEPRECATED_HPP
 
-#if defined(MQTT_DEPRECATED_TEST)
+#if defined(MQTT_USE_DEPRECATED)
 
 #define MQTT_DEPRECATED(msg) // for test, ignore it
 
-#else  // defined(MQTT_DEPRECATED_TEST)
+#else  // defined(MQTT_USE_DEPRECATED)
 
 #if __cplusplus >= 201402L
 
@@ -31,6 +31,6 @@
 
 #endif // __cplusplus >= 201402L
 
-#endif // defined(MQTT_DEPRECATED_TEST)
+#endif // defined(MQTT_USE_DEPRECATED)
 
 #endif // MQTT_DEPRECATED_HPP

--- a/test/test_settings.hpp
+++ b/test/test_settings.hpp
@@ -7,7 +7,7 @@
 #if !defined(MQTT_TEST_SETTINGS_HPP)
 #define MQTT_TEST_SETTINGS_HPP
 
-#define MQTT_DEPRECATED_TEST
+#define MQTT_USE_DEPRECATED
 
 #include <string>
 #include <boost/uuid/uuid.hpp>


### PR DESCRIPTION
Renamed from MQTT_DEPRECATED_TEST to MQTT_USE_DEPRECATED.

The macro is documented at https://github.com/redboltz/mqtt_cpp/wiki/Config