### PR TITLE
Rename std::vector<MQTT_NS::v5::property_variant> as MQTT_NS::v5::properties

### DIFF
--- a/example/v5_no_tls_both.cpp
+++ b/example/v5_no_tls_both.cpp
@@ -29,7 +29,7 @@ void client_proc(
     // Setup handlers
     c->set_v5_connack_handler( // use v5 handler
         [&c, &pid_sub1, &pid_sub2]
-        (bool sp, MQTT_NS::v5::connect_reason_code reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/){
+        (bool sp, MQTT_NS::v5::connect_reason_code reason_code, MQTT_NS::v5::properties /*props*/){
             std::cout << "[client] Connack handler called" << std::endl;
             std::cout << "[client] Clean Session: " << std::boolalpha << sp << std::endl;
             std::cout << "[client] Connect Reason Code: " << reason_code << std::endl;
@@ -56,7 +56,7 @@ void client_proc(
         });
     c->set_v5_puback_handler( // use v5 handler
         [&]
-        (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/){
+        (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code reason_code, MQTT_NS::v5::properties /*props*/){
             std::cout <<
                 "[client] puback received. packet_id: " << packet_id <<
                 " reason_code: " << reason_code << std::endl;
@@ -65,7 +65,7 @@ void client_proc(
         });
     c->set_v5_pubrec_handler( // use v5 handler
         [&]
-        (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/){
+        (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code reason_code, MQTT_NS::v5::properties /*props*/){
             std::cout <<
                 "[client] pubrec received. packet_id: " << packet_id <<
                 " reason_code: " << reason_code << std::endl;
@@ -73,7 +73,7 @@ void client_proc(
         });
     c->set_v5_pubcomp_handler( // use v5 handler
         [&]
-        (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/){
+        (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code reason_code, MQTT_NS::v5::properties /*props*/){
             std::cout <<
                 "[client] pubcomp received. packet_id: " << packet_id <<
                 " reason_code: " << reason_code << std::endl;
@@ -84,7 +84,7 @@ void client_proc(
         [&]
         (packet_id_t packet_id,
          std::vector<MQTT_NS::v5::suback_reason_code> reasons,
-         std::vector<MQTT_NS::v5::property_variant> /*props*/){
+         MQTT_NS::v5::properties /*props*/){
             std::cout << "[client] suback received. packet_id: " << packet_id << std::endl;
             for (auto const& e : reasons) {
                 switch (e) {
@@ -119,7 +119,7 @@ void client_proc(
          MQTT_NS::optional<packet_id_t> packet_id,
          MQTT_NS::buffer topic_name,
          MQTT_NS::buffer contents,
-         std::vector<MQTT_NS::v5::property_variant> /*props*/){
+         MQTT_NS::v5::properties /*props*/){
             std::cout << "[client] publish received. "
                       << "dup: " << std::boolalpha << is_dup
                       << " qos: " << qos_value
@@ -233,7 +233,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                  MQTT_NS::optional<MQTT_NS::will>,
                  bool clean_session,
                  std::uint16_t keep_alive,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/){
+                 MQTT_NS::v5::properties /*props*/){
                     using namespace MQTT_NS::literals;
                     std::cout << "[server] client_id    : " << client_id << std::endl;
                     std::cout << "[server] username     : " << (username ? username.value() : "none"_mb) << std::endl;
@@ -249,7 +249,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
             );
             ep.set_v5_disconnect_handler( // use v5 handler
                 [&connections, &subs, wp]
-                (MQTT_NS::v5::disconnect_reason_code reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (MQTT_NS::v5::disconnect_reason_code reason_code, MQTT_NS::v5::properties /*props*/) {
                     std::cout <<
                         "[server] disconnect received." <<
                         " reason_code: " << reason_code << std::endl;
@@ -259,7 +259,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                 });
             ep.set_v5_puback_handler( // use v5 handler
                 []
-                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/){
+                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code reason_code, MQTT_NS::v5::properties /*props*/){
                     std::cout <<
                         "[server] puback received. packet_id: " << packet_id <<
                         " reason_code: " << reason_code << std::endl;
@@ -267,7 +267,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                 });
             ep.set_v5_pubrec_handler( // use v5 handler
                 []
-                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/){
+                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code reason_code, MQTT_NS::v5::properties /*props*/){
                     std::cout <<
                         "[server] pubrec received. packet_id: " << packet_id <<
                         " reason_code: " << reason_code << std::endl;
@@ -275,7 +275,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                 });
             ep.set_v5_pubrel_handler( // use v5 handler
                 []
-                (packet_id_t packet_id, MQTT_NS::v5::pubrel_reason_code reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/){
+                (packet_id_t packet_id, MQTT_NS::v5::pubrel_reason_code reason_code, MQTT_NS::v5::properties /*props*/){
                     std::cout <<
                         "[server] pubrel received. packet_id: " << packet_id <<
                         " reason_code: " << reason_code << std::endl;
@@ -283,7 +283,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                 });
             ep.set_v5_pubcomp_handler( // use v5 handler
                 []
-                (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/){
+                (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code reason_code, MQTT_NS::v5::properties /*props*/){
                     std::cout <<
                         "[server] pubcomp received. packet_id: " << packet_id <<
                         " reason_code: " << reason_code << std::endl;
@@ -297,7 +297,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::buffer topic_name,
                  MQTT_NS::buffer contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/){
+                 MQTT_NS::v5::properties /*props*/){
                     std::cout << "[server] publish received."
                               << " dup: " << std::boolalpha << is_dup
                               << " qos: " << qos_value
@@ -323,7 +323,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                 [&subs, wp]
                 (packet_id_t packet_id,
                  std::vector<std::tuple<MQTT_NS::buffer, MQTT_NS::subscribe_options>> entries,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     std::cout << "[server] subscribe received. packet_id: " << packet_id << std::endl;
                     std::vector<MQTT_NS::v5::suback_reason_code> res;
                     res.reserve(entries.size());
@@ -344,7 +344,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                 [&subs, wp]
                 (packet_id_t packet_id,
                  std::vector<MQTT_NS::buffer> topics,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     std::cout << "[server] unsubscribe received. packet_id: " << packet_id << std::endl;
                     for (auto const& topic : topics) {
                         subs.erase(topic);

--- a/example/v5_no_tls_client.cpp
+++ b/example/v5_no_tls_client.cpp
@@ -38,7 +38,7 @@ int main(int argc, char** argv) {
     // Setup handlers
     c->set_v5_connack_handler( // use v5 handler
         [&c, &pid_sub1, &pid_sub2]
-        (bool sp, MQTT_NS::v5::connect_reason_code reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/){
+        (bool sp, MQTT_NS::v5::connect_reason_code reason_code, MQTT_NS::v5::properties /*props*/){
             std::cout << "[client] Connack handler called" << std::endl;
             std::cout << "[client] Clean Session: " << std::boolalpha << sp << std::endl;
             std::cout << "[client] Connect Reason Code: " << reason_code << std::endl;
@@ -65,7 +65,7 @@ int main(int argc, char** argv) {
         });
     c->set_v5_puback_handler( // use v5 handler
         [&]
-        (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/){
+        (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code reason_code, MQTT_NS::v5::properties /*props*/){
             std::cout <<
                 "[client] puback received. packet_id: " << packet_id <<
                 " reason_code: " << reason_code << std::endl;
@@ -74,7 +74,7 @@ int main(int argc, char** argv) {
         });
     c->set_v5_pubrec_handler( // use v5 handler
         [&]
-        (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/){
+        (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code reason_code, MQTT_NS::v5::properties /*props*/){
             std::cout <<
                 "[client] pubrec received. packet_id: " << packet_id <<
                 " reason_code: " << reason_code << std::endl;
@@ -82,7 +82,7 @@ int main(int argc, char** argv) {
         });
     c->set_v5_pubcomp_handler( // use v5 handler
         [&]
-        (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/){
+        (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code reason_code, MQTT_NS::v5::properties /*props*/){
             std::cout <<
                 "[client] pubcomp received. packet_id: " << packet_id <<
                 " reason_code: " << reason_code << std::endl;
@@ -93,7 +93,7 @@ int main(int argc, char** argv) {
         [&]
         (packet_id_t packet_id,
          std::vector<MQTT_NS::v5::suback_reason_code> reasons,
-         std::vector<MQTT_NS::v5::property_variant> /*props*/){
+         MQTT_NS::v5::properties /*props*/){
             std::cout << "[client] suback received. packet_id: " << packet_id << std::endl;
             for (auto const& e : reasons) {
                 switch (e) {
@@ -128,7 +128,7 @@ int main(int argc, char** argv) {
          MQTT_NS::optional<packet_id_t> packet_id,
          MQTT_NS::string_view topic_name,
          MQTT_NS::string_view contents,
-         std::vector<MQTT_NS::v5::property_variant> /*props*/){
+         MQTT_NS::v5::properties /*props*/){
             std::cout << "[client] publish received. "
                       << "dup: " << std::boolalpha << is_dup
                       << " qos: " << qos_value

--- a/example/v5_no_tls_prop.cpp
+++ b/example/v5_no_tls_prop.cpp
@@ -26,7 +26,7 @@ void client_proc(Client& c) {
     // Setup handlers
     c->set_v5_connack_handler( // use v5 handler
         [&c]
-        (bool sp, v5::connect_reason_code reason_code, std::vector<MQTT_NS::v5::property_variant> props){
+        (bool sp, v5::connect_reason_code reason_code, MQTT_NS::v5::properties props){
             std::cout << "[client] Connack handler called" << std::endl;
             std::cout << "[client] Clean Session: " << std::boolalpha << sp << std::endl;
             std::cout << "[client] Connect Reason Code: " << reason_code << std::endl;
@@ -109,7 +109,7 @@ void client_proc(Client& c) {
         });
 
     // prepare connect properties
-    std::vector<MQTT_NS::v5::property_variant> con_ps {
+    MQTT_NS::v5::properties con_ps {
         MQTT_NS::v5::property::session_expiry_interval(0x12345678UL),
         MQTT_NS::v5::property::receive_maximum(0x1234U),
         MQTT_NS::v5::property::maximum_packet_size(0x12345678UL),
@@ -192,7 +192,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections) {
                  MQTT_NS::optional<MQTT_NS::will>,
                  bool clean_session,
                  std::uint16_t keep_alive,
-                 std::vector<MQTT_NS::v5::property_variant> props){
+                 MQTT_NS::v5::properties props){
                     std::cout << "[server] client_id    : " << client_id << std::endl;
                     std::cout << "[server] username     : " << (username ? username.value() : "none"_mb) << std::endl;
                     std::cout << "[server] password     : " << (password ? password.value() : "none"_mb) << std::endl;
@@ -242,7 +242,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections) {
                     BOOST_ASSERT(sp);
                     connections.insert(sp);
 
-                    std::vector<MQTT_NS::v5::property_variant> connack_ps {
+                    MQTT_NS::v5::properties connack_ps {
                         MQTT_NS::v5::property::session_expiry_interval(0),
                         MQTT_NS::v5::property::receive_maximum(0),
                         MQTT_NS::v5::property::maximum_qos(MQTT_NS::qos::exactly_once),
@@ -268,7 +268,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections) {
             );
             ep.set_v5_disconnect_handler( // use v5 handler
                 [&connections, wp]
-                (MQTT_NS::v5::disconnect_reason_code reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (MQTT_NS::v5::disconnect_reason_code reason_code, MQTT_NS::v5::properties /*props*/) {
                     std::cout <<
                         "[server] disconnect received." <<
                         " reason_code: " << reason_code << std::endl;

--- a/example/v5_no_tls_server.cpp
+++ b/example/v5_no_tls_server.cpp
@@ -117,7 +117,7 @@ int main(int argc, char** argv) {
                  MQTT_NS::optional<MQTT_NS::will>,
                  bool clean_session,
                  std::uint16_t keep_alive,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/){
+                 MQTT_NS::v5::properties /*props*/){
                     using namespace MQTT_NS::literals;
                     std::cout << "[server] client_id    : " << client_id << std::endl;
                     std::cout << "[server] username     : " << (username ? username.value() : "none"_mb) << std::endl;
@@ -133,7 +133,7 @@ int main(int argc, char** argv) {
             );
             ep.set_v5_disconnect_handler( // use v5 handler
                 [&connections, &subs, wp]
-                (MQTT_NS::v5::disconnect_reason_code reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (MQTT_NS::v5::disconnect_reason_code reason_code, MQTT_NS::v5::properties /*props*/) {
                     std::cout <<
                         "[server] disconnect received." <<
                         " reason_code: " << reason_code << std::endl;
@@ -143,7 +143,7 @@ int main(int argc, char** argv) {
                 });
             ep.set_v5_puback_handler( // use v5 handler
                 []
-                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/){
+                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code reason_code, MQTT_NS::v5::properties /*props*/){
                     std::cout <<
                         "[server] puback received. packet_id: " << packet_id <<
                         " reason_code: " << reason_code << std::endl;
@@ -151,7 +151,7 @@ int main(int argc, char** argv) {
                 });
             ep.set_v5_pubrec_handler( // use v5 handler
                 []
-                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/){
+                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code reason_code, MQTT_NS::v5::properties /*props*/){
                     std::cout <<
                         "[server] pubrec received. packet_id: " << packet_id <<
                         " reason_code: " << reason_code << std::endl;
@@ -159,7 +159,7 @@ int main(int argc, char** argv) {
                 });
             ep.set_v5_pubrel_handler( // use v5 handler
                 []
-                (packet_id_t packet_id, MQTT_NS::v5::pubrel_reason_code reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/){
+                (packet_id_t packet_id, MQTT_NS::v5::pubrel_reason_code reason_code, MQTT_NS::v5::properties /*props*/){
                     std::cout <<
                         "[server] pubrel received. packet_id: " << packet_id <<
                         " reason_code: " << reason_code << std::endl;
@@ -167,7 +167,7 @@ int main(int argc, char** argv) {
                 });
             ep.set_v5_pubcomp_handler( // use v5 handler
                 []
-                (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/){
+                (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code reason_code, MQTT_NS::v5::properties /*props*/){
                     std::cout <<
                         "[server] pubcomp received. packet_id: " << packet_id <<
                         " reason_code: " << reason_code << std::endl;
@@ -181,7 +181,7 @@ int main(int argc, char** argv) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::buffer topic_name,
                  MQTT_NS::buffer contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/){
+                 MQTT_NS::v5::properties /*props*/){
                     std::cout << "[server] publish received."
                               << " dup: " << std::boolalpha << is_dup
                               << " qos: " << qos_value
@@ -207,7 +207,7 @@ int main(int argc, char** argv) {
                 [&subs, wp]
                 (packet_id_t packet_id,
                  std::vector<std::tuple<MQTT_NS::buffer, MQTT_NS::subscribe_options>> entries,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     std::cout << "[server] subscribe received. packet_id: " << packet_id << std::endl;
                     std::vector<MQTT_NS::v5::suback_reason_code> res;
                     res.reserve(entries.size());
@@ -228,7 +228,7 @@ int main(int argc, char** argv) {
                 [&subs, wp]
                 (packet_id_t packet_id,
                  std::vector<MQTT_NS::buffer> topics,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     std::cout << "[server] unsubscribe received. packet_id: " << packet_id << std::endl;
                     for (auto const& topic : topics) {
                         subs.erase(topic);

--- a/include/mqtt/callable_overlay.hpp
+++ b/include/mqtt/callable_overlay.hpp
@@ -330,7 +330,7 @@ struct callable_overlay final : public Impl
                                               MQTT_NS::optional<will> will,
                                               bool clean_start,
                                               std::uint16_t keep_alive,
-                                              std::vector<v5::property_variant> props) override final {
+                                              v5::properties props) override final {
         return    ! h_v5_connect_
                || h_v5_connect_(MQTT_NS::force_move(client_id),
                                 MQTT_NS::force_move(user_name),
@@ -359,7 +359,7 @@ struct callable_overlay final : public Impl
      */
     MQTT_ALWAYS_INLINE bool on_v5_connack(bool session_present,
                                               v5::connect_reason_code reason_code,
-                                              std::vector<v5::property_variant> props) override final {
+                                              v5::properties props) override final {
         return    ! h_v5_connack_
                || h_v5_connack_(session_present, reason_code, MQTT_NS::force_move(props));
     }
@@ -395,7 +395,7 @@ struct callable_overlay final : public Impl
                                               MQTT_NS::optional<packet_id_t> packet_id,
                                               MQTT_NS::buffer topic_name,
                                               MQTT_NS::buffer contents,
-                                              std::vector<v5::property_variant> props) override final {
+                                              v5::properties props) override final {
         return    ! h_v5_publish_
                || h_v5_publish_(dup,
                                 qos_value,
@@ -424,7 +424,7 @@ struct callable_overlay final : public Impl
      */
     MQTT_ALWAYS_INLINE bool on_v5_puback(packet_id_t packet_id,
                                              v5::puback_reason_code reason_code,
-                                             std::vector<v5::property_variant> props) override final {
+                                             v5::properties props) override final {
         return    ! h_v5_puback_
                || h_v5_puback_(packet_id, reason_code, MQTT_NS::force_move(props));
     }
@@ -447,7 +447,7 @@ struct callable_overlay final : public Impl
      */
     MQTT_ALWAYS_INLINE bool on_v5_pubrec(packet_id_t packet_id,
                                              v5::pubrec_reason_code reason_code,
-                                             std::vector<v5::property_variant> props) override final {
+                                             v5::properties props) override final {
         return    ! h_v5_pubrec_
                || h_v5_pubrec_(packet_id, reason_code, MQTT_NS::force_move(props));
     }
@@ -470,7 +470,7 @@ struct callable_overlay final : public Impl
      */
     MQTT_ALWAYS_INLINE bool on_v5_pubrel(packet_id_t packet_id,
                                              v5::pubrel_reason_code reason_code,
-                                             std::vector<v5::property_variant> props) override final {
+                                             v5::properties props) override final {
         return    ! h_v5_pubrel_
                || h_v5_pubrel_(packet_id, reason_code, MQTT_NS::force_move(props));
     }
@@ -493,7 +493,7 @@ struct callable_overlay final : public Impl
      */
     MQTT_ALWAYS_INLINE bool on_v5_pubcomp(packet_id_t packet_id,
                                               v5::pubcomp_reason_code reason_code,
-                                              std::vector<v5::property_variant> props) override final {
+                                              v5::properties props) override final {
         return    ! h_v5_pubcomp_
                || h_v5_pubcomp_(packet_id, reason_code, MQTT_NS::force_move(props));
     }
@@ -514,7 +514,7 @@ struct callable_overlay final : public Impl
      */
     MQTT_ALWAYS_INLINE bool on_v5_subscribe(packet_id_t packet_id,
                                                 std::vector<std::tuple<MQTT_NS::buffer, subscribe_options>> entries,
-                                                std::vector<v5::property_variant> props) override final {
+                                                v5::properties props) override final {
         return    ! h_v5_subscribe_
                || h_v5_subscribe_(packet_id, MQTT_NS::force_move(entries), MQTT_NS::force_move(props));
     }
@@ -536,7 +536,7 @@ struct callable_overlay final : public Impl
      */
     MQTT_ALWAYS_INLINE bool on_v5_suback(packet_id_t packet_id,
                                              std::vector<MQTT_NS::v5::suback_reason_code> reasons,
-                                             std::vector<v5::property_variant> props) override final {
+                                             v5::properties props) override final {
         return    ! h_v5_suback_
                || h_v5_suback_(packet_id, MQTT_NS::force_move(reasons), MQTT_NS::force_move(props));
     }
@@ -558,7 +558,7 @@ struct callable_overlay final : public Impl
      */
     MQTT_ALWAYS_INLINE bool on_v5_unsubscribe(packet_id_t packet_id,
                                                   std::vector<MQTT_NS::buffer> topics,
-                                                  std::vector<v5::property_variant> props) override final {
+                                                  v5::properties props) override final {
         return    ! h_v5_unsubscribe_
                || h_v5_unsubscribe_(packet_id, MQTT_NS::force_move(topics), MQTT_NS::force_move(props));
     }
@@ -580,7 +580,7 @@ struct callable_overlay final : public Impl
      */
     MQTT_ALWAYS_INLINE bool on_v5_unsuback(packet_id_t packet_id,
                                                std::vector<v5::unsuback_reason_code> reasons,
-                                               std::vector<v5::property_variant> props) override final {
+                                               v5::properties props) override final {
         return    ! h_v5_unsuback_
                || h_v5_unsuback_(packet_id, MQTT_NS::force_move(reasons), MQTT_NS::force_move(props));
     }
@@ -599,7 +599,7 @@ struct callable_overlay final : public Impl
      *        3.14.2.2 DISCONNECT Properties
      */
     MQTT_ALWAYS_INLINE void on_v5_disconnect(v5::disconnect_reason_code reason_code,
-                                                 std::vector<v5::property_variant> props) override final {
+                                                 v5::properties props) override final {
         if(h_v5_disconnect_) h_v5_disconnect_(reason_code, MQTT_NS::force_move(props));
     }
 
@@ -618,7 +618,7 @@ struct callable_overlay final : public Impl
      * @return if the handler returns true, then continue receiving, otherwise quit.
      */
     MQTT_ALWAYS_INLINE bool on_v5_auth(v5::auth_reason_code reason_code,
-                                           std::vector<v5::property_variant> props) override final {
+                                           v5::properties props) override final {
         return    ! h_v5_auth_
                || h_v5_auth_(reason_code, MQTT_NS::force_move(props));
 
@@ -998,7 +998,7 @@ struct callable_overlay final : public Impl
              MQTT_NS::optional<will> will,
              bool clean_start,
              std::uint16_t keep_alive,
-             std::vector<v5::property_variant> props)
+             v5::properties props)
     >;
 
     /**
@@ -1020,7 +1020,7 @@ struct callable_overlay final : public Impl
     using v5_connack_handler = std::function<
         bool(bool session_present,
              v5::connect_reason_code reason_code,
-             std::vector<v5::property_variant> props)
+             v5::properties props)
     >;
 
     /**
@@ -1055,7 +1055,7 @@ struct callable_overlay final : public Impl
              MQTT_NS::optional<packet_id_t> packet_id,
              MQTT_NS::buffer topic_name,
              MQTT_NS::buffer contents,
-             std::vector<v5::property_variant> props)
+             v5::properties props)
     >;
 
     /**
@@ -1077,7 +1077,7 @@ struct callable_overlay final : public Impl
     using v5_puback_handler = std::function<
         bool(packet_id_t packet_id,
              v5::puback_reason_code reason_code,
-             std::vector<v5::property_variant> props)
+             v5::properties props)
     >;
 
     /**
@@ -1099,7 +1099,7 @@ struct callable_overlay final : public Impl
     using v5_pubrec_handler = std::function<
         bool(packet_id_t packet_id,
              v5::pubrec_reason_code reason_code,
-             std::vector<v5::property_variant> props)
+             v5::properties props)
     >;
 
     /**
@@ -1121,7 +1121,7 @@ struct callable_overlay final : public Impl
     using v5_pubrel_handler = std::function<
         bool(packet_id_t packet_id,
              v5::pubrel_reason_code reason_code,
-             std::vector<v5::property_variant> props)
+             v5::properties props)
     >;
 
     /**
@@ -1143,7 +1143,7 @@ struct callable_overlay final : public Impl
     using v5_pubcomp_handler = std::function<
         bool(packet_id_t packet_id,
              v5::pubcomp_reason_code reason_code,
-             std::vector<v5::property_variant> props)
+             v5::properties props)
     >;
 
     /**
@@ -1163,7 +1163,7 @@ struct callable_overlay final : public Impl
     using v5_subscribe_handler = std::function<
         bool(packet_id_t packet_id,
              std::vector<std::tuple<MQTT_NS::buffer, subscribe_options>> entries,
-             std::vector<v5::property_variant> props)
+             v5::properties props)
     >;
 
     /**
@@ -1184,7 +1184,7 @@ struct callable_overlay final : public Impl
     using v5_suback_handler = std::function<
         bool(packet_id_t packet_id,
              std::vector<MQTT_NS::v5::suback_reason_code> reasons,
-             std::vector<v5::property_variant> props)
+             v5::properties props)
     >;
 
     /**
@@ -1205,7 +1205,7 @@ struct callable_overlay final : public Impl
     using v5_unsubscribe_handler = std::function<
         bool(packet_id_t packet_id,
              std::vector<MQTT_NS::buffer> topics,
-             std::vector<v5::property_variant> props)
+             v5::properties props)
     >;
 
     /**
@@ -1226,7 +1226,7 @@ struct callable_overlay final : public Impl
     using v5_unsuback_handler = std::function<
         bool(packet_id_t,
              std::vector<v5::unsuback_reason_code> reasons,
-             std::vector<v5::property_variant> props)
+             v5::properties props)
     >;
 
     /**
@@ -1244,7 +1244,7 @@ struct callable_overlay final : public Impl
      */
     using v5_disconnect_handler = std::function<
         void(v5::disconnect_reason_code reason_code,
-             std::vector<v5::property_variant> props)
+             v5::properties props)
     >;
 
     /**
@@ -1263,7 +1263,7 @@ struct callable_overlay final : public Impl
      */
     using v5_auth_handler = std::function<
         bool(v5::auth_reason_code reason_code,
-             std::vector<v5::property_variant> props)
+             v5::properties props)
     >;
 
 

--- a/include/mqtt/client.hpp
+++ b/include/mqtt/client.hpp
@@ -377,7 +377,7 @@ public:
      * @param func finish handler that is called when the session is finished
      */
     void connect(any session_life_keeper = any()) {
-        connect(std::vector<v5::property_variant>{}, force_move(session_life_keeper));
+        connect(v5::properties{}, force_move(session_life_keeper));
     }
 
     /**
@@ -388,7 +388,7 @@ public:
      *        3.1.2.11 CONNECT Properties
      * @param func finish handler that is called when the session is finished
      */
-    void connect(std::vector<v5::property_variant> props, any session_life_keeper = any()) {
+    void connect(v5::properties props, any session_life_keeper = any()) {
         as::ip::tcp::resolver r(ioc_);
         auto eps = r.resolve(host_, port_);
         setup_socket(socket_);
@@ -403,7 +403,7 @@ public:
      * @param func finish handler that is called when the session is finished
      */
     void connect(std::shared_ptr<Socket>&& socket, any session_life_keeper = any()) {
-        connect(force_move(socket), std::vector<v5::property_variant>{}, force_move(session_life_keeper));
+        connect(force_move(socket), v5::properties{}, force_move(session_life_keeper));
     }
 
     /**
@@ -416,7 +416,7 @@ public:
      *        3.1.2.11 CONNECT Properties
      * @param func finish handler that is called when the session is finished
      */
-    void connect(std::shared_ptr<Socket>&& socket, std::vector<v5::property_variant> props, any session_life_keeper = any()) {
+    void connect(std::shared_ptr<Socket>&& socket, v5::properties props, any session_life_keeper = any()) {
         as::ip::tcp::resolver r(ioc_);
         auto eps = r.resolve(host_, port_);
         socket_ = force_move(socket);
@@ -443,7 +443,7 @@ public:
     void disconnect(
         boost::posix_time::time_duration const& timeout,
         v5::disconnect_reason_code reason_code = v5::disconnect_reason_code::normal_disconnection,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         if (ping_duration_ms_ != 0) tim_ping_.cancel();
         if (base::connected()) {
@@ -479,7 +479,7 @@ public:
      */
     void disconnect(
         v5::disconnect_reason_code reason_code = v5::disconnect_reason_code::normal_disconnection,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         if (ping_duration_ms_ != 0) tim_ping_.cancel();
         if (base::connected()) {
@@ -536,7 +536,7 @@ public:
     void async_disconnect(
         boost::posix_time::time_duration const& timeout,
         v5::disconnect_reason_code reason_code,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()) {
         if (ping_duration_ms_ != 0) tim_ping_.cancel();
         if (base::connected()) {
@@ -589,7 +589,7 @@ public:
      */
     void async_disconnect(
         v5::disconnect_reason_code reason_code,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()) {
         if (ping_duration_ms_ != 0) tim_ping_.cancel();
         if (base::connected()) {
@@ -685,7 +685,7 @@ private:
 
 #endif // defined(MQTT_USE_TLS)
 
-    void start_session(std::vector<v5::property_variant> props, any session_life_keeper) {
+    void start_session(v5::properties props, any session_life_keeper) {
         base::async_read_control_packet_type(force_move(session_life_keeper));
         // sync base::connect() refer to parameters only in the function.
         // So they can be passed as view.
@@ -704,7 +704,7 @@ private:
     template <typename Strand>
     void handshake_socket(
         tcp_endpoint<as::ip::tcp::socket, Strand>&,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         any session_life_keeper) {
         start_session(force_move(props), force_move(session_life_keeper));
     }
@@ -713,7 +713,7 @@ private:
     template <typename Strand>
     void handshake_socket(
         ws_endpoint<as::ip::tcp::socket, Strand>& socket,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         any session_life_keeper) {
         socket.async_handshake(
             host_,
@@ -731,7 +731,7 @@ private:
     template <typename Strand>
     void handshake_socket(
         tcp_endpoint<as::ssl::stream<as::ip::tcp::socket>, Strand>& socket,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         any session_life_keeper) {
         socket.async_handshake(
             as::ssl::stream_base::client,
@@ -746,7 +746,7 @@ private:
     template <typename Strand>
     void handshake_socket(
         ws_endpoint<as::ssl::stream<as::ip::tcp::socket>, Strand>& socket,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         any session_life_keeper) {
         socket.next_layer().async_handshake(
             as::ssl::stream_base::client,
@@ -768,7 +768,7 @@ private:
 #endif // defined(MQTT_USE_TLS)
 
     template <typename Iterator>
-    void connect_impl(Socket& socket, Iterator it, Iterator end, std::vector<v5::property_variant> props, any session_life_keeper) {
+    void connect_impl(Socket& socket, Iterator it, Iterator end, v5::properties props, any session_life_keeper) {
         as::async_connect(
             socket.lowest_layer(), it, end,
             [this, self = this->shared_from_this(), &socket, session_life_keeper = force_move(session_life_keeper), props = force_move(props)]

--- a/include/mqtt/deprecated_msg.hpp
+++ b/include/mqtt/deprecated_msg.hpp
@@ -5,26 +5,26 @@
 "suback(\n" \
 "    packet_id_t packet_id,\n" \
 "    variant<suback_reason_code, v5::suback_reason_code> reason,\n" \
-"    std::vector<v5::property_variant> props = {}\n" \
+"    v5::properties props = {}\n" \
 ")\n" \
 "or\n" \
 "suback(\n" \
 "    packet_id_t packet_id,\n" \
 "    variant<std::vector<suback_reason_code>, std::vector<v5::suback_reason_code>> reasons,\n" \
-"    std::vector<v5::property_variant> props = {}\n" \
+"    v5::properties props = {}\n" \
 ")\n"
 
 #define MQTT_DEPRECATED_MSG_UNSUBACK "Use\n"   \
 "unsuback(\n" \
 "    packet_id_t packet_id,\n" \
 "    variant<unsuback_reason_code, v5::unsuback_reason_code> reason,\n" \
-"    std::vector<v5::property_variant> props = {}\n" \
+"    v5::properties props = {}\n" \
 ")\n" \
 "or\n" \
 "unsuback(\n" \
 "    packet_id_t packet_id,\n" \
 "    variant<std::vector<unsuback_reason_code>, std::vector<v5::unsuback_reason_code>> reasons,\n" \
-"    std::vector<v5::property_variant> props = {}\n" \
+"    v5::properties props = {}\n" \
 ")\n"
 
 #define MQTT_DEPRECATED_MSG_ASYNC_SUBACK "Use\n"   \
@@ -37,7 +37,7 @@
 "async_suback(\n" \
 "    packet_id_t packet_id,\n" \
 "    variant<suback_reason_code, v5::suback_reason_code> reason,\n" \
-"    std::vector<v5::property_variant> props,\n" \
+"    v5::properties props,\n" \
 "    any session_life_keeper = any()\n" \
 ")\n" \
 "or\n" \
@@ -50,7 +50,7 @@
 "async_suback(\n" \
 "    packet_id_t packet_id,\n" \
 "    variant<std::vector<suback_reason_code>, std::vector<v5::suback_reason_code>> reasons,\n" \
-"    std::vector<v5::property_variant> props,\n" \
+"    v5::properties props,\n" \
 "    any session_life_keeper = any()\n" \
 ")\n"
 
@@ -64,7 +64,7 @@
 "async_unsuback(\n" \
 "    packet_id_t packet_id,\n" \
 "    variant<unsuback_reason_code, v5::unsuback_reason_code> reason,\n" \
-"    std::vector<v5::property_variant> props,\n" \
+"    v5::properties props,\n" \
 "    any session_life_keeper = any()\n" \
 ")\n" \
 "or\n" \
@@ -77,7 +77,7 @@
 "async_unsuback(\n" \
 "    packet_id_t packet_id,\n" \
 "    variant<std::vector<unsuback_reason_code>, std::vector<v5::unsuback_reason_code>> reasons,\n" \
-"    std::vector<v5::property_variant> props,\n" \
+"    v5::properties props,\n" \
 "    any session_life_keeper = any()\n" \
 ")\n"
 

--- a/include/mqtt/endpoint.hpp
+++ b/include/mqtt/endpoint.hpp
@@ -348,7 +348,7 @@ public:
                                MQTT_NS::optional<will> will,
                                bool clean_start,
                                std::uint16_t keep_alive,
-                               std::vector<v5::property_variant> props) = 0;
+                               v5::properties props) = 0;
 
     /**
      * @brief Connack handler
@@ -368,7 +368,7 @@ public:
      */
     virtual bool on_v5_connack(bool session_present,
                                v5::connect_reason_code reason_code,
-                               std::vector<v5::property_variant> props) = 0;
+                               v5::properties props) = 0;
 
     /**
      * @brief Publish handler
@@ -401,7 +401,7 @@ public:
                                MQTT_NS::optional<packet_id_t> packet_id,
                                MQTT_NS::buffer topic_name,
                                MQTT_NS::buffer contents,
-                               std::vector<v5::property_variant> props) = 0;
+                               v5::properties props) = 0;
 
     /**
      * @brief Puback handler
@@ -421,7 +421,7 @@ public:
      */
     virtual bool on_v5_puback(packet_id_t packet_id,
                               v5::puback_reason_code reason_code,
-                              std::vector<v5::property_variant> props) = 0;
+                              v5::properties props) = 0;
 
     /**
      * @brief Pubrec handler
@@ -441,7 +441,7 @@ public:
      */
     virtual bool on_v5_pubrec(packet_id_t packet_id,
                               v5::pubrec_reason_code reason_code,
-                              std::vector<v5::property_variant> props) = 0;
+                              v5::properties props) = 0;
 
     /**
      * @brief Pubrel handler
@@ -461,7 +461,7 @@ public:
      */
     virtual bool on_v5_pubrel(packet_id_t packet_id,
                               v5::pubrel_reason_code reason_code,
-                              std::vector<v5::property_variant> props) = 0;
+                              v5::properties props) = 0;
 
     /**
      * @brief Pubcomp handler
@@ -481,7 +481,7 @@ public:
      */
     virtual bool on_v5_pubcomp(packet_id_t packet_id,
                                v5::pubcomp_reason_code reason_code,
-                               std::vector<v5::property_variant> props) = 0;
+                               v5::properties props) = 0;
 
     /**
      * @brief Subscribe handler
@@ -499,7 +499,7 @@ public:
      */
     virtual bool on_v5_subscribe(packet_id_t packet_id,
                                  std::vector<std::tuple<MQTT_NS::buffer, subscribe_options>> entries,
-                                 std::vector<v5::property_variant> props) = 0;
+                                 v5::properties props) = 0;
 
     /**
      * @brief Suback handler
@@ -518,7 +518,7 @@ public:
      */
     virtual bool on_v5_suback(packet_id_t packet_id,
                               std::vector<MQTT_NS::v5::suback_reason_code> reasons,
-                              std::vector<v5::property_variant> props) = 0;
+                              v5::properties props) = 0;
 
     /**
      * @brief Unsubscribe handler
@@ -537,7 +537,7 @@ public:
      */
     virtual bool on_v5_unsubscribe(packet_id_t packet_id,
                                    std::vector<MQTT_NS::buffer> topics,
-                                   std::vector<v5::property_variant> props) = 0;
+                                   v5::properties props) = 0;
 
     /**
      * @brief Unsuback handler
@@ -556,7 +556,7 @@ public:
      */
     virtual bool on_v5_unsuback(packet_id_t,
                                 std::vector<v5::unsuback_reason_code> reasons,
-                                std::vector<v5::property_variant> props) = 0;
+                                v5::properties props) = 0;
 
     /**
      * @brief Disconnect handler
@@ -572,7 +572,7 @@ public:
      *        3.14.2.2 DISCONNECT Properties
      */
     virtual void on_v5_disconnect(v5::disconnect_reason_code reason_code,
-                                  std::vector<v5::property_variant> props) = 0;
+                                  v5::properties props) = 0;
 
     /**
      * @brief Auth handler
@@ -589,7 +589,7 @@ public:
      * @return if the handler returns true, then continue receiving, otherwise quit.
      */
     virtual bool on_v5_auth(v5::auth_reason_code reason_code,
-                            std::vector<v5::property_variant> props) = 0;
+                            v5::properties props) = 0;
 
     // Original handlers
 
@@ -777,7 +777,7 @@ public:
         std::string contents,
         qos qos_value = qos::at_most_once,
         bool retain = false,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         BOOST_ASSERT(qos_value == qos::at_most_once || qos_value == qos::at_least_once || qos_value == qos::exactly_once);
         if(qos_value == qos::at_most_once) {
@@ -832,7 +832,7 @@ public:
         any life_keeper,
         qos qos_value = qos::at_most_once,
         bool retain = false,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         BOOST_ASSERT(qos_value == qos::at_most_once || qos_value == qos::at_least_once || qos_value == qos::exactly_once);
         if(qos_value == qos::at_most_once) {
@@ -870,7 +870,7 @@ public:
         buffer contents,
         qos qos_value = qos::at_most_once,
         bool retain = false,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         BOOST_ASSERT(qos_value == qos::at_most_once || qos_value == qos::at_least_once || qos_value == qos::exactly_once);
         packet_id_t packet_id = (qos_value == qos::at_most_once) ? 0 : acquire_unique_packet_id();
@@ -898,7 +898,7 @@ public:
     packet_id_t subscribe(
         string_view topic_name,
         subscribe_options option,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         packet_id_t packet_id = acquire_unique_packet_id();
         acquired_subscribe(packet_id, topic_name, option, force_move(props));
@@ -925,7 +925,7 @@ public:
     packet_id_t subscribe(
         as::const_buffer topic_name,
         subscribe_options option,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         packet_id_t packet_id = acquire_unique_packet_id();
         acquired_subscribe(packet_id, topic_name, option, force_move(props));
@@ -952,7 +952,7 @@ public:
     packet_id_t subscribe(
         buffer topic_name,
         subscribe_options option,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         packet_id_t packet_id = acquire_unique_packet_id();
         acquired_subscribe(packet_id, force_move(topic_name), option, force_move(props));
@@ -975,7 +975,7 @@ public:
      */
     packet_id_t subscribe(
         std::vector<std::tuple<string_view, subscribe_options>> params,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         packet_id_t packet_id = acquire_unique_packet_id();
         std::vector<std::tuple<buffer, subscribe_options>> buf_params;
@@ -1004,7 +1004,7 @@ public:
      */
     packet_id_t subscribe(
         std::vector<std::tuple<as::const_buffer, subscribe_options>> params,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         packet_id_t packet_id = acquire_unique_packet_id();
         acquired_subscribe(packet_id, force_move(params), force_move(props));
@@ -1027,7 +1027,7 @@ public:
      */
     packet_id_t subscribe(
         std::vector<std::tuple<buffer, subscribe_options>> params,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         packet_id_t packet_id = acquire_unique_packet_id();
         acquired_subscribe(packet_id, force_move(params), force_move(props));
@@ -1049,7 +1049,7 @@ public:
      */
     packet_id_t unsubscribe(
         string_view topic_name,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         return unsubscribe(as::buffer(topic_name.data(), topic_name.size()), force_move(props));
     }
@@ -1069,7 +1069,7 @@ public:
      */
     packet_id_t unsubscribe(
         as::const_buffer topic_name,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         packet_id_t packet_id = acquire_unique_packet_id();
         acquired_unsubscribe(packet_id, topic_name, force_move(props));
@@ -1091,7 +1091,7 @@ public:
      */
     packet_id_t unsubscribe(
         buffer topic_name,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         packet_id_t packet_id = acquire_unique_packet_id();
         acquired_unsubscribe(packet_id, force_move(topic_name), force_move(props));
@@ -1112,7 +1112,7 @@ public:
      */
     packet_id_t unsubscribe(
         std::vector<string_view> params,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         std::vector<buffer> buf_params;
         buf_params.reserve(params.size());
@@ -1139,7 +1139,7 @@ public:
      */
     packet_id_t unsubscribe(
         std::vector<as::const_buffer> params,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         packet_id_t packet_id = acquire_unique_packet_id();
         acquired_unsubscribe(packet_id, force_move(params), force_move(props));
@@ -1160,7 +1160,7 @@ public:
      */
     packet_id_t unsubscribe(
         std::vector<buffer> params,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         packet_id_t packet_id = acquire_unique_packet_id();
         acquired_unsubscribe(packet_id, force_move(params), force_move(props));
@@ -1184,7 +1184,7 @@ public:
      */
     void disconnect(
         v5::disconnect_reason_code reason = v5::disconnect_reason_code::normal_disconnection,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         if (connected_ && mqtt_connected_) {
             disconnect_requested_ = true;
@@ -1232,7 +1232,7 @@ public:
         std::string contents,
         qos qos_value = qos::at_most_once,
         bool retain = false,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         auto sp_topic    = std::make_shared<std::string>(force_move(topic_name));
         auto sp_contents = std::make_shared<std::string>(force_move(contents));
@@ -1273,7 +1273,7 @@ public:
         any life_keeper,
         qos qos_value = qos::at_most_once,
         bool retain = false,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         BOOST_ASSERT(qos_value == qos::at_most_once || qos_value == qos::at_least_once || qos_value == qos::exactly_once);
         if (register_packet_id(packet_id)) {
@@ -1313,7 +1313,7 @@ public:
         any life_keeper,
         qos qos_value = qos::at_most_once,
         bool retain = false,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         BOOST_ASSERT(qos_value == qos::at_most_once || qos_value == qos::at_least_once || qos_value == qos::exactly_once);
         if (register_packet_id(packet_id)) {
@@ -1350,7 +1350,7 @@ public:
         std::string contents,
         qos qos_value = qos::at_most_once,
         bool retain = false,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         auto sp_topic    = std::make_shared<std::string>(force_move(topic_name));
         auto sp_contents = std::make_shared<std::string>(force_move(contents));
@@ -1391,7 +1391,7 @@ public:
         any life_keeper,
         qos qos_value = qos::at_most_once,
         bool retain = false,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         BOOST_ASSERT(qos_value == qos::at_most_once || qos_value == qos::at_least_once || qos_value == qos::exactly_once);
         if (register_packet_id(packet_id)) {
@@ -1428,7 +1428,7 @@ public:
         buffer contents,
         qos qos_value = qos::at_most_once,
         bool retain = false,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         BOOST_ASSERT(qos_value == qos::at_most_once || qos_value == qos::at_least_once || qos_value == qos::exactly_once);
         if (register_packet_id(packet_id)) {
@@ -1461,7 +1461,7 @@ public:
         packet_id_t packet_id,
         string_view topic_name,
         subscribe_options option,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         if (register_packet_id(packet_id)) {
             acquired_subscribe(packet_id, topic_name, option, force_move(props));
@@ -1493,7 +1493,7 @@ public:
         packet_id_t packet_id,
         as::const_buffer topic_name,
         subscribe_options option,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         if (register_packet_id(packet_id)) {
             acquired_subscribe(packet_id, topic_name, option, force_move(props));
@@ -1519,7 +1519,7 @@ public:
     bool subscribe(
         packet_id_t packet_id,
         std::vector<std::tuple<string_view, subscribe_options>> params,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         if (register_packet_id(packet_id)) {
             std::vector<std::tuple<buffer, subscribe_options>> buf_params;
@@ -1551,7 +1551,7 @@ public:
     bool subscribe(
         packet_id_t packet_id,
         std::vector<std::tuple<as::const_buffer, subscribe_options>> params,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         if (register_packet_id(packet_id)) {
             acquired_subscribe(packet_id, force_move(params), force_move(props));
@@ -1577,7 +1577,7 @@ public:
     bool subscribe(
         packet_id_t packet_id,
         std::vector<std::tuple<buffer, subscribe_options>> params,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         if (register_packet_id(packet_id)) {
             acquired_subscribe(packet_id, force_move(params), force_move(props));
@@ -1604,7 +1604,7 @@ public:
     bool unsubscribe(
         packet_id_t packet_id,
         string_view topic_name,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         if (register_packet_id(packet_id)) {
             acquired_unsubscribe(packet_id, topic_name, force_move(props));
@@ -1631,7 +1631,7 @@ public:
     bool unsubscribe(
         packet_id_t packet_id,
         as::const_buffer topic_name,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         if (register_packet_id(packet_id)) {
             acquired_unsubscribe(packet_id, topic_name, force_move(props));
@@ -1657,7 +1657,7 @@ public:
     bool unsubscribe(
         packet_id_t packet_id,
         std::vector<string_view> params,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         if (register_packet_id(packet_id)) {
             std::vector<buffer> buf_params;
@@ -1689,7 +1689,7 @@ public:
     bool unsubscribe(
         packet_id_t packet_id,
         std::vector<as::const_buffer> params,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         if (register_packet_id(packet_id)) {
             acquired_unsubscribe(packet_id, force_move(params), force_move(props));
@@ -1715,7 +1715,7 @@ public:
     bool unsubscribe(
         packet_id_t packet_id,
         std::vector<buffer> params,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         if (register_packet_id(packet_id)) {
             acquired_unsubscribe(packet_id, force_move(params), force_move(props));
@@ -1753,7 +1753,7 @@ public:
         std::string contents,
         qos qos_value = qos::at_most_once,
         bool retain = false,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         if(qos_value == qos::at_most_once) {
             // In the at_most_once case, we know a priori that send_publish won't track the lifetime.
@@ -1812,7 +1812,7 @@ public:
         any life_keeper,
         qos qos_value = qos::at_most_once,
         bool retain = false,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         BOOST_ASSERT(qos_value == qos::at_most_once || qos_value == qos::at_least_once || qos_value == qos::exactly_once);
         BOOST_ASSERT((qos_value == qos::at_most_once && packet_id == 0) || (qos_value != qos::at_most_once && packet_id != 0));
@@ -1856,7 +1856,7 @@ public:
         buffer contents,
         qos qos_value = qos::at_most_once,
         bool retain = false,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         BOOST_ASSERT(qos_value == qos::at_most_once || qos_value == qos::at_least_once || qos_value == qos::exactly_once);
         BOOST_ASSERT((qos_value == qos::at_most_once && packet_id == 0) || (qos_value != qos::at_most_once && packet_id != 0));
@@ -1900,7 +1900,7 @@ public:
         std::string contents,
         qos qos_value = qos::at_most_once,
         bool retain = false,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         if(qos_value == qos::at_most_once)
         {
@@ -1961,7 +1961,7 @@ public:
         any life_keeper,
         qos qos_value = qos::at_most_once,
         bool retain = false,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         BOOST_ASSERT(qos_value == qos::at_most_once || qos_value == qos::at_least_once || qos_value == qos::exactly_once);
         BOOST_ASSERT((qos_value == qos::at_most_once && packet_id == 0) || (qos_value != qos::at_most_once && packet_id != 0));
@@ -2005,7 +2005,7 @@ public:
         buffer contents,
         qos qos_value = qos::at_most_once,
         bool retain = false,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         BOOST_ASSERT(qos_value == qos::at_most_once || qos_value == qos::at_least_once || qos_value == qos::exactly_once);
         BOOST_ASSERT((qos_value == qos::at_most_once && packet_id == 0) || (qos_value != qos::at_most_once && packet_id != 0));
@@ -2044,7 +2044,7 @@ public:
         packet_id_t packet_id,
         string_view topic_name,
         subscribe_options option,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         std::vector<std::tuple<buffer, subscribe_options>> params;
         send_subscribe(force_move(params), packet_id, topic_name, option, force_move(props));
@@ -2072,7 +2072,7 @@ public:
         packet_id_t packet_id,
         as::const_buffer topic_name,
         subscribe_options option,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         std::vector<std::tuple<buffer, subscribe_options>> params;
         send_subscribe(force_move(params), packet_id, topic_name, option, force_move(props));
@@ -2094,7 +2094,7 @@ public:
     void acquired_subscribe(
         packet_id_t packet_id,
         std::vector<std::tuple<string_view, subscribe_options>> params,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         std::vector<std::tuple<buffer, subscribe_options>> cb_params;
         cb_params.reserve(params.size());
@@ -2120,7 +2120,7 @@ public:
     void acquired_subscribe(
         packet_id_t packet_id,
         std::vector<std::tuple<buffer, subscribe_options>> params,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         send_subscribe(force_move(params), packet_id, force_move(props));
     }
@@ -2142,7 +2142,7 @@ public:
     void acquired_unsubscribe(
         packet_id_t packet_id,
         string_view topic_name,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
 
         std::vector<buffer> params;
@@ -2167,7 +2167,7 @@ public:
     void acquired_unsubscribe(
         packet_id_t packet_id,
         as::const_buffer topic_name,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
 
         std::vector<buffer> params;
@@ -2191,7 +2191,7 @@ public:
     void acquired_unsubscribe(
         packet_id_t packet_id,
         std::vector<string_view> params,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         std::vector<buffer> cb_params;
         cb_params.reserve(params.size());
@@ -2218,7 +2218,7 @@ public:
     void acquired_unsubscribe(
         packet_id_t packet_id,
         std::vector<as::const_buffer> params,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         std::vector<buffer> cb_params;
         cb_params.reserve(params.size());
@@ -2245,7 +2245,7 @@ public:
     void acquired_unsubscribe(
         packet_id_t packet_id,
         std::vector<buffer> params,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         send_unsubscribe(force_move(params), packet_id, force_move(props));
     }
@@ -2280,7 +2280,7 @@ public:
      */
     void auth(
         v5::auth_reason_code reason_code = v5::auth_reason_code::success,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         send_auth(reason_code, force_move(props));
     }
@@ -2321,7 +2321,7 @@ public:
         optional<std::string> const& password,
         optional<will> w,
         std::uint16_t keep_alive_sec,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         connect_requested_ = true;
         send_connect(
@@ -2384,7 +2384,7 @@ public:
         optional<buffer> password,
         optional<will> w,
         std::uint16_t keep_alive_sec,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         connect_requested_ = true;
         send_connect(
@@ -2410,7 +2410,7 @@ public:
     void connack(
         bool session_present,
         variant<connect_return_code, v5::connect_reason_code> reason_code,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         send_connack(session_present, reason_code, force_move(props));
     }
@@ -2430,7 +2430,7 @@ public:
     void puback(
         packet_id_t packet_id,
         v5::puback_reason_code reason_code = v5::puback_reason_code::success,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         send_puback(packet_id, reason_code, force_move(props));
     }
@@ -2450,7 +2450,7 @@ public:
     void pubrec(
         packet_id_t packet_id,
         v5::pubrec_reason_code reason_code = v5::pubrec_reason_code::success,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         send_pubrec(packet_id, reason_code, force_move(props));
     }
@@ -2473,7 +2473,7 @@ public:
     void pubrel(
         packet_id_t packet_id,
         v5::pubrel_reason_code reason_code = v5::pubrel_reason_code::success,
-        std::vector<v5::property_variant> props = {},
+        v5::properties props = {},
         any life_keeper = any()
     ) {
         send_pubrel(packet_id, reason_code, force_move(props), force_move(life_keeper));
@@ -2494,7 +2494,7 @@ public:
     void pubcomp(
         packet_id_t packet_id,
         v5::pubcomp_reason_code reason_code = v5::pubcomp_reason_code::success,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         send_pubcomp(packet_id, reason_code, force_move(props));
     }
@@ -2514,7 +2514,7 @@ public:
     void suback(
         packet_id_t packet_id,
         variant<suback_return_code, v5::suback_reason_code> reason,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         variant<std::vector<suback_return_code>, std::vector<v5::suback_reason_code>> params;
         send_suback(force_move(params), packet_id, std::move(reason), std::move(props));
@@ -2535,7 +2535,7 @@ public:
     void suback(
         packet_id_t packet_id,
         variant<std::vector<suback_return_code>, std::vector<v5::suback_reason_code>> reasons,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         send_suback(force_move(reasons), packet_id, force_move(props));
     }
@@ -2565,7 +2565,7 @@ public:
     void unsuback(
         packet_id_t packet_id,
         v5::unsuback_reason_code reason,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         send_unsuback(std::vector<v5::unsuback_reason_code>{}, packet_id, reason, std::move(reason), std::move(props));
     }
@@ -2585,7 +2585,7 @@ public:
     void unsuback(
         packet_id_t packet_id,
         std::vector<v5::unsuback_reason_code> reasons,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         send_unsuback(force_move(reasons), packet_id, force_move(props));
     }
@@ -2646,7 +2646,7 @@ public:
         std::string contents,
         qos qos_value,
         bool retain,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         BOOST_ASSERT(qos_value == qos::at_most_once || qos_value == qos::at_least_once || qos_value == qos::exactly_once);
@@ -2717,7 +2717,7 @@ public:
         any life_keeper,
         qos qos_value,
         bool retain,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         BOOST_ASSERT(qos_value == qos::at_most_once || qos_value == qos::at_least_once || qos_value == qos::exactly_once);
@@ -2782,7 +2782,7 @@ public:
         buffer contents,
         qos qos_value,
         bool retain,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         BOOST_ASSERT(qos_value == qos::at_most_once || qos_value == qos::at_least_once || qos_value == qos::exactly_once);
@@ -2839,7 +2839,7 @@ public:
     packet_id_t async_subscribe(
         std::string topic_name,
         subscribe_options option,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         packet_id_t packet_id = acquire_unique_packet_id();
@@ -2894,7 +2894,7 @@ public:
     packet_id_t async_subscribe(
         as::const_buffer topic_name,
         subscribe_options option,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         packet_id_t packet_id = acquire_unique_packet_id();
@@ -2949,7 +2949,7 @@ public:
     packet_id_t async_subscribe(
         buffer topic_name,
         subscribe_options option,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         packet_id_t packet_id = acquire_unique_packet_id();
@@ -2998,7 +2998,7 @@ public:
      */
     packet_id_t async_subscribe(
         std::vector<std::tuple<std::string, subscribe_options>> const& params,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         packet_id_t packet_id = acquire_unique_packet_id();
@@ -3047,7 +3047,7 @@ public:
      */
     packet_id_t async_subscribe(
         std::vector<std::tuple<as::const_buffer, subscribe_options>> const& params,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         packet_id_t packet_id = acquire_unique_packet_id();
@@ -3096,7 +3096,7 @@ public:
      */
     packet_id_t async_subscribe(
         std::vector<std::tuple<buffer, subscribe_options>> params,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         packet_id_t packet_id = acquire_unique_packet_id();
@@ -3141,7 +3141,7 @@ public:
      */
     packet_id_t async_unsubscribe(
         std::string topic_name,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         packet_id_t packet_id = acquire_unique_packet_id();
@@ -3186,7 +3186,7 @@ public:
      */
     packet_id_t async_unsubscribe(
         as::const_buffer topic_name,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         packet_id_t packet_id = acquire_unique_packet_id();
@@ -3231,7 +3231,7 @@ public:
      */
     packet_id_t async_unsubscribe(
         buffer topic_name,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         packet_id_t packet_id = acquire_unique_packet_id();
@@ -3276,7 +3276,7 @@ public:
      */
     packet_id_t async_unsubscribe(
         std::vector<std::string> const& params,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         packet_id_t packet_id = acquire_unique_packet_id();
@@ -3321,7 +3321,7 @@ public:
      */
     packet_id_t async_unsubscribe(
         std::vector<as::const_buffer> const& params,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         packet_id_t packet_id = acquire_unique_packet_id();
@@ -3366,7 +3366,7 @@ public:
      */
     packet_id_t async_unsubscribe(
         std::vector<buffer> params,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         packet_id_t packet_id = acquire_unique_packet_id();
@@ -3389,7 +3389,7 @@ public:
             disconnect_requested_ = true;
             // The reason code and property vector are only used if we're using mqttv5.
             async_send_disconnect(v5::disconnect_reason_code::normal_disconnection,
-                                  std::vector<v5::property_variant>{},
+                                  v5::properties{},
                                   force_move(func));
         }
     }
@@ -3412,7 +3412,7 @@ public:
      */
     void async_disconnect(
         v5::disconnect_reason_code reason,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         if (connected_ && mqtt_connected_) {
@@ -3487,7 +3487,7 @@ public:
         std::string contents,
         qos qos_value,
         bool retain,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         BOOST_ASSERT(qos_value == qos::at_most_once || qos_value == qos::at_least_once || qos_value == qos::exactly_once);
@@ -3567,7 +3567,7 @@ public:
         any life_keeper,
         qos qos_value,
         bool retain,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         BOOST_ASSERT(qos_value == qos::at_most_once || qos_value == qos::at_least_once || qos_value == qos::exactly_once);
@@ -3641,7 +3641,7 @@ public:
         buffer contents,
         qos qos_value,
         bool retain,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         BOOST_ASSERT(qos_value == qos::at_most_once || qos_value == qos::at_least_once || qos_value == qos::exactly_once);
@@ -3716,7 +3716,7 @@ public:
         std::string contents,
         qos qos_value,
         bool retain,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         BOOST_ASSERT(qos_value == qos::at_most_once || qos_value == qos::at_least_once || qos_value == qos::exactly_once);
@@ -3796,7 +3796,7 @@ public:
         any life_keeper,
         qos qos_value,
         bool retain,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         BOOST_ASSERT(qos_value == qos::at_most_once || qos_value == qos::at_least_once || qos_value == qos::exactly_once);
@@ -3870,7 +3870,7 @@ public:
         buffer contents,
         qos qos_value,
         bool retain,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         BOOST_ASSERT(qos_value == qos::at_most_once || qos_value == qos::at_least_once || qos_value == qos::exactly_once);
@@ -3936,7 +3936,7 @@ public:
         packet_id_t packet_id,
         std::string topic_name,
         subscribe_options option,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         if (register_packet_id(packet_id)) {
@@ -4001,7 +4001,7 @@ public:
         packet_id_t packet_id,
         as::const_buffer topic_name,
         subscribe_options option,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         if (register_packet_id(packet_id)) {
@@ -4066,7 +4066,7 @@ public:
         packet_id_t packet_id,
         buffer topic_name,
         subscribe_options option,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         if (register_packet_id(packet_id)) {
@@ -4123,7 +4123,7 @@ public:
     bool async_subscribe(
         packet_id_t packet_id,
         std::vector<std::tuple<std::string, subscribe_options>> const& params,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         if (register_packet_id(packet_id)) {
@@ -4180,7 +4180,7 @@ public:
     bool async_subscribe(
         packet_id_t packet_id,
         std::vector<std::tuple<as::const_buffer, subscribe_options>> const& params,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         if (register_packet_id(packet_id)) {
@@ -4237,7 +4237,7 @@ public:
     bool async_subscribe(
         packet_id_t packet_id,
         std::vector<std::tuple<buffer, subscribe_options>> params,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         if (register_packet_id(packet_id)) {
@@ -4292,7 +4292,7 @@ public:
     bool async_unsubscribe(
         packet_id_t packet_id,
         buffer topic_name,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         if (register_packet_id(packet_id)) {
@@ -4347,7 +4347,7 @@ public:
     bool async_unsubscribe(
         packet_id_t packet_id,
         std::vector<std::string> const& params,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         if (register_packet_id(packet_id)) {
@@ -4402,7 +4402,7 @@ public:
     bool async_unsubscribe(
         packet_id_t packet_id,
         std::vector<as::const_buffer> const& params,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         if (register_packet_id(packet_id)) {
@@ -4457,7 +4457,7 @@ public:
     bool async_unsubscribe(
         packet_id_t packet_id,
         std::vector<buffer> params,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         if (register_packet_id(packet_id)) {
@@ -4510,7 +4510,7 @@ public:
             retain,
             false,
             packet_id,
-            std::vector<v5::property_variant>{},
+            v5::properties{},
             buffer(sv_contents),
             force_move(func),
             std::make_pair(force_move(sp_topic_name), force_move(sp_contents))
@@ -4546,7 +4546,7 @@ public:
         std::string contents,
         qos qos_value,
         bool retain,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         BOOST_ASSERT(qos_value == qos::at_most_once || qos_value == qos::at_least_once || qos_value == qos::exactly_once);
@@ -4609,7 +4609,7 @@ public:
             retain,
             false,
             packet_id,
-            std::vector<v5::property_variant>{},
+            v5::properties{},
             buffer(string_view(get_pointer(contents), get_size(contents))),
             force_move(func),
             force_move(life_keeper)
@@ -4648,7 +4648,7 @@ public:
         any life_keeper,
         qos qos_value,
         bool retain,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         BOOST_ASSERT(qos_value == qos::at_most_once || qos_value == qos::at_least_once || qos_value == qos::exactly_once);
@@ -4703,7 +4703,7 @@ public:
             retain,
             false,
             packet_id,
-            std::vector<v5::property_variant>{},
+            v5::properties{},
             force_move(contents),
             force_move(func),
             any()
@@ -4739,7 +4739,7 @@ public:
         buffer contents,
         qos qos_value,
         bool retain,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         BOOST_ASSERT(qos_value == qos::at_most_once || qos_value == qos::at_least_once || qos_value == qos::exactly_once);
@@ -4799,7 +4799,7 @@ public:
             retain,
             true,
             packet_id,
-            std::vector<v5::property_variant>{},
+            v5::properties{},
             buffer(sv_contents),
             force_move(func),
             std::make_pair(force_move(sp_topic_name), force_move(sp_contents))
@@ -4835,7 +4835,7 @@ public:
         std::string contents,
         qos qos_value,
         bool retain,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         BOOST_ASSERT(qos_value == qos::at_most_once || qos_value == qos::at_least_once || qos_value == qos::exactly_once);
@@ -4897,7 +4897,7 @@ public:
             retain,
             true,
             packet_id,
-            std::vector<v5::property_variant>{},
+            v5::properties{},
             buffer(string_view(get_pointer(contents), get_size(contents))),
             force_move(func),
             force_move(life_keeper)
@@ -4936,7 +4936,7 @@ public:
         any life_keeper,
         qos qos_value,
         bool retain,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         BOOST_ASSERT(qos_value == qos::at_most_once || qos_value == qos::at_least_once || qos_value == qos::exactly_once);
@@ -4990,7 +4990,7 @@ public:
             retain,
             true,
             packet_id,
-            std::vector<v5::property_variant>{},
+            v5::properties{},
             force_move(contents),
             force_move(func),
             any()
@@ -5028,7 +5028,7 @@ public:
         buffer contents,
         qos qos_value,
         bool retain,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         BOOST_ASSERT(qos_value == qos::at_most_once || qos_value == qos::at_least_once || qos_value == qos::exactly_once);
@@ -5108,7 +5108,7 @@ public:
         packet_id_t packet_id,
         std::string topic_name,
         subscribe_options option,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         auto sp_topic_name = std::make_shared<std::string>(force_move(topic_name));
@@ -5182,7 +5182,7 @@ public:
         packet_id_t packet_id,
         as::const_buffer topic_name,
         subscribe_options option,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
 
@@ -5259,7 +5259,7 @@ public:
         packet_id_t packet_id,
         buffer topic_name,
         subscribe_options option,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
 
@@ -5337,7 +5337,7 @@ public:
     void acquired_async_subscribe(
         packet_id_t packet_id,
         std::vector<std::tuple<std::string, subscribe_options>> params,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
 
@@ -5418,7 +5418,7 @@ public:
     void acquired_async_subscribe(
         packet_id_t packet_id,
         std::vector<std::tuple<as::const_buffer, subscribe_options>> params,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
 
@@ -5498,7 +5498,7 @@ public:
     void acquired_async_subscribe(
         packet_id_t packet_id,
         std::vector<std::tuple<buffer, subscribe_options>> params,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
 
@@ -5597,7 +5597,7 @@ public:
     void acquired_async_unsubscribe(
         packet_id_t packet_id,
         buffer topic_name,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         std::vector<buffer> params { force_move(topic_name) };
@@ -5660,7 +5660,7 @@ public:
     void acquired_async_unsubscribe(
         packet_id_t packet_id,
         std::vector<std::string> params,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
 
@@ -5743,7 +5743,7 @@ public:
     void acquired_async_unsubscribe(
         packet_id_t packet_id,
         std::vector<as::const_buffer> params,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
 
@@ -5801,7 +5801,7 @@ public:
     void acquired_async_unsubscribe(
         packet_id_t packet_id,
         std::vector<buffer> params,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
 
@@ -5850,7 +5850,7 @@ public:
      */
     void async_auth(
         v5::auth_reason_code reason_code = v5::auth_reason_code::success,
-        std::vector<v5::property_variant> props = {},
+        v5::properties props = {},
         async_handler_t func = async_handler_t()) {
         async_send_auth(reason_code, force_move(props), force_move(func));
     }
@@ -5891,7 +5891,7 @@ public:
             force_move(password),
             force_move(w),
             keep_alive_sec,
-            std::vector<v5::property_variant>{},
+            v5::properties{},
             force_move(func));
     }
 
@@ -5928,7 +5928,7 @@ public:
         optional<buffer> password,
         optional<will> w,
         std::uint16_t keep_alive_sec,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         connect_requested_ = true;
@@ -5954,7 +5954,7 @@ public:
         variant<connect_return_code, v5::connect_reason_code> reason_code,
         async_handler_t func = async_handler_t()
     ) {
-        async_send_connack(session_present, reason_code, std::vector<v5::property_variant>{}, force_move(func));
+        async_send_connack(session_present, reason_code, v5::properties{}, force_move(func));
     }
 
     /**
@@ -5972,7 +5972,7 @@ public:
     void async_connack(
         bool session_present,
         variant<connect_return_code, v5::connect_reason_code> reason_code,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         async_send_connack(session_present, reason_code, force_move(props), force_move(func));
@@ -5989,7 +5989,7 @@ public:
         packet_id_t packet_id,
         async_handler_t func = async_handler_t()
     ) {
-        async_send_puback(packet_id, v5::puback_reason_code::success, std::vector<v5::property_variant>{}, force_move(func));
+        async_send_puback(packet_id, v5::puback_reason_code::success, v5::properties{}, force_move(func));
     }
 
     /**
@@ -6010,7 +6010,7 @@ public:
     void async_puback(
         packet_id_t packet_id,
         v5::puback_reason_code reason_code,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         async_send_puback(packet_id, reason_code, force_move(props), force_move(func));
@@ -6027,7 +6027,7 @@ public:
         packet_id_t packet_id,
         async_handler_t func = async_handler_t()
     ) {
-        async_send_pubrec(packet_id, v5::pubrec_reason_code::success, std::vector<v5::property_variant>{}, force_move(func));
+        async_send_pubrec(packet_id, v5::pubrec_reason_code::success, v5::properties{}, force_move(func));
     }
 
     /**
@@ -6048,7 +6048,7 @@ public:
     void async_pubrec(
         packet_id_t packet_id,
         v5::pubrec_reason_code reason_code,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         async_send_pubrec(packet_id, reason_code, force_move(props), force_move(func));
@@ -6065,7 +6065,7 @@ public:
         packet_id_t packet_id,
         async_handler_t func = async_handler_t()
     ) {
-        async_send_pubrel(packet_id, v5::pubrel_reason_code::success, std::vector<v5::property_variant>{}, force_move(func));
+        async_send_pubrel(packet_id, v5::pubrel_reason_code::success, v5::properties{}, force_move(func));
     }
 
     /**
@@ -6088,7 +6088,7 @@ public:
     void async_pubrel(
         packet_id_t packet_id,
         v5::pubrel_reason_code reason_code,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t(),
         any life_keeper = any()
     ) {
@@ -6106,7 +6106,7 @@ public:
         packet_id_t packet_id,
         async_handler_t func = async_handler_t()
     ) {
-        async_send_pubcomp(packet_id, v5::pubcomp_reason_code::success, std::vector<v5::property_variant>{}, force_move(func));
+        async_send_pubcomp(packet_id, v5::pubcomp_reason_code::success, v5::properties{}, force_move(func));
     }
 
     /**
@@ -6127,7 +6127,7 @@ public:
     void async_pubcomp(
         packet_id_t packet_id,
         v5::pubcomp_reason_code reason_code,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         async_send_pubcomp(packet_id, reason_code, force_move(props), force_move(func));
@@ -6149,7 +6149,7 @@ public:
         variant<suback_return_code, v5::suback_reason_code> reason,
         async_handler_t func = async_handler_t()
     ) {
-        async_send_suback(std::vector<std::uint8_t>{}, packet_id, reason, std::vector<v5::property_variant>{}, force_move(func));
+        async_send_suback(std::vector<std::uint8_t>{}, packet_id, reason, v5::properties{}, force_move(func));
     }
 
     /**
@@ -6170,7 +6170,7 @@ public:
     void async_suback(
         packet_id_t packet_id,
         variant<suback_return_code, v5::suback_reason_code> reason,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         async_send_suback(std::vector<std::uint8_t>{}, packet_id, reason, force_move(props), force_move(func));
@@ -6192,7 +6192,7 @@ public:
         variant<std::vector<suback_return_code>, std::vector<v5::suback_reason_code>> reasons,
         async_handler_t func = async_handler_t()
     ) {
-        async_send_suback(force_move(reasons), packet_id, std::vector<v5::property_variant>{}, force_move(func));
+        async_send_suback(force_move(reasons), packet_id, v5::properties{}, force_move(func));
     }
 
     /**
@@ -6213,7 +6213,7 @@ public:
     void async_suback(
         packet_id_t packet_id,
         variant<std::vector<suback_return_code>, std::vector<v5::suback_reason_code>> reasons,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         async_send_suback(force_move(reasons), packet_id, force_move(props), force_move(func));
@@ -6256,7 +6256,7 @@ public:
     void async_unsuback(
         packet_id_t packet_id,
         v5::unsuback_reason_code reason,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         async_send_unsuback(std::vector<v5::unsuback_reason_code>{}, packet_id, reason, force_move(props), force_move(func));
@@ -6278,7 +6278,7 @@ public:
         std::vector<v5::unsuback_reason_code> reasons,
         async_handler_t func = async_handler_t()
     ) {
-        async_send_unsuback(force_move(reasons), packet_id, std::vector<v5::property_variant>{}, force_move(func));
+        async_send_unsuback(force_move(reasons), packet_id, v5::properties{}, force_move(func));
     }
 
     /**
@@ -6299,7 +6299,7 @@ public:
     void async_unsuback(
         packet_id_t packet_id,
         std::vector<v5::unsuback_reason_code> reasons,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func = async_handler_t()
     ) {
         async_send_unsuback(force_move(reasons), packet_id, force_move(props), force_move(func));
@@ -7674,7 +7674,7 @@ private:
     void process_properties(
         any session_life_keeper,
         buffer buf,
-        std::function<void(std::vector<v5::property_variant>, buffer, any, this_type_sp)> handler,
+        std::function<void(v5::properties, buffer, any, this_type_sp)> handler,
         this_type_sp self
     ) {
         process_variable_length(
@@ -7690,7 +7690,7 @@ private:
                     return;
                 }
                 if (property_length == 0) {
-                    handler(std::vector<v5::property_variant>(), force_move(buf), force_move(session_life_keeper), force_move(self));
+                    handler(v5::properties(), force_move(buf), force_move(session_life_keeper), force_move(self));
                     return;
                 }
 
@@ -7735,7 +7735,7 @@ private:
                                 force_move(session_life_keeper),
                                 buffer(string_view(result.address, result.len), result.spa),
                                 property_length,
-                                std::vector<v5::property_variant>(),
+                                v5::properties(),
                                 force_move(handler),
                                 force_move(self)
                             );
@@ -7757,7 +7757,7 @@ private:
                                 force_move(session_life_keeper),
                                 force_move(buf),
                                 property_length,
-                                std::vector<v5::property_variant>(),
+                                v5::properties(),
                                 force_move(handler),
                                 force_move(self)
                             );
@@ -7773,8 +7773,8 @@ private:
         any session_life_keeper,
         buffer buf,
         std::size_t property_length_rest,
-        std::vector<v5::property_variant> props,
-        std::function<void(std::vector<v5::property_variant>, buffer, any, this_type_sp)> handler,
+        v5::properties props,
+        std::function<void(v5::properties, buffer, any, this_type_sp)> handler,
         this_type_sp self
     ) {
 
@@ -7843,8 +7843,8 @@ private:
         buffer buf,
         v5::property::id id,
         std::size_t property_length_rest,
-        std::vector<v5::property_variant> props,
-        std::function<void(std::vector<v5::property_variant>, buffer, any, this_type_sp)> handler,
+        v5::properties props,
+        std::function<void(v5::properties, buffer, any, this_type_sp)> handler,
         this_type_sp self
     ) {
 
@@ -8776,9 +8776,9 @@ private:
         std::size_t header_len;
         char connect_flag;
         std::uint16_t keep_alive;
-        std::vector<v5::property_variant> props;
+        v5::properties props;
         buffer client_id;
-        std::vector<v5::property_variant> will_props;
+        v5::properties will_props;
         buffer will_topic;
         buffer will_payload;
         optional<buffer> user_name;
@@ -8876,7 +8876,7 @@ private:
                     info = force_move(info)
                 ]
                 (
-                    std::vector<v5::property_variant> props,
+                    v5::properties props,
                     buffer buf,
                     any session_life_keeper,
                     this_type_sp self
@@ -9010,7 +9010,7 @@ private:
                         topic_message_proc
                     ]
                     (
-                         std::vector<v5::property_variant> will_props,
+                         v5::properties will_props,
                          buffer buf,
                          any session_life_keeper,
                          this_type_sp self
@@ -9152,7 +9152,7 @@ private:
         std::size_t header_len;
         bool session_present;
         variant<connect_return_code, v5::connect_reason_code> reason_code;
-        std::vector<v5::property_variant> props;
+        v5::properties props;
     };
 
     void process_connack(
@@ -9230,7 +9230,7 @@ private:
                     info = force_move(info)
                 ]
                 (
-                    std::vector<v5::property_variant> props,
+                    v5::properties props,
                     buffer buf,
                     any session_life_keeper,
                     this_type_sp self
@@ -9330,7 +9330,7 @@ private:
     struct publish_info {
         buffer topic_name;
         optional<packet_id_t> packet_id;
-        std::vector<v5::property_variant> props;
+        v5::properties props;
     };
 
     void process_publish(
@@ -9449,7 +9449,7 @@ private:
                     this,
                     info = force_move(info)
                 ]
-                (std::vector<v5::property_variant> props, buffer buf, any session_life_keeper, this_type_sp self) mutable {
+                (v5::properties props, buffer buf, any session_life_keeper, this_type_sp self) mutable {
                     info.props = force_move(props);
                     process_publish_impl<publish_phase::payload>(
                         force_move(session_life_keeper),
@@ -9523,7 +9523,7 @@ private:
                                         async_send_puback(
                                             *info.packet_id,
                                             v5::puback_reason_code::success,
-                                            std::vector<v5::property_variant>{},
+                                            v5::properties{},
                                             [session_life_keeper](auto){}
                                         );
                                     }
@@ -9545,7 +9545,7 @@ private:
                                         async_send_pubrec(
                                             *info.packet_id,
                                             v5::pubrec_reason_code::success,
-                                            std::vector<v5::property_variant>{},
+                                            v5::properties{},
                                             [session_life_keeper](auto){}
                                         );
                                     }
@@ -9573,7 +9573,7 @@ private:
     struct puback_info {
         packet_id_t packet_id;
         v5::puback_reason_code reason_code;
-        std::vector<v5::property_variant> props;
+        v5::properties props;
     };
 
     void process_puback(
@@ -9667,7 +9667,7 @@ private:
                     this,
                     info = force_move(info)
                 ]
-                (std::vector<v5::property_variant> props, buffer buf, any session_life_keeper, this_type_sp self) mutable {
+                (v5::properties props, buffer buf, any session_life_keeper, this_type_sp self) mutable {
                     info.props = force_move(props);
                     process_puback_impl<puback_phase::finish>(
                         force_move(session_life_keeper),
@@ -9718,7 +9718,7 @@ private:
     struct pubrec_info {
         packet_id_t packet_id;
         v5::pubrec_reason_code reason_code;
-        std::vector<v5::property_variant> props;
+        v5::properties props;
     };
 
     void process_pubrec(
@@ -9812,7 +9812,7 @@ private:
                     this,
                     info = force_move(info)
                 ]
-                (std::vector<v5::property_variant> props, buffer buf, any session_life_keeper, this_type_sp self) mutable {
+                (v5::properties props, buffer buf, any session_life_keeper, this_type_sp self) mutable {
                     info.props = force_move(props);
                     process_pubrec_impl<pubrec_phase::finish>(
                         force_move(session_life_keeper),
@@ -9849,7 +9849,7 @@ private:
                                 async_send_pubrel(
                                     info.packet_id,
                                     v5::pubrel_reason_code::success,
-                                    std::vector<v5::property_variant>{},
+                                    v5::properties{},
                                     [session_life_keeper](auto){}
                                 );
                             }
@@ -9891,7 +9891,7 @@ private:
     struct pubrel_info {
         packet_id_t packet_id;
         v5::pubrel_reason_code reason_code;
-        std::vector<v5::property_variant> props;
+        v5::properties props;
     };
 
     void process_pubrel(
@@ -9985,7 +9985,7 @@ private:
                     this,
                     info = force_move(info)
                 ]
-                (std::vector<v5::property_variant> props, buffer buf, any session_life_keeper, this_type_sp self) mutable {
+                (v5::properties props, buffer buf, any session_life_keeper, this_type_sp self) mutable {
                     info.props = force_move(props);
                     process_pubrel_impl<pubrel_phase::finish>(
                         force_move(session_life_keeper),
@@ -10011,7 +10011,7 @@ private:
                                 async_send_pubcomp(
                                     info.packet_id,
                                     v5::pubcomp_reason_code::success,
-                                    std::vector<v5::property_variant>{},
+                                    v5::properties{},
                                     [session_life_keeper](auto){}
                                 );
                             }
@@ -10051,7 +10051,7 @@ private:
     struct pubcomp_info {
         packet_id_t packet_id;
         v5::pubcomp_reason_code reason_code;
-        std::vector<v5::property_variant> props;
+        v5::properties props;
     };
 
     void process_pubcomp(
@@ -10145,7 +10145,7 @@ private:
                     this,
                     info = force_move(info)
                 ]
-                (std::vector<v5::property_variant> props, buffer buf, any session_life_keeper, this_type_sp self) mutable {
+                (v5::properties props, buffer buf, any session_life_keeper, this_type_sp self) mutable {
                     info.props = force_move(props);
                     process_pubcomp_impl<pubcomp_phase::finish>(
                         force_move(session_life_keeper),
@@ -10196,7 +10196,7 @@ private:
 
     struct subscribe_info {
         packet_id_t packet_id;
-        std::vector<v5::property_variant> props;
+        v5::properties props;
         std::vector<std::tuple<buffer, subscribe_options>> entries;
     };
 
@@ -10269,7 +10269,7 @@ private:
                     this,
                     info = force_move(info)
                 ]
-                (std::vector<v5::property_variant> props, buffer buf, any session_life_keeper, this_type_sp self) mutable {
+                (v5::properties props, buffer buf, any session_life_keeper, this_type_sp self) mutable {
                     info.props = force_move(props);
                     process_subscribe_impl<subscribe_phase::topic>(
                         force_move(session_life_keeper),
@@ -10361,7 +10361,7 @@ private:
 
     struct suback_info {
         packet_id_t packet_id;
-        std::vector<v5::property_variant> props;
+        v5::properties props;
     };
 
     void process_suback(
@@ -10433,7 +10433,7 @@ private:
                     this,
                     info = force_move(info)
                 ]
-                (std::vector<v5::property_variant> props, buffer buf, any session_life_keeper, this_type_sp self) mutable {
+                (v5::properties props, buffer buf, any session_life_keeper, this_type_sp self) mutable {
                     info.props = force_move(props);
                     process_suback_impl<suback_phase::reasons>(
                         force_move(session_life_keeper),
@@ -10534,7 +10534,7 @@ private:
 
     struct unsubscribe_info {
         packet_id_t packet_id;
-        std::vector<v5::property_variant> props;
+        v5::properties props;
         std::vector<buffer> entries;
     };
 
@@ -10607,7 +10607,7 @@ private:
                     this,
                     info = force_move(info)
                 ]
-                (std::vector<v5::property_variant> props, buffer buf, any session_life_keeper, this_type_sp self) mutable {
+                (v5::properties props, buffer buf, any session_life_keeper, this_type_sp self) mutable {
                     info.props = force_move(props);
                     process_unsubscribe_impl<unsubscribe_phase::topic>(
                         force_move(session_life_keeper),
@@ -10678,7 +10678,7 @@ private:
 
     struct unsuback_info {
         packet_id_t packet_id;
-        std::vector<v5::property_variant> props;
+        v5::properties props;
     };
 
     void process_unsuback(
@@ -10755,7 +10755,7 @@ private:
                     this,
                     info = force_move(info)
                 ]
-                (std::vector<v5::property_variant> props, buffer buf, any session_life_keeper, this_type_sp self) mutable {
+                (v5::properties props, buffer buf, any session_life_keeper, this_type_sp self) mutable {
                     info.props = force_move(props);
                     process_unsuback_impl<unsuback_phase::reasons>(
                         force_move(session_life_keeper),
@@ -10845,7 +10845,7 @@ private:
 
     struct disconnect_info {
         v5::disconnect_reason_code reason_code;
-        std::vector<v5::property_variant> props;
+        v5::properties props;
     };
 
     void process_disconnect(
@@ -10854,7 +10854,7 @@ private:
         this_type_sp self
     ) {
         if (remaining_length_ == 0) {
-            disconnect_info info { v5::disconnect_reason_code::normal_disconnection, std::vector<v5::property_variant>() };
+            disconnect_info info { v5::disconnect_reason_code::normal_disconnection, v5::properties() };
             process_disconnect_impl<disconnect_phase::finish>(
                 force_move(session_life_keeper),
                 buffer(),
@@ -10924,7 +10924,7 @@ private:
                     this,
                     info = force_move(info)
                 ]
-                (std::vector<v5::property_variant> props, buffer buf, any session_life_keeper, this_type_sp self) mutable {
+                (v5::properties props, buffer buf, any session_life_keeper, this_type_sp self) mutable {
                     info.props = force_move(props);
                     process_disconnect_impl<disconnect_phase::finish>(
                         force_move(session_life_keeper),
@@ -10961,7 +10961,7 @@ private:
 
     struct auth_info {
         v5::auth_reason_code reason_code;
-        std::vector<v5::property_variant> props;
+        v5::properties props;
     };
 
     void process_auth(
@@ -10978,7 +10978,7 @@ private:
             process_auth_impl<auth_phase::finish>(
                 force_move(session_life_keeper),
                 buffer(),
-                auth_info{ v5::auth_reason_code::success, std::vector<v5::property_variant>() },
+                auth_info{ v5::auth_reason_code::success, v5::properties() },
                 force_move(self)
             );
             return;
@@ -11039,7 +11039,7 @@ private:
                     this,
                     info = force_move(info)
                 ]
-                (std::vector<v5::property_variant> props, buffer buf, any session_life_keeper, this_type_sp self) mutable {
+                (v5::properties props, buffer buf, any session_life_keeper, this_type_sp self) mutable {
                     info.props = force_move(props);
                     process_auth_impl<auth_phase::finish>(
                         force_move(session_life_keeper),
@@ -11075,7 +11075,7 @@ private:
         optional<buffer> password,
         optional<will> w,
         std::uint16_t keep_alive_sec,
-        std::vector<v5::property_variant> props
+        v5::properties props
     ) {
         switch (version_) {
         case protocol_version::v3_1_1:
@@ -11112,7 +11112,7 @@ private:
     void send_connack(
         bool session_present,
         variant<connect_return_code, v5::connect_reason_code> reason_code,
-        std::vector<v5::property_variant> props
+        v5::properties props
     ) {
         switch (version_) {
         case protocol_version::v3_1_1:
@@ -11144,7 +11144,7 @@ private:
         bool retain,
         bool dup,
         packet_id_t packet_id,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         buffer payload,
         any life_keeper) {
 
@@ -11205,7 +11205,7 @@ private:
     void send_puback(
         packet_id_t packet_id,
         v5::puback_reason_code reason = v5::puback_reason_code::success,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         switch (version_) {
         case protocol_version::v3_1_1:
@@ -11225,7 +11225,7 @@ private:
     void send_pubrec(
         packet_id_t packet_id,
         v5::pubrec_reason_code reason = v5::pubrec_reason_code::success,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         switch (version_) {
         case protocol_version::v3_1_1:
@@ -11243,7 +11243,7 @@ private:
     void send_pubrel(
         packet_id_t packet_id,
         v5::pubrel_reason_code reason = v5::pubrel_reason_code::success,
-        std::vector<v5::property_variant> props = {},
+        v5::properties props = {},
         any life_keeper = any()
     ) {
 
@@ -11291,7 +11291,7 @@ private:
     void store_pubrel(
         packet_id_t packet_id,
         v5::pubrel_reason_code reason = v5::pubrel_reason_code::success,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
 
         auto impl =
@@ -11336,7 +11336,7 @@ private:
     void send_pubcomp(
         packet_id_t packet_id,
         v5::pubcomp_reason_code reason = v5::pubcomp_reason_code::success,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         switch (version_) {
         case protocol_version::v3_1_1:
@@ -11389,7 +11389,7 @@ private:
     void send_subscribe(
         std::vector<std::tuple<buffer, subscribe_options>> params,
         packet_id_t packet_id,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         for(auto const& p : params)
         {
@@ -11426,7 +11426,7 @@ private:
     void send_suback(
         variant<std::vector<suback_return_code>, std::vector<v5::suback_reason_code>> params,
         packet_id_t packet_id,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         switch (version_) {
         case protocol_version::v3_1_1:
@@ -11474,7 +11474,7 @@ private:
     void send_unsubscribe(
         std::vector<buffer> params,
         packet_id_t packet_id,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         switch (version_) {
         case protocol_version::v3_1_1:
@@ -11518,7 +11518,7 @@ private:
     void send_unsuback(
         std::vector<v5::unsuback_reason_code> params,
         packet_id_t packet_id,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         switch (version_) {
         case protocol_version::v3_1_1:
@@ -11563,7 +11563,7 @@ private:
 
     void send_auth(
         v5::auth_reason_code reason = v5::auth_reason_code::success,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         switch (version_) {
         case protocol_version::v3_1_1:
@@ -11580,7 +11580,7 @@ private:
 
     void send_disconnect(
         v5::disconnect_reason_code reason = v5::disconnect_reason_code::normal_disconnection,
-        std::vector<v5::property_variant> props = {}
+        v5::properties props = {}
     ) {
         switch (version_) {
         case protocol_version::v3_1_1:
@@ -11622,7 +11622,7 @@ private:
         optional<will> const& w,
         bool clean_session,
         std::uint16_t keep_alive_sec,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func) {
 
         clean_session_ = clean_session;
@@ -11664,7 +11664,7 @@ private:
     void async_send_connack(
         bool session_present,
         variant<connect_return_code, v5::connect_reason_code> reason_code,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func
     ) {
         switch (version_) {
@@ -11699,7 +11699,7 @@ private:
         bool retain,
         bool dup,
         packet_id_t packet_id,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         buffer payload,
         async_handler_t func,
         any life_keeper) {
@@ -11769,7 +11769,7 @@ private:
     void async_send_puback(
         packet_id_t packet_id,
         v5::puback_reason_code reason,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func
     ) {
         switch (version_) {
@@ -11802,7 +11802,7 @@ private:
     void async_send_pubrec(
         packet_id_t packet_id,
         v5::pubrec_reason_code reason,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func
     ) {
         switch (version_) {
@@ -11827,7 +11827,7 @@ private:
     void async_send_pubrel(
         packet_id_t packet_id,
         v5::pubrel_reason_code reason,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func,
         any life_keeper = any()
     ) {
@@ -11900,7 +11900,7 @@ private:
     void async_send_pubcomp(
         packet_id_t packet_id,
         v5::pubcomp_reason_code reason,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func
     ) {
         switch (version_) {
@@ -11991,7 +11991,7 @@ private:
         std::vector<std::tuple<buffer, subscribe_options>> params,
         any life_keepers,
         packet_id_t packet_id,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func) {
 
         switch (version_) {
@@ -12044,7 +12044,7 @@ private:
     void async_send_suback(
         variant<std::vector<suback_return_code>, std::vector<v5::suback_reason_code>> params,
         packet_id_t packet_id,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func
     ) {
         switch (version_) {
@@ -12130,7 +12130,7 @@ private:
         std::vector<buffer> params,
         any life_keepers,
         packet_id_t packet_id,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func) {
 
         switch (version_) {
@@ -12195,7 +12195,7 @@ private:
     void async_send_unsuback(
         std::vector<v5::unsuback_reason_code> params,
         packet_id_t packet_id,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func
     ) {
         switch (version_) {
@@ -12248,7 +12248,7 @@ private:
 
     void async_send_auth(
         v5::auth_reason_code reason,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func
     ) {
         switch (version_) {
@@ -12266,7 +12266,7 @@ private:
 
     void async_send_disconnect(
         v5::disconnect_reason_code reason,
-        std::vector<v5::property_variant> props,
+        v5::properties props,
         async_handler_t func
     ) {
         switch (version_) {

--- a/include/mqtt/property_variant.hpp
+++ b/include/mqtt/property_variant.hpp
@@ -11,6 +11,8 @@
 #include <mqtt/property.hpp>
 #include <mqtt/variant.hpp>
 
+#include <vector>
+
 namespace MQTT_NS {
 
 namespace v5 {
@@ -45,6 +47,8 @@ using property_variant = variant<
     property::subscription_identifier_available,
     property::shared_subscription_available
 >;
+
+using properties = std::vector<property_variant>;
 
 namespace property {
 

--- a/include/mqtt/v5_message.hpp
+++ b/include/mqtt/v5_message.hpp
@@ -48,8 +48,6 @@ namespace as = boost::asio;
 
 namespace v5 {
 
-using properties = std::vector<property_variant>;
-
 namespace detail {
 
 class header_only_message {

--- a/include/mqtt/will.hpp
+++ b/include/mqtt/will.hpp
@@ -35,7 +35,7 @@ public:
          buffer message,
          bool retain,
          qos qos_value,
-         std::vector<v5::property_variant> props = {})
+         v5::properties props = {})
         :topic_(force_move(topic)),
          message_(force_move(message)),
          retain_(retain),
@@ -57,7 +57,7 @@ public:
     will(buffer topic,
          buffer message,
          bool retain = false,
-         std::vector<v5::property_variant> props = {})
+         v5::properties props = {})
         :will(force_move(topic), force_move(message), retain, qos::at_most_once, force_move(props))
     {}
 
@@ -73,7 +73,7 @@ public:
     will(buffer topic,
          buffer message,
          qos qos_value,
-         std::vector<v5::property_variant> props = {})
+         v5::properties props = {})
         :will(force_move(topic), force_move(message), false, qos_value, force_move(props))
     {}
 
@@ -95,10 +95,10 @@ public:
     constexpr qos get_qos() const {
         return qos_;
     }
-    constexpr std::vector<v5::property_variant> const& props() const {
+    constexpr v5::properties const& props() const {
         return props_;
     }
-    constexpr std::vector<v5::property_variant>& props() {
+    constexpr v5::properties& props() {
         return props_;
     }
 
@@ -107,7 +107,7 @@ private:
     buffer message_;
     bool retain_ = false;
     qos qos_ = qos::at_most_once;
-    std::vector<v5::property_variant> props_;
+    v5::properties props_;
 };
 
 } // namespace MQTT_NS

--- a/test/as_buffer_async_pubsub_1.cpp
+++ b/test/as_buffer_async_pubsub_1.cpp
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -133,25 +133,25 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                 });
             c->set_v5_puback_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -167,7 +167,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -183,7 +183,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
@@ -335,7 +335,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -349,7 +349,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                 });
             c->set_v5_puback_handler(
                 [&chk, &c, &pid_pub, &pid_unsub]
-                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_puback");
                     BOOST_TEST(packet_id == pid_pub);
                     auto topic1 = std::make_shared<std::string>("topic1");
@@ -361,19 +361,19 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_pub, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -390,7 +390,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -406,7 +406,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
@@ -555,7 +555,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -569,20 +569,20 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                 });
             c->set_v5_puback_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubrec_handler(
                 [&chk, &pid_pub]
-                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_pubrec");
                     BOOST_TEST(packet_id == pid_pub);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 [&chk, &c, &pid_unsub, &pid_pub]
-                (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_pubcomp");
                     BOOST_TEST(packet_id == pid_pub);
                     auto topic1 = std::make_shared<std::string>("topic1");
@@ -594,7 +594,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == 1);
                     BOOST_TEST(reasons.size() == 1U);
@@ -611,7 +611,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -627,7 +627,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
@@ -769,7 +769,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -783,25 +783,25 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                 });
             c->set_v5_puback_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -817,7 +817,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -833,7 +833,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
@@ -994,7 +994,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -1008,26 +1008,26 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                 });
             c->set_v5_puback_handler(
                 [&chk, &pid_pub]
-                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_puback");
                     BOOST_TEST(packet_id == pid_pub);
                     return true;
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -1044,7 +1044,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -1060,7 +1060,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
@@ -1214,7 +1214,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -1228,20 +1228,20 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                 });
             c->set_v5_puback_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubrec_handler(
                 [&chk, &pid_pub]
-                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_pubrec");
                     BOOST_TEST(packet_id == pid_pub);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 [&chk, &c, &pid_pub, &pid_unsub]
-                (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_pubcomp");
                     BOOST_TEST(packet_id == pid_pub);
                     auto topic1 = std::make_shared<std::string>("topic1");
@@ -1253,7 +1253,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -1270,7 +1270,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -1286,7 +1286,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);

--- a/test/as_buffer_async_pubsub_2.cpp
+++ b/test/as_buffer_async_pubsub_2.cpp
@@ -122,7 +122,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -136,25 +136,25 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                 });
             c->set_v5_puback_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -172,7 +172,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -188,7 +188,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
@@ -350,7 +350,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -364,7 +364,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                 });
             c->set_v5_puback_handler(
                 [&chk, &c, &pid_pub, &pid_unsub]
-                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_puback");
                     BOOST_TEST(packet_id == pid_pub);
                     auto topic1 = std::make_shared<std::string>("topic1");
@@ -376,19 +376,19 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -405,7 +405,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -421,7 +421,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
@@ -577,7 +577,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -591,20 +591,20 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                 });
             c->set_v5_puback_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubrec_handler(
                 [&chk, &pid_pub]
-                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_pubrec");
                     BOOST_TEST(packet_id == pid_pub);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 [&chk, &c, &pid_pub, &pid_unsub]
-                (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_pubcomp");
                     BOOST_TEST(packet_id == pid_pub);
                     auto topic1 = std::make_shared<std::string>("topic1");
@@ -616,7 +616,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -633,7 +633,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -649,7 +649,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::exactly_once);
@@ -789,7 +789,7 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -803,25 +803,25 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
                 });
             c->set_v5_puback_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -838,7 +838,7 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -854,7 +854,7 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
@@ -997,7 +997,7 @@ BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -1011,25 +1011,25 @@ BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
                 });
             c->set_v5_puback_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -1045,7 +1045,7 @@ BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -1061,7 +1061,7 @@ BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
@@ -1209,7 +1209,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -1223,7 +1223,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                 });
             c->set_v5_puback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_puback");
                     BOOST_TEST(packet_id == 1);
                     auto topic1 = std::make_shared<std::string>("topic1");
@@ -1235,19 +1235,19 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -1266,7 +1266,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -1282,7 +1282,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false); // not propagated
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);

--- a/test/as_buffer_pubsub.cpp
+++ b/test/as_buffer_pubsub.cpp
@@ -102,7 +102,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -111,25 +111,25 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                 });
             c->set_v5_puback_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -139,7 +139,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -155,7 +155,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
@@ -291,7 +291,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -301,7 +301,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                 });
             c->set_v5_puback_handler(
                 [&chk, &c, &pub_seq_finished, &pid_pub, &pid_unsub]
-                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_puback");
                     BOOST_TEST(packet_id == pid_pub);
                     pub_seq_finished = true;
@@ -310,19 +310,19 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_pub, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -332,7 +332,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -348,7 +348,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
@@ -485,7 +485,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -494,20 +494,20 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                 });
             c->set_v5_puback_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubrec_handler(
                 [&chk, &pid_pub]
-                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_pubrec");
                     BOOST_TEST(packet_id == pid_pub);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 [&chk, &c, &pub_seq_finished, &pid_unsub, &pid_pub]
-                (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_pubcomp");
                     BOOST_TEST(packet_id == pid_pub);
                     pub_seq_finished = true;
@@ -516,7 +516,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == 1);
                     BOOST_TEST(reasons.size() == 1U);
@@ -526,7 +526,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -542,7 +542,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
@@ -670,7 +670,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -679,25 +679,25 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                 });
             c->set_v5_puback_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -707,7 +707,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -723,7 +723,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
@@ -869,7 +869,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -878,7 +878,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                 });
             c->set_v5_puback_handler(
                 [&chk, &c, &pub_seq_finished, &pid_pub, &pid_unsub]
-                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_puback");
                     BOOST_TEST(packet_id == pid_pub);
                     pub_seq_finished = true;
@@ -887,19 +887,19 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -909,7 +909,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -925,7 +925,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
@@ -1068,7 +1068,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -1077,20 +1077,20 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                 });
             c->set_v5_puback_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubrec_handler(
                 [&chk, &pid_pub]
-                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_pubrec");
                     BOOST_TEST(packet_id == pid_pub);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 [&chk, &c, &pub_seq_finished, &pid_pub, &pid_unsub]
-                (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_pubcomp");
                     BOOST_TEST(packet_id == pid_pub);
                     pub_seq_finished = true;
@@ -1099,7 +1099,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -1109,7 +1109,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -1125,7 +1125,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
@@ -1250,7 +1250,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -1259,25 +1259,25 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                 });
             c->set_v5_puback_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -1287,7 +1287,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -1303,7 +1303,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
@@ -1449,7 +1449,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -1458,7 +1458,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                 });
             c->set_v5_puback_handler(
                 [&chk, &c, &pub_seq_finished, &pid_pub, &pid_unsub]
-                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_puback");
                     BOOST_TEST(packet_id == pid_pub);
                     pub_seq_finished = true;
@@ -1467,19 +1467,19 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -1489,7 +1489,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -1505,7 +1505,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
@@ -1648,7 +1648,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -1657,20 +1657,20 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                 });
             c->set_v5_puback_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubrec_handler(
                 [&chk, &pid_pub]
-                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_pubrec");
                     BOOST_TEST(packet_id == pid_pub);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 [&chk, &c, &pub_seq_finished, &pid_pub, &pid_unsub]
-                (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_pubcomp");
                     BOOST_TEST(packet_id == pid_pub);
                     pub_seq_finished = true;
@@ -1679,7 +1679,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -1689,7 +1689,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -1705,7 +1705,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::exactly_once);
@@ -1830,7 +1830,7 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -1839,25 +1839,25 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
                 });
             c->set_v5_puback_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -1867,7 +1867,7 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -1883,7 +1883,7 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
@@ -2011,7 +2011,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -2020,7 +2020,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                 });
             c->set_v5_puback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_puback");
                     BOOST_TEST(packet_id == 1);
                     pid_unsub = c->unsubscribe("topic1");
@@ -2028,19 +2028,19 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -2051,7 +2051,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -2067,7 +2067,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false); // not propagated
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);

--- a/test/as_buffer_sub.cpp
+++ b/test/as_buffer_sub.cpp
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_single ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -69,14 +69,14 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_single ) {
                 });
             c->set_v5_suback_handler(
                 [&chk, &c]
-                (packet_id_t, std::vector<MQTT_NS::v5::suback_reason_code>, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, std::vector<MQTT_NS::v5::suback_reason_code>, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     c->unsubscribe("topic1");
                     return true;
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c]
-                (packet_id_t, std::vector<MQTT_NS::v5::unsuback_reason_code>, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, std::vector<MQTT_NS::v5::unsuback_reason_code>, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     c->disconnect();
                     return true;
@@ -156,7 +156,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -170,14 +170,14 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg ) {
                 });
             c->set_v5_suback_handler(
                 [&chk, &c]
-                (packet_id_t, std::vector<MQTT_NS::v5::suback_reason_code>, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, std::vector<MQTT_NS::v5::suback_reason_code>, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     c->unsubscribe({"topic1"s, "topic2"s});
                     return true;
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c]
-                (packet_id_t, std::vector<MQTT_NS::v5::unsuback_reason_code>, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, std::vector<MQTT_NS::v5::unsuback_reason_code>, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     c->disconnect();
                     return true;
@@ -257,7 +257,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -271,14 +271,14 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec ) {
                 });
             c->set_v5_suback_handler(
                 [&chk, &c]
-                (packet_id_t, std::vector<MQTT_NS::v5::suback_reason_code>, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, std::vector<MQTT_NS::v5::suback_reason_code>, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     c->unsubscribe(std::vector<MQTT_NS::string_view>{"topic1", "topic2"});
                     return true;
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c]
-                (packet_id_t, std::vector<MQTT_NS::v5::unsuback_reason_code>, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, std::vector<MQTT_NS::v5::unsuback_reason_code>, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     c->disconnect();
                     return true;
@@ -359,7 +359,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_single_async ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -372,7 +372,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_single_async ) {
                 });
             c->set_v5_suback_handler(
                 [&chk, &c]
-                (packet_id_t, std::vector<MQTT_NS::v5::suback_reason_code>, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, std::vector<MQTT_NS::v5::suback_reason_code>, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     auto topic = std::make_shared<std::string>("topic1");
                     c->async_unsubscribe(
@@ -382,7 +382,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_single_async ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c]
-                (packet_id_t, std::vector<MQTT_NS::v5::unsuback_reason_code>, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, std::vector<MQTT_NS::v5::unsuback_reason_code>, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     c->async_disconnect();
                     return true;
@@ -473,7 +473,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg_async ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -490,7 +490,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg_async ) {
                 });
             c->set_v5_suback_handler(
                 [&chk, &c]
-                (packet_id_t, std::vector<MQTT_NS::v5::suback_reason_code>, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, std::vector<MQTT_NS::v5::suback_reason_code>, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     auto topic1 = std::make_shared<std::string>("topic1");
                     auto topic2 = std::make_shared<std::string>("topic2");
@@ -505,7 +505,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg_async ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c]
-                (packet_id_t, std::vector<MQTT_NS::v5::unsuback_reason_code>, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, std::vector<MQTT_NS::v5::unsuback_reason_code>, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     c->async_disconnect();
                     return true;
@@ -600,7 +600,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec_async ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -619,7 +619,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec_async ) {
                 });
             c->set_v5_suback_handler(
                 [&chk, &c]
-                (packet_id_t, std::vector<MQTT_NS::v5::suback_reason_code>, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, std::vector<MQTT_NS::v5::suback_reason_code>, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     auto topic1 = std::make_shared<std::string>("topic1");
                     auto topic2 = std::make_shared<std::string>("topic2");
@@ -636,7 +636,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec_async ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c]
-                (packet_id_t, std::vector<MQTT_NS::v5::unsuback_reason_code>, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, std::vector<MQTT_NS::v5::unsuback_reason_code>, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     c->async_disconnect();
                     return true;

--- a/test/async_pubsub_1.cpp
+++ b/test/async_pubsub_1.cpp
@@ -105,7 +105,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -114,7 +114,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
@@ -153,19 +153,19 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                 });
             c->set_v5_puback_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
@@ -296,7 +296,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -309,7 +309,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                 });
             c->set_v5_puback_handler(
                 [&chk, &c, &pid_pub, &pid_unsub]
-                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_puback");
                     BOOST_TEST(packet_id == pid_pub);
                     pid_unsub = c->async_unsubscribe(
@@ -318,19 +318,19 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_pub, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -340,7 +340,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -356,7 +356,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
@@ -490,7 +490,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -499,20 +499,20 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                 });
             c->set_v5_puback_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubrec_handler(
                 [&chk, &pid_pub]
-                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_pubrec");
                     BOOST_TEST(packet_id == pid_pub);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 [&chk, &c, &pid_unsub, &pid_pub]
-                (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_pubcomp");
                     BOOST_TEST(packet_id == pid_pub);
                     pid_unsub = c->async_unsubscribe("topic1");
@@ -520,7 +520,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == 1);
                     BOOST_TEST(reasons.size() == 1U);
@@ -530,7 +530,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -546,7 +546,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
@@ -675,7 +675,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -684,25 +684,25 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                 });
             c->set_v5_puback_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -712,7 +712,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -728,7 +728,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
@@ -871,7 +871,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -880,26 +880,26 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                 });
             c->set_v5_puback_handler(
                 [&chk, &pid_pub]
-                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_puback");
                     BOOST_TEST(packet_id == pid_pub);
                     return true;
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -909,7 +909,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -925,7 +925,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
@@ -1065,7 +1065,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -1074,20 +1074,20 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                 });
             c->set_v5_puback_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubrec_handler(
                 [&chk, &pid_pub]
-                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_pubrec");
                     BOOST_TEST(packet_id == pid_pub);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 [&chk, &c, &pid_pub, &pid_unsub]
-                (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_pubcomp");
                     BOOST_TEST(packet_id == pid_pub);
                     pid_unsub = c->async_unsubscribe("topic1");
@@ -1095,7 +1095,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -1105,7 +1105,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -1121,7 +1121,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);

--- a/test/async_pubsub_2.cpp
+++ b/test/async_pubsub_2.cpp
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -116,25 +116,25 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                 });
             c->set_v5_puback_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(reasons.size() == 1U);
                     BOOST_TEST(reasons[0] == MQTT_NS::v5::unsuback_reason_code::success);
@@ -160,7 +160,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
@@ -303,7 +303,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -312,7 +312,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                 });
             c->set_v5_puback_handler(
                 [&chk, &c, &pid_pub, &pid_unsub]
-                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_puback");
                     BOOST_TEST(packet_id == pid_pub);
                     pid_unsub = c->async_unsubscribe("topic1");
@@ -320,19 +320,19 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -342,7 +342,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -358,7 +358,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
@@ -499,7 +499,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -508,20 +508,20 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                 });
             c->set_v5_puback_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubrec_handler(
                 [&chk, &pid_pub]
-                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_pubrec");
                     BOOST_TEST(packet_id == pid_pub);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 [&chk, &c, &pid_pub, &pid_unsub]
-                (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_pubcomp");
                     BOOST_TEST(packet_id == pid_pub);
                     pid_unsub = c->async_unsubscribe("topic1");
@@ -529,7 +529,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -539,7 +539,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -555,7 +555,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::exactly_once);
@@ -680,7 +680,7 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -689,25 +689,25 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
                 });
             c->set_v5_puback_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -717,7 +717,7 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -733,7 +733,7 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
@@ -862,7 +862,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -871,7 +871,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                 });
             c->set_v5_puback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_puback");
                     BOOST_TEST(packet_id == 1);
                     pid_unsub = c->async_unsubscribe("topic1");
@@ -879,19 +879,19 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -903,7 +903,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -919,7 +919,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false); // not propagated
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
@@ -1047,7 +1047,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function_buffer ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -1056,7 +1056,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function_buffer ) {
                 });
             c->set_v5_puback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_puback");
                     BOOST_TEST(packet_id == 1);
                     pid_unsub = c->async_unsubscribe("topic1");
@@ -1064,19 +1064,19 @@ BOOST_AUTO_TEST_CASE( publish_dup_function_buffer ) {
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -1088,7 +1088,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function_buffer ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -1104,7 +1104,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function_buffer ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false); // not propagated
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
@@ -1161,7 +1161,7 @@ BOOST_AUTO_TEST_CASE( pub_sub_prop ) {
             cont("h_close"),
         };
 
-        std::vector<MQTT_NS::v5::property_variant> ps {
+        MQTT_NS::v5::properties ps {
             MQTT_NS::v5::property::payload_format_indicator(MQTT_NS::v5::property::payload_format_indicator::string),
             MQTT_NS::v5::property::message_expiry_interval(0x12345678UL),
             MQTT_NS::v5::property::topic_alias(0x1234U),
@@ -1177,7 +1177,7 @@ BOOST_AUTO_TEST_CASE( pub_sub_prop ) {
 
         c->set_v5_connack_handler(
             [&chk, &c, &pid_sub]
-            (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_connack");
                 BOOST_TEST(sp == false);
                 BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -1186,7 +1186,7 @@ BOOST_AUTO_TEST_CASE( pub_sub_prop ) {
             });
         c->set_v5_suback_handler(
             [&chk, &c, &pid_sub, ps = std::move(ps)]
-            (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_suback");
                 BOOST_TEST(packet_id == pid_sub);
                 BOOST_TEST(reasons.size() == 1U);
@@ -1196,7 +1196,7 @@ BOOST_AUTO_TEST_CASE( pub_sub_prop ) {
             });
         c->set_v5_unsuback_handler(
             [&chk, &c, &pid_unsub]
-            (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_unsuback");
                 BOOST_TEST(packet_id == pid_unsub);
                 BOOST_TEST(reasons.size() == 1U);
@@ -1212,7 +1212,7 @@ BOOST_AUTO_TEST_CASE( pub_sub_prop ) {
              MQTT_NS::optional<packet_id_t> packet_id,
              MQTT_NS::string_view topic,
              MQTT_NS::string_view contents,
-             std::vector<MQTT_NS::v5::property_variant> props) {
+             MQTT_NS::v5::properties props) {
                 MQTT_CHK("h_publish");
                 BOOST_TEST(is_dup == false);
                 BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
@@ -1272,19 +1272,19 @@ BOOST_AUTO_TEST_CASE( pub_sub_prop ) {
             });
         c->set_v5_puback_handler(
             []
-            (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                 BOOST_CHECK(false);
                 return true;
             });
         c->set_v5_pubrec_handler(
             []
-            (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                 BOOST_CHECK(false);
                 return true;
             });
         c->set_v5_pubcomp_handler(
             []
-            (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                 BOOST_CHECK(false);
                 return true;
             });
@@ -1338,7 +1338,7 @@ BOOST_AUTO_TEST_CASE( puback_props ) {
             cont("h_close"),
         };
 
-        std::vector<MQTT_NS::v5::property_variant> pubackps {
+        MQTT_NS::v5::properties pubackps {
             MQTT_NS::v5::property::reason_string("test success"_mb),
             MQTT_NS::v5::property::user_property("key1"_mb, "val1"_mb),
             MQTT_NS::v5::property::user_property("key2"_mb, "val2"_mb),
@@ -1346,7 +1346,7 @@ BOOST_AUTO_TEST_CASE( puback_props ) {
         std::size_t puback_user_prop_count = 0;
 
         b.set_puback_props_handler(
-            [&puback_user_prop_count, size = pubackps.size()] (std::vector<MQTT_NS::v5::property_variant> const& props) {
+            [&puback_user_prop_count, size = pubackps.size()] (MQTT_NS::v5::properties const& props) {
                 BOOST_TEST(props.size() == size);
                 for (auto const& p : props) {
                     MQTT_NS::visit(
@@ -1390,7 +1390,7 @@ BOOST_AUTO_TEST_CASE( puback_props ) {
 
         c->set_v5_connack_handler(
             [&chk, &c, &pid_sub]
-            (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_connack");
                 BOOST_TEST(sp == false);
                 BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -1399,26 +1399,26 @@ BOOST_AUTO_TEST_CASE( puback_props ) {
             });
         c->set_v5_puback_handler(
             [&chk, &pid_pub]
-            (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_puback");
                 BOOST_TEST(packet_id == pid_pub);
                 return true;
             });
         c->set_v5_pubrec_handler(
             []
-            (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                 BOOST_CHECK(false);
                 return true;
             });
         c->set_v5_pubcomp_handler(
             []
-            (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                 BOOST_CHECK(false);
                 return true;
             });
         c->set_v5_suback_handler(
             [&chk, &c, &pid_sub, &pid_pub]
-            (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_suback");
                 BOOST_TEST(packet_id == pid_sub);
                 BOOST_TEST(reasons.size() == 1U);
@@ -1428,7 +1428,7 @@ BOOST_AUTO_TEST_CASE( puback_props ) {
             });
         c->set_v5_unsuback_handler(
             [&chk, &c, &pid_unsub]
-            (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_unsuback");
                 BOOST_TEST(packet_id == pid_unsub);
                 BOOST_TEST(reasons.size() == 1U);
@@ -1444,7 +1444,7 @@ BOOST_AUTO_TEST_CASE( puback_props ) {
              MQTT_NS::optional<packet_id_t> packet_id,
              MQTT_NS::string_view topic,
              MQTT_NS::string_view contents,
-             std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+             MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_publish");
                 BOOST_TEST(is_dup == false);
                 BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
@@ -1516,21 +1516,21 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
             cont("h_close"),
         };
 
-        std::vector<MQTT_NS::v5::property_variant> pubrecps {
+        MQTT_NS::v5::properties pubrecps {
             MQTT_NS::v5::property::reason_string("test success"_mb),
             MQTT_NS::v5::property::user_property("key1"_mb, "val1"_mb),
             MQTT_NS::v5::property::user_property("key2"_mb, "val2"_mb),
         };
         std::size_t pubrec_user_prop_count = 0;
 
-        std::vector<MQTT_NS::v5::property_variant> pubrelps {
+        MQTT_NS::v5::properties pubrelps {
             MQTT_NS::v5::property::reason_string("test success"_mb),
             MQTT_NS::v5::property::user_property("key1"_mb, "val1"_mb),
             MQTT_NS::v5::property::user_property("key2"_mb, "val2"_mb),
         };
         std::size_t pubrel_user_prop_count = 0;
 
-        std::vector<MQTT_NS::v5::property_variant> pubcompps {
+        MQTT_NS::v5::properties pubcompps {
             MQTT_NS::v5::property::reason_string("test success"_mb),
             MQTT_NS::v5::property::user_property("key1"_mb, "val1"_mb),
             MQTT_NS::v5::property::user_property("key2"_mb, "val2"_mb),
@@ -1538,7 +1538,7 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
         std::size_t pubcomp_user_prop_count = 0;
 
         b.set_pubrec_props_handler(
-            [&pubrec_user_prop_count, size = pubrecps.size()] (std::vector<MQTT_NS::v5::property_variant> const& props) {
+            [&pubrec_user_prop_count, size = pubrecps.size()] (MQTT_NS::v5::properties const& props) {
                 BOOST_TEST(props.size() == size);
                 for (auto const& p : props) {
                     MQTT_NS::visit(
@@ -1572,7 +1572,7 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
         );
 
         b.set_pubrel_props_handler(
-            [&pubrel_user_prop_count, size = pubrelps.size()] (std::vector<MQTT_NS::v5::property_variant> const& props) {
+            [&pubrel_user_prop_count, size = pubrelps.size()] (MQTT_NS::v5::properties const& props) {
                 BOOST_TEST(props.size() == size);
                 for (auto const& p : props) {
                     MQTT_NS::visit(
@@ -1606,7 +1606,7 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
         );
 
         b.set_pubcomp_props_handler(
-            [&pubcomp_user_prop_count, size = pubcompps.size()] (std::vector<MQTT_NS::v5::property_variant> const& props) {
+            [&pubcomp_user_prop_count, size = pubcompps.size()] (MQTT_NS::v5::properties const& props) {
                 BOOST_TEST(props.size() == size);
                 for (auto const& p : props) {
                     MQTT_NS::visit(
@@ -1649,7 +1649,7 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
 
         c->set_v5_connack_handler(
             [&chk, &c, &pid_sub]
-            (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_connack");
                 BOOST_TEST(sp == false);
                 BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -1658,13 +1658,13 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
             });
         c->set_v5_puback_handler(
             []
-            (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                 BOOST_CHECK(false);
                 return true;
             });
         c->set_v5_pubrec_handler(
             [&chk, &c, &pid_pub, pubrelps = std::move(pubrelps)]
-            (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_pubrec");
                 BOOST_TEST(packet_id == pid_pub);
                 c->async_pubrel(packet_id, MQTT_NS::v5::pubrel_reason_code::success, std::move(pubrelps));
@@ -1672,7 +1672,7 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
             });
         c->set_v5_pubcomp_handler(
             [&chk, &c, &pid_pub, &pid_unsub]
-            (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_pubcomp");
                 BOOST_TEST(packet_id == pid_pub);
                 pid_unsub = c->async_unsubscribe("topic1");
@@ -1680,7 +1680,7 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
             });
         c->set_v5_suback_handler(
             [&chk, &c, &pid_sub, &pid_pub]
-            (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_suback");
                 BOOST_TEST(packet_id == pid_sub);
                 BOOST_TEST(reasons.size() == 1U);
@@ -1690,7 +1690,7 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
             });
         c->set_v5_unsuback_handler(
             [&chk, &c, &pid_unsub]
-            (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_unsuback");
                 BOOST_TEST(packet_id == pid_unsub);
                 BOOST_TEST(reasons.size() == 1U);
@@ -1706,7 +1706,7 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
              MQTT_NS::optional<packet_id_t> packet_id,
              MQTT_NS::string_view topic,
              MQTT_NS::string_view contents,
-             std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+             MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_publish");
                 BOOST_TEST(is_dup == false);
                 BOOST_TEST(qos_value == MQTT_NS::qos::exactly_once);
@@ -1720,7 +1720,7 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
             });
         c->set_v5_pubrel_handler(
             [&c, pubcompps = std::move(pubcompps)]
-            (packet_id_t packet_id, MQTT_NS::v5::pubrel_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (packet_id_t packet_id, MQTT_NS::v5::pubrel_reason_code, MQTT_NS::v5::properties /*props*/) {
                 c->async_pubcomp(packet_id, MQTT_NS::v5::pubcomp_reason_code::success, std::move(pubcompps));
                 return true;
             });

--- a/test/connect.cpp
+++ b/test/connect.cpp
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE( connect ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(c->connected() == true);
                     BOOST_TEST(sp == false);
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE( connect_no_strand ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -166,7 +166,7 @@ BOOST_AUTO_TEST_CASE( keep_alive ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -249,7 +249,7 @@ BOOST_AUTO_TEST_CASE( keep_alive_and_send_control_packet ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &tim]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -341,7 +341,7 @@ BOOST_AUTO_TEST_CASE( connect_again ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&first, &chk, &c]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     if (first) {
                         MQTT_CHK("h_connack1");
                     }
@@ -410,7 +410,7 @@ BOOST_AUTO_TEST_CASE( nocid ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -465,7 +465,7 @@ BOOST_AUTO_TEST_CASE( nocid_noclean ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::client_identifier_not_valid);
@@ -550,7 +550,7 @@ BOOST_AUTO_TEST_CASE( noclean ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &connect, &c]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     switch (connect) {
                     case 0:
                         MQTT_CHK("h_connack1");
@@ -606,7 +606,7 @@ BOOST_AUTO_TEST_CASE( noclean ) {
                     case MQTT_NS::protocol_version::v5:
                         // set session_expiry_interval as infinity.
                         c->connect(
-                            std::vector<MQTT_NS::v5::property_variant>{
+                            MQTT_NS::v5::properties{
                                 MQTT_NS::v5::property::session_expiry_interval(0xFFFFFFFFUL)
                             }
                         );
@@ -663,7 +663,7 @@ BOOST_AUTO_TEST_CASE( disconnect_timeout ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &s]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -723,7 +723,7 @@ BOOST_AUTO_TEST_CASE( disconnect_not_timeout ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &s]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -783,7 +783,7 @@ BOOST_AUTO_TEST_CASE( async_disconnect_timeout ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &s]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -843,7 +843,7 @@ BOOST_AUTO_TEST_CASE( async_disconnect_not_timeout ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &s]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -890,7 +890,7 @@ BOOST_AUTO_TEST_CASE( connect_disconnect_prop ) {
             cont("h_close"),
         };
 
-        std::vector<MQTT_NS::v5::property_variant> con_ps {
+        MQTT_NS::v5::properties con_ps {
             MQTT_NS::v5::property::session_expiry_interval(0x12345678UL),
             MQTT_NS::v5::property::receive_maximum(0x1234U),
             MQTT_NS::v5::property::maximum_packet_size(0x12345678UL),
@@ -905,7 +905,7 @@ BOOST_AUTO_TEST_CASE( connect_disconnect_prop ) {
 
         std::size_t con_user_prop_count = 0;
 
-        std::vector<MQTT_NS::v5::property_variant> discon_ps {
+        MQTT_NS::v5::properties discon_ps {
             MQTT_NS::v5::property::session_expiry_interval(0x12345678UL),
             MQTT_NS::v5::property::reason_string("test reason string"_mb),
             MQTT_NS::v5::property::user_property("key1"_mb, "val1"_mb),
@@ -916,7 +916,7 @@ BOOST_AUTO_TEST_CASE( connect_disconnect_prop ) {
         std::size_t discon_user_prop_count = 0;
 
         b.set_connect_props_handler(
-            [&con_user_prop_count, size = con_ps.size()] (std::vector<MQTT_NS::v5::property_variant> const& props) {
+            [&con_user_prop_count, size = con_ps.size()] (MQTT_NS::v5::properties const& props) {
                 BOOST_TEST(size == props.size());
                 for (auto const& p : props) {
                     MQTT_NS::visit(
@@ -971,7 +971,7 @@ BOOST_AUTO_TEST_CASE( connect_disconnect_prop ) {
         );
 
         b.set_disconnect_props_handler(
-            [&discon_user_prop_count, size = discon_ps.size()] (std::vector<MQTT_NS::v5::property_variant> const& props) {
+            [&discon_user_prop_count, size = discon_ps.size()] (MQTT_NS::v5::properties const& props) {
                 BOOST_TEST(size == props.size());
                 for (auto const& p : props) {
                     MQTT_NS::visit(
@@ -1012,7 +1012,7 @@ BOOST_AUTO_TEST_CASE( connect_disconnect_prop ) {
 
         c->set_v5_connack_handler(
             [&chk, &c, discon_ps = std::move(discon_ps)]
-            (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_connack");
                 BOOST_TEST(c->connected() == true);
                 BOOST_TEST(sp == false);
@@ -1058,7 +1058,7 @@ BOOST_AUTO_TEST_CASE( connack_prop ) {
             cont("h_close"),
         };
 
-        std::vector<MQTT_NS::v5::property_variant> ps {
+        MQTT_NS::v5::properties ps {
             MQTT_NS::v5::property::session_expiry_interval(0),
             MQTT_NS::v5::property::receive_maximum(0),
             MQTT_NS::v5::property::maximum_qos(MQTT_NS::qos::exactly_once),
@@ -1086,7 +1086,7 @@ BOOST_AUTO_TEST_CASE( connack_prop ) {
 
         c->set_v5_connack_handler(
             [&chk, &c, &user_prop_count, prop_size]
-            (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> props) {
+            (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties props) {
                 MQTT_CHK("h_connack");
                 BOOST_TEST(c->connected() == true);
                 BOOST_TEST(sp == false);

--- a/test/manual_publish.cpp
+++ b/test/manual_publish.cpp
@@ -137,7 +137,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -160,7 +160,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                 });
             c->set_v5_puback_handler(
                 [&chk, &c]
-                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_TEST(packet_id == 1);
                     MQTT_CHK("h_puback");
                     {
@@ -176,19 +176,19 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == 1);
                     BOOST_TEST(reasons.size() == 1U);
@@ -212,7 +212,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == 1);
                     BOOST_TEST(reasons.size() == 1U);
@@ -228,7 +228,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
                     BOOST_TEST(is_retain == false);

--- a/test/offline.cpp
+++ b/test/offline.cpp
@@ -15,7 +15,7 @@ inline void connect_no_clean(Client& c) {
     c->set_clean_session(false);
     if (c->get_protocol_version() == MQTT_NS::protocol_version::v5) {
         // set session_expiry_interval as infinity.
-        c->connect(std::vector<MQTT_NS::v5::property_variant>{MQTT_NS::v5::property::session_expiry_interval(0xFFFFFFFFUL)});
+        c->connect(MQTT_NS::v5::properties{MQTT_NS::v5::property::session_expiry_interval(0xFFFFFFFFUL)});
     }
     else {
         c->connect();
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE( publish_qos1 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
                     auto ret = chk.match(
                         "start",
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE( publish_qos1 ) {
                 });
             c->set_v5_puback_handler(
                 [&chk, &c, &pid_pub]
-                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code /*reason*/, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code /*reason*/, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_puback");
                     BOOST_TEST(packet_id == pid_pub);
                     c->disconnect();
@@ -210,7 +210,7 @@ BOOST_AUTO_TEST_CASE( publish_qos2 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
                     auto ret = chk.match(
                         "start",
@@ -232,14 +232,14 @@ BOOST_AUTO_TEST_CASE( publish_qos2 ) {
                 });
             c->set_v5_pubrec_handler(
                 [&chk, &pid_pub]
-                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code /*reason*/, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code /*reason*/, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_pubrec");
                     BOOST_TEST(packet_id == pid_pub);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 [&chk, &c, &pid_pub]
-                (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code/*reason*/, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code/*reason*/, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_pubcomp");
                     BOOST_TEST(packet_id == pid_pub);
                     c->disconnect();
@@ -354,7 +354,7 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
                     auto ret = chk.match(
                         "start",
@@ -376,7 +376,7 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1 ) {
                 });
             c->set_v5_puback_handler(
                 [&chk, &c, &pid_pub1, &pid_pub2]
-                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code /*reason*/, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code /*reason*/, MQTT_NS::v5::properties /*props*/) {
                     auto ret = chk.match(
                         "h_connack2",
                         [&] {
@@ -490,7 +490,7 @@ BOOST_AUTO_TEST_CASE( async_publish_qos1 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
                     auto ret = chk.match(
                         "start",
@@ -512,7 +512,7 @@ BOOST_AUTO_TEST_CASE( async_publish_qos1 ) {
                 });
             c->set_v5_puback_handler(
                 [&chk, &c, &pid_pub]
-                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code /*reason*/, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code /*reason*/, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_puback");
                     BOOST_TEST(packet_id == pid_pub);
                     c->async_disconnect();

--- a/test/pubsub.cpp
+++ b/test/pubsub.cpp
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -112,25 +112,25 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                 });
             c->set_v5_puback_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -156,7 +156,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
@@ -296,7 +296,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -309,7 +309,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                 });
             c->set_v5_puback_handler(
                 [&chk, &c, &pub_seq_finished, &pid_pub, &pid_unsub]
-                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_puback");
                     BOOST_TEST(packet_id == pid_pub);
                     pub_seq_finished = true;
@@ -319,19 +319,19 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_pub, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -341,7 +341,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -357,7 +357,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
@@ -494,7 +494,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                 (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -503,20 +503,20 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                 });
             c->set_v5_puback_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubrec_handler(
                 [&chk, &pid_pub]
-                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_pubrec");
                     BOOST_TEST(packet_id == pid_pub);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 [&chk, &c, &pub_seq_finished, &pid_unsub, &pid_pub]
-                (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_pubcomp");
                     BOOST_TEST(packet_id == pid_pub);
                     pub_seq_finished = true;
@@ -525,7 +525,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == 1);
                     BOOST_TEST(reasons.size() == 1U);
@@ -535,7 +535,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -551,7 +551,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
@@ -679,7 +679,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -688,25 +688,25 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                 });
             c->set_v5_puback_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -716,7 +716,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -732,7 +732,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
@@ -877,7 +877,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -886,7 +886,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                 });
             c->set_v5_puback_handler(
                 [&chk, &c, &pub_seq_finished, &pid_pub, &pid_unsub]
-                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_puback");
                     BOOST_TEST(packet_id == pid_pub);
                     pub_seq_finished = true;
@@ -895,19 +895,19 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -917,7 +917,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -933,7 +933,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
@@ -1075,7 +1075,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -1084,20 +1084,20 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                 });
             c->set_v5_puback_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubrec_handler(
                 [&chk, &pid_pub]
-                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_pubrec");
                     BOOST_TEST(packet_id == pid_pub);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 [&chk, &c, &pub_seq_finished, &pid_pub, &pid_unsub]
-                (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_pubcomp");
                     BOOST_TEST(packet_id == pid_pub);
                     pub_seq_finished = true;
@@ -1106,7 +1106,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -1116,7 +1116,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -1132,7 +1132,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
@@ -1263,7 +1263,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -1272,25 +1272,25 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                 });
             c->set_v5_puback_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -1300,7 +1300,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -1316,7 +1316,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
@@ -1457,7 +1457,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -1466,7 +1466,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                 });
             c->set_v5_puback_handler(
                 [&chk, &c, &pub_seq_finished, &pid_pub, &pid_unsub]
-                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_puback");
                     BOOST_TEST(packet_id == pid_pub);
                     pub_seq_finished = true;
@@ -1475,19 +1475,19 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -1497,7 +1497,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -1513,7 +1513,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
@@ -1656,7 +1656,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -1665,20 +1665,20 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                 });
             c->set_v5_puback_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubrec_handler(
                 [&chk, &pid_pub]
-                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_pubrec");
                     BOOST_TEST(packet_id == pid_pub);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 [&chk, &c, &pub_seq_finished, &pid_pub, &pid_unsub]
-                (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_pubcomp");
                     BOOST_TEST(packet_id == pid_pub);
                     pub_seq_finished = true;
@@ -1687,7 +1687,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub, &pid_pub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -1697,7 +1697,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -1713,7 +1713,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::exactly_once);
@@ -1838,7 +1838,7 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -1847,25 +1847,25 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
                 });
             c->set_v5_puback_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -1875,7 +1875,7 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -1891,7 +1891,7 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
@@ -2016,7 +2016,7 @@ BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -2025,25 +2025,25 @@ BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
                 });
             c->set_v5_puback_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -2053,7 +2053,7 @@ BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -2069,7 +2069,7 @@ BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
@@ -2198,7 +2198,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -2207,7 +2207,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                 });
             c->set_v5_puback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_puback");
                     BOOST_TEST(packet_id == 1);
                     pid_unsub = c->unsubscribe("topic1");
@@ -2215,19 +2215,19 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -2239,7 +2239,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -2255,7 +2255,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false); // not propagated
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
@@ -2383,7 +2383,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function_buffer ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -2392,7 +2392,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function_buffer ) {
                 });
             c->set_v5_puback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_puback");
                     BOOST_TEST(packet_id == 1);
                     pid_unsub = c->unsubscribe("topic1"_mb);
@@ -2400,19 +2400,19 @@ BOOST_AUTO_TEST_CASE( publish_dup_function_buffer ) {
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -2424,7 +2424,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function_buffer ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -2440,7 +2440,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function_buffer ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false); // not propagated
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
@@ -2496,7 +2496,7 @@ BOOST_AUTO_TEST_CASE( pub_sub_prop ) {
             cont("h_close"),
         };
 
-        std::vector<MQTT_NS::v5::property_variant> ps {
+        MQTT_NS::v5::properties ps {
             MQTT_NS::v5::property::payload_format_indicator(MQTT_NS::v5::property::payload_format_indicator::string),
             MQTT_NS::v5::property::message_expiry_interval(0x12345678UL),
             MQTT_NS::v5::property::content_type("content type"_mb),
@@ -2513,7 +2513,7 @@ BOOST_AUTO_TEST_CASE( pub_sub_prop ) {
 
         c->set_v5_connack_handler(
             [&chk, &c, &pid_sub]
-            (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_connack");
                 BOOST_TEST(sp == false);
                 BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -2522,25 +2522,25 @@ BOOST_AUTO_TEST_CASE( pub_sub_prop ) {
             });
         c->set_v5_puback_handler(
             []
-            (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                 BOOST_CHECK(false);
                 return true;
             });
         c->set_v5_pubrec_handler(
             []
-            (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                 BOOST_CHECK(false);
                 return true;
             });
         c->set_v5_pubcomp_handler(
             []
-            (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                 BOOST_CHECK(false);
                 return true;
             });
         c->set_v5_suback_handler(
             [&chk, &c, &pid_sub, ps = std::move(ps)]
-            (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_suback");
                 BOOST_TEST(packet_id == pid_sub);
                 BOOST_TEST(reasons.size() == 1U);
@@ -2550,7 +2550,7 @@ BOOST_AUTO_TEST_CASE( pub_sub_prop ) {
             });
         c->set_v5_unsuback_handler(
             [&chk, &c, &pid_unsub]
-            (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_unsuback");
                 BOOST_TEST(packet_id == pid_unsub);
                 BOOST_TEST(reasons.size() == 1U);
@@ -2566,7 +2566,7 @@ BOOST_AUTO_TEST_CASE( pub_sub_prop ) {
              MQTT_NS::optional<packet_id_t> packet_id,
              MQTT_NS::string_view topic,
              MQTT_NS::string_view contents,
-             std::vector<MQTT_NS::v5::property_variant> props) {
+             MQTT_NS::v5::properties props) {
                 MQTT_CHK("h_publish");
                 BOOST_TEST(is_dup == false);
                 BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
@@ -2678,7 +2678,7 @@ BOOST_AUTO_TEST_CASE( puback_prop ) {
             cont("h_close"),
         };
 
-        std::vector<MQTT_NS::v5::property_variant> pubackps {
+        MQTT_NS::v5::properties pubackps {
             MQTT_NS::v5::property::reason_string("test success"_mb),
             MQTT_NS::v5::property::user_property("key1"_mb, "val1"_mb),
             MQTT_NS::v5::property::user_property("key2"_mb, "val2"_mb),
@@ -2697,7 +2697,7 @@ BOOST_AUTO_TEST_CASE( puback_prop ) {
 
         c->set_v5_connack_handler(
             [&chk, &c, &pid_sub]
-            (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_connack");
                 BOOST_TEST(sp == false);
                 BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -2706,7 +2706,7 @@ BOOST_AUTO_TEST_CASE( puback_prop ) {
             });
         c->set_v5_puback_handler(
             [&chk, &c, &pub_seq_finished, &pid_pub, &pid_unsub, puback_prop_size, &puback_user_prop_count]
-            (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> props) {
+            (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties props) {
                 MQTT_CHK("h_puback");
                 BOOST_TEST(packet_id == pid_pub);
                 pub_seq_finished = true;
@@ -2746,19 +2746,19 @@ BOOST_AUTO_TEST_CASE( puback_prop ) {
             });
         c->set_v5_pubrec_handler(
             []
-            (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                 BOOST_CHECK(false);
                 return true;
             });
         c->set_v5_pubcomp_handler(
             []
-            (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                 BOOST_CHECK(false);
                 return true;
             });
         c->set_v5_suback_handler(
             [&chk, &c, &pid_sub, &pid_pub]
-            (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_suback");
                 BOOST_TEST(packet_id == pid_sub);
                 BOOST_TEST(reasons.size() == 1U);
@@ -2768,7 +2768,7 @@ BOOST_AUTO_TEST_CASE( puback_prop ) {
             });
         c->set_v5_unsuback_handler(
             [&chk, &c, &pid_unsub]
-            (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_unsuback");
                 BOOST_TEST(packet_id == pid_unsub);
                 BOOST_TEST(reasons.size() == 1U);
@@ -2784,7 +2784,7 @@ BOOST_AUTO_TEST_CASE( puback_prop ) {
              MQTT_NS::optional<packet_id_t> packet_id,
              MQTT_NS::string_view topic,
              MQTT_NS::string_view contents,
-             std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+             MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_publish");
                 BOOST_TEST(is_dup == false);
                 BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
@@ -2843,7 +2843,7 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
             cont("h_close"),
         };
 
-        std::vector<MQTT_NS::v5::property_variant> pubrecps {
+        MQTT_NS::v5::properties pubrecps {
             MQTT_NS::v5::property::reason_string("test success"_mb),
             MQTT_NS::v5::property::user_property("key1"_mb, "val1"_mb),
             MQTT_NS::v5::property::user_property("key2"_mb, "val2"_mb),
@@ -2852,14 +2852,14 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
         b.set_pubrec_props(std::move(pubrecps));
         std::size_t pubrec_user_prop_count = 0;
 
-        std::vector<MQTT_NS::v5::property_variant> pubrelps {
+        MQTT_NS::v5::properties pubrelps {
             MQTT_NS::v5::property::reason_string("test success"_mb),
             MQTT_NS::v5::property::user_property("key1"_mb, "val1"_mb),
             MQTT_NS::v5::property::user_property("key2"_mb, "val2"_mb),
         };
         std::size_t pubrel_user_prop_count = 0;
 
-        std::vector<MQTT_NS::v5::property_variant> pubcompps {
+        MQTT_NS::v5::properties pubcompps {
             MQTT_NS::v5::property::reason_string("test success"_mb),
             MQTT_NS::v5::property::user_property("key1"_mb, "val1"_mb),
             MQTT_NS::v5::property::user_property("key2"_mb, "val2"_mb),
@@ -2869,7 +2869,7 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
         std::size_t pubcomp_user_prop_count = 0;
 
         b.set_pubrel_props_handler(
-            [&pubrel_user_prop_count, size = pubrelps.size()] (std::vector<MQTT_NS::v5::property_variant> const& props) {
+            [&pubrel_user_prop_count, size = pubrelps.size()] (MQTT_NS::v5::properties const& props) {
                 BOOST_TEST(props.size() == size);
                 for (auto const& p : props) {
                     MQTT_NS::visit(
@@ -2912,7 +2912,7 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
 
         c->set_v5_connack_handler(
             [&chk, &c, &pid_sub]
-            (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_connack");
                 BOOST_TEST(sp == false);
                 BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -2921,13 +2921,13 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
             });
         c->set_v5_puback_handler(
             []
-            (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                 BOOST_CHECK(false);
                 return true;
             });
         c->set_v5_pubrec_handler(
             [&chk, &c, &pid_pub, pubrec_prop_size, &pubrec_user_prop_count, pubrelps = std::move(pubrelps)]
-            (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> props) {
+            (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties props) {
                 MQTT_CHK("h_pubrec");
                 BOOST_TEST(packet_id == pid_pub);
 
@@ -2967,7 +2967,7 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
             });
         c->set_v5_pubcomp_handler(
             [&chk, &c, &pub_seq_finished, &pid_pub, &pid_unsub, pubcomp_prop_size, &pubcomp_user_prop_count]
-            (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> props) {
+            (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties props) {
                 MQTT_CHK("h_pubcomp");
                 BOOST_TEST(packet_id == pid_pub);
 
@@ -3007,7 +3007,7 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
             });
         c->set_v5_suback_handler(
             [&chk, &c, &pid_sub, &pid_pub]
-            (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_suback");
                 BOOST_TEST(packet_id == pid_sub);
                 BOOST_TEST(reasons.size() == 1U);
@@ -3017,7 +3017,7 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
             });
         c->set_v5_unsuback_handler(
             [&chk, &c, &pid_unsub]
-            (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_unsuback");
                 BOOST_TEST(packet_id == pid_unsub);
                 BOOST_TEST(reasons.size() == 1U);
@@ -3033,7 +3033,7 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
              MQTT_NS::optional<packet_id_t> packet_id,
              MQTT_NS::string_view topic,
              MQTT_NS::string_view contents,
-             std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+             MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_publish");
                 BOOST_TEST(is_dup == false);
                 BOOST_TEST(qos_value == MQTT_NS::qos::exactly_once);
@@ -3047,7 +3047,7 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
             });
         c->set_v5_pubrel_handler(
             [&c]
-            (packet_id_t packet_id, MQTT_NS::v5::pubrel_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (packet_id_t packet_id, MQTT_NS::v5::pubrel_reason_code, MQTT_NS::v5::properties /*props*/) {
                 c->pubcomp(packet_id, MQTT_NS::v5::pubcomp_reason_code::success, {});
                 return true;
             });

--- a/test/resend.cpp
+++ b/test/resend.cpp
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE( publish_qos1 ) {
             cont("h_close2"),
         };
 
-        std::vector<MQTT_NS::v5::property_variant> ps {
+        MQTT_NS::v5::properties ps {
             MQTT_NS::v5::property::payload_format_indicator(MQTT_NS::v5::property::payload_format_indicator::string),
             MQTT_NS::v5::property::message_expiry_interval(0x12345678UL),
             MQTT_NS::v5::property::topic_alias(0x1234U),
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE( publish_qos1 ) {
 
         std::size_t user_prop_count = 0;
         b.set_publish_props_handler(
-            [&user_prop_count, size = ps.size()] (std::vector<MQTT_NS::v5::property_variant> const& props) {
+            [&user_prop_count, size = ps.size()] (MQTT_NS::v5::properties const& props) {
                 BOOST_TEST(props.size() == size);
 
                 for (auto const& p : props) {
@@ -152,7 +152,7 @@ BOOST_AUTO_TEST_CASE( publish_qos1 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_pub, ps = std::move(ps)]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
                     auto ret = chk.match(
                         "start",
@@ -181,7 +181,7 @@ BOOST_AUTO_TEST_CASE( publish_qos1 ) {
                 });
             c->set_v5_puback_handler(
                 [&chk, &c, &pid_pub]
-                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_puback");
                     BOOST_TEST(packet_id == pid_pub);
                     c->disconnect();
@@ -314,7 +314,7 @@ BOOST_AUTO_TEST_CASE( publish_qos2 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_pub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
                     auto ret = chk.match(
                         "start",
@@ -343,14 +343,14 @@ BOOST_AUTO_TEST_CASE( publish_qos2 ) {
                 });
             c->set_v5_pubrec_handler(
                 [&chk, &pid_pub]
-                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_pubrec");
                     BOOST_TEST(packet_id == pid_pub);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 [&chk, &c, &pid_pub]
-                (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_pubcomp");
                     BOOST_TEST(packet_id == pid_pub);
                     c->disconnect();
@@ -435,7 +435,7 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2 ) {
             cont("h_close2"),
         };
 
-        std::vector<MQTT_NS::v5::property_variant> ps {
+        MQTT_NS::v5::properties ps {
             MQTT_NS::v5::property::reason_string("test success"_mb),
             MQTT_NS::v5::property::user_property("key1"_mb, "val1"_mb),
             MQTT_NS::v5::property::user_property("key2"_mb, "val2"_mb),
@@ -443,7 +443,7 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2 ) {
         std::size_t user_prop_count = 0;
 
         b.set_pubrel_props_handler(
-            [&user_prop_count, size = ps.size()] (std::vector<MQTT_NS::v5::property_variant> const& props) {
+            [&user_prop_count, size = ps.size()] (MQTT_NS::v5::properties const& props) {
                 BOOST_TEST(props.size() == size);
                 for (auto const& p : props) {
                     MQTT_NS::visit(
@@ -533,7 +533,7 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2 ) {
             c->set_auto_pub_response(false);
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_pub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
                     auto ret = chk.match(
                         "start",
@@ -561,7 +561,7 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2 ) {
                 });
             c->set_v5_pubrec_handler(
                 [&chk, &c, &pid_pub, ps = std::move(ps)]
-                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_pubrec");
                     BOOST_TEST(packet_id == pid_pub);
                     c->pubrel(packet_id, MQTT_NS::v5::pubrel_reason_code::success, std::move(ps));
@@ -570,7 +570,7 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2 ) {
                 });
             c->set_v5_pubcomp_handler(
                 [&chk, &c]
-                (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_pubcomp");
                     BOOST_TEST(packet_id == 1);
                     c->disconnect();
@@ -713,7 +713,7 @@ BOOST_AUTO_TEST_CASE( publish_pubrel_qos2 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, & pid_pub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
                     auto ret = chk.match(
                         "start",
@@ -747,7 +747,7 @@ BOOST_AUTO_TEST_CASE( publish_pubrel_qos2 ) {
                 });
             c->set_v5_pubrec_handler(
                 [&chk, &c, &pid_pub]
-                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_pubrec");
                     BOOST_TEST(packet_id == pid_pub);
                     c->force_disconnect();
@@ -755,7 +755,7 @@ BOOST_AUTO_TEST_CASE( publish_pubrel_qos2 ) {
                 });
             c->set_v5_pubcomp_handler(
                 [&chk, &c, &pid_pub]
-                (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_pubcomp");
                     BOOST_TEST(packet_id == pid_pub);
                     c->disconnect();
@@ -919,7 +919,7 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1 ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_pub1, &pid_pub2]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
                     auto ret = chk.match(
                         "start",
@@ -949,7 +949,7 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1 ) {
                 });
             c->set_v5_puback_handler(
                 [&chk, &c, &pid_pub1, &pid_pub2]
-                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     auto ret = chk.match(
                         "h_connack3",
                         [&] {

--- a/test/resend_serialize.cpp
+++ b/test/resend_serialize.cpp
@@ -816,7 +816,7 @@ BOOST_AUTO_TEST_CASE( publish_qos1_v5 ) {
         cont("h_close2"),
     };
 
-    std::vector<MQTT_NS::v5::property_variant> ps {
+    MQTT_NS::v5::properties ps {
         MQTT_NS::v5::property::payload_format_indicator(MQTT_NS::v5::property::payload_format_indicator::string),
         MQTT_NS::v5::property::message_expiry_interval(0x12345678UL),
         MQTT_NS::v5::property::topic_alias(0x1234U),
@@ -829,7 +829,7 @@ BOOST_AUTO_TEST_CASE( publish_qos1_v5 ) {
 
     std::size_t user_prop_count = 0;
     b.set_publish_props_handler(
-        [&user_prop_count, size = ps.size()] (std::vector<MQTT_NS::v5::property_variant> const& props) {
+        [&user_prop_count, size = ps.size()] (MQTT_NS::v5::properties const& props) {
             BOOST_TEST(props.size() == size);
 
             for (auto const& p : props) {
@@ -888,7 +888,7 @@ BOOST_AUTO_TEST_CASE( publish_qos1_v5 ) {
 
     c1->set_v5_connack_handler(
         [&chk, &c1, &pid_pub, ps = std::move(ps)]
-        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
             BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
             auto ret = chk.match(
                 "start",
@@ -949,7 +949,7 @@ BOOST_AUTO_TEST_CASE( publish_qos1_v5 ) {
 
     c2->set_v5_connack_handler(
         [&chk]
-        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
             BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
             MQTT_CHK("h_connack3");
             BOOST_TEST(sp == true);
@@ -963,7 +963,7 @@ BOOST_AUTO_TEST_CASE( publish_qos1_v5 ) {
         });
     c2->set_v5_puback_handler(
         [&chk, &c2, &pid_pub]
-        (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+        (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
             MQTT_CHK("h_puback");
             BOOST_TEST(packet_id == pid_pub);
             c2->disconnect();
@@ -1027,7 +1027,7 @@ BOOST_AUTO_TEST_CASE( publish_qos2_v5 ) {
 
     c1->set_v5_connack_handler(
         [&chk, &c1, &pid_pub]
-        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
             BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
             auto ret = chk.match(
                 "start",
@@ -1088,7 +1088,7 @@ BOOST_AUTO_TEST_CASE( publish_qos2_v5 ) {
 
     c2->set_v5_connack_handler(
         [&chk]
-        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
             BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
             MQTT_CHK("h_connack3");
             BOOST_TEST(sp == true);
@@ -1102,14 +1102,14 @@ BOOST_AUTO_TEST_CASE( publish_qos2_v5 ) {
         });
     c2->set_v5_pubrec_handler(
         [&chk, &pid_pub]
-        (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+        (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
             MQTT_CHK("h_pubrec");
             BOOST_TEST(packet_id == pid_pub);
             return true;
         });
     c2->set_v5_pubcomp_handler(
         [&chk, &c2, &pid_pub]
-        (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+        (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
             MQTT_CHK("h_pubcomp");
             BOOST_TEST(packet_id == pid_pub);
             c2->disconnect();
@@ -1171,7 +1171,7 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2_v5 ) {
         cont("h_close2"),
     };
 
-    std::vector<MQTT_NS::v5::property_variant> ps {
+    MQTT_NS::v5::properties ps {
         MQTT_NS::v5::property::reason_string("test success"_mb),
         MQTT_NS::v5::property::user_property("key1"_mb, "val1"_mb),
         MQTT_NS::v5::property::user_property("key2"_mb, "val2"_mb),
@@ -1179,7 +1179,7 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2_v5 ) {
     std::size_t user_prop_count = 0;
 
     b.set_pubrel_props_handler(
-        [&user_prop_count, size = ps.size()] (std::vector<MQTT_NS::v5::property_variant> const& props) {
+        [&user_prop_count, size = ps.size()] (MQTT_NS::v5::properties const& props) {
             BOOST_TEST(props.size() == size);
             for (auto const& p : props) {
                 MQTT_NS::visit(
@@ -1222,7 +1222,7 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2_v5 ) {
 
     c1->set_v5_connack_handler(
         [&chk, &c1, &pid_pub]
-        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
             BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
             auto ret = chk.match(
                 "start",
@@ -1281,7 +1281,7 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2_v5 ) {
         });
     c1->set_v5_pubrec_handler(
         [&chk, &c1, &pid_pub, ps = std::move(ps)]
-        (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+        (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
             MQTT_CHK("h_pubrec");
             BOOST_TEST(packet_id == pid_pub);
             c1->pubrel(packet_id, MQTT_NS::v5::pubrel_reason_code::success, std::move(ps));
@@ -1291,7 +1291,7 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2_v5 ) {
 
     c2->set_v5_connack_handler(
         [&chk]
-        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
             BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
             MQTT_CHK("h_connack3");
             BOOST_TEST(sp == true);
@@ -1305,7 +1305,7 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2_v5 ) {
         });
     c2->set_v5_pubcomp_handler(
         [&chk, &c2]
-        (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+        (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
             MQTT_CHK("h_pubcomp");
             BOOST_TEST(packet_id == 1);
             c2->disconnect();
@@ -1370,7 +1370,7 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1_v5 ) {
 
     c1->set_v5_connack_handler(
         [&chk, &c1, &pid_pub1, &pid_pub2]
-        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
             BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
             auto ret = chk.match(
                 "start",
@@ -1431,7 +1431,7 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1_v5 ) {
         });
     c2->set_v5_connack_handler(
         [&chk]
-        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
             BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
             MQTT_CHK("h_connack3");
             BOOST_TEST(sp == true);
@@ -1445,7 +1445,7 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1_v5 ) {
         });
     c2->set_v5_puback_handler(
         [&chk, &c2, &pid_pub1, &pid_pub2]
-        (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+        (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
             auto ret = chk.match(
                 "start",
                 [&] {

--- a/test/resend_serialize_ptr_size.cpp
+++ b/test/resend_serialize_ptr_size.cpp
@@ -619,7 +619,7 @@ BOOST_AUTO_TEST_CASE( publish_qos1_v5 ) {
         cont("h_close2"),
     };
 
-    std::vector<MQTT_NS::v5::property_variant> ps {
+    MQTT_NS::v5::properties ps {
         MQTT_NS::v5::property::payload_format_indicator(MQTT_NS::v5::property::payload_format_indicator::string),
         MQTT_NS::v5::property::message_expiry_interval(0x12345678UL),
         MQTT_NS::v5::property::topic_alias(0x1234U),
@@ -632,7 +632,7 @@ BOOST_AUTO_TEST_CASE( publish_qos1_v5 ) {
 
     std::size_t user_prop_count = 0;
     b.set_publish_props_handler(
-        [&user_prop_count, size = ps.size()] (std::vector<MQTT_NS::v5::property_variant> const& props) {
+        [&user_prop_count, size = ps.size()] (MQTT_NS::v5::properties const& props) {
             BOOST_TEST(props.size() == size);
 
             for (auto const& p : props) {
@@ -691,7 +691,7 @@ BOOST_AUTO_TEST_CASE( publish_qos1_v5 ) {
 
     c1->set_v5_connack_handler(
         [&chk, &c1, &pid_pub, ps = std::move(ps)]
-        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
             BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
             auto ret = chk.match(
                 "start",
@@ -744,7 +744,7 @@ BOOST_AUTO_TEST_CASE( publish_qos1_v5 ) {
 
     c2->set_v5_connack_handler(
         [&chk]
-        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
             BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
             MQTT_CHK("h_connack3");
             BOOST_TEST(sp == true);
@@ -758,7 +758,7 @@ BOOST_AUTO_TEST_CASE( publish_qos1_v5 ) {
         });
     c2->set_v5_puback_handler(
         [&chk, &c2, &pid_pub]
-        (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+        (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
             MQTT_CHK("h_puback");
             BOOST_TEST(packet_id == pid_pub);
             c2->disconnect();
@@ -816,7 +816,7 @@ BOOST_AUTO_TEST_CASE( publish_qos2_v5 ) {
 
     c1->set_v5_connack_handler(
         [&chk, &c1, &pid_pub]
-        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
             BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
             auto ret = chk.match(
                 "start",
@@ -869,7 +869,7 @@ BOOST_AUTO_TEST_CASE( publish_qos2_v5 ) {
 
     c2->set_v5_connack_handler(
         [&chk]
-        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
             BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
             MQTT_CHK("h_connack3");
             BOOST_TEST(sp == true);
@@ -883,14 +883,14 @@ BOOST_AUTO_TEST_CASE( publish_qos2_v5 ) {
         });
     c2->set_v5_pubrec_handler(
         [&chk, &pid_pub]
-        (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+        (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
             MQTT_CHK("h_pubrec");
             BOOST_TEST(packet_id == pid_pub);
             return true;
         });
     c2->set_v5_pubcomp_handler(
         [&chk, &c2, &pid_pub]
-        (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+        (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
             MQTT_CHK("h_pubcomp");
             BOOST_TEST(packet_id == pid_pub);
             c2->disconnect();
@@ -946,7 +946,7 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2_v5 ) {
         cont("h_close2"),
     };
 
-    std::vector<MQTT_NS::v5::property_variant> ps {
+    MQTT_NS::v5::properties ps {
         MQTT_NS::v5::property::reason_string("test success"_mb),
         MQTT_NS::v5::property::user_property("key1"_mb, "val1"_mb),
         MQTT_NS::v5::property::user_property("key2"_mb, "val2"_mb),
@@ -954,7 +954,7 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2_v5 ) {
     std::size_t user_prop_count = 0;
 
     b.set_pubrel_props_handler(
-        [&user_prop_count, size = ps.size()] (std::vector<MQTT_NS::v5::property_variant> const& props) {
+        [&user_prop_count, size = ps.size()] (MQTT_NS::v5::properties const& props) {
             BOOST_TEST(props.size() == size);
             for (auto const& p : props) {
                 MQTT_NS::visit(
@@ -997,7 +997,7 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2_v5 ) {
 
     c1->set_v5_connack_handler(
         [&chk, &c1, &pid_pub]
-        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
             BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
             auto ret = chk.match(
                 "start",
@@ -1048,7 +1048,7 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2_v5 ) {
         });
     c1->set_v5_pubrec_handler(
         [&chk, &c1, &pid_pub, ps = std::move(ps)]
-        (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+        (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
             MQTT_CHK("h_pubrec");
             BOOST_TEST(packet_id == pid_pub);
             c1->pubrel(packet_id, MQTT_NS::v5::pubrel_reason_code::success, std::move(ps));
@@ -1058,7 +1058,7 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2_v5 ) {
 
     c2->set_v5_connack_handler(
         [&chk]
-        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
             BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
             MQTT_CHK("h_connack3");
             BOOST_TEST(sp == true);
@@ -1072,7 +1072,7 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2_v5 ) {
         });
     c2->set_v5_pubcomp_handler(
         [&chk, &c2]
-        (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+        (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
             MQTT_CHK("h_pubcomp");
             BOOST_TEST(packet_id == 1);
             c2->disconnect();
@@ -1131,7 +1131,7 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1_v5 ) {
 
     c1->set_v5_connack_handler(
         [&chk, &c1, &pid_pub1, &pid_pub2]
-        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
             BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
             auto ret = chk.match(
                 "start",
@@ -1184,7 +1184,7 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1_v5 ) {
         });
     c2->set_v5_connack_handler(
         [&chk]
-        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
             BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
             MQTT_CHK("h_connack3");
             BOOST_TEST(sp == true);
@@ -1198,7 +1198,7 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1_v5 ) {
         });
     c2->set_v5_puback_handler(
         [&chk, &c2, &pid_pub1, &pid_pub2]
-        (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+        (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
             auto ret = chk.match(
                 "h_connack3",
                 [&] {

--- a/test/retain.cpp
+++ b/test/retain.cpp
@@ -106,7 +106,7 @@ BOOST_AUTO_TEST_CASE( simple ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -118,25 +118,25 @@ BOOST_AUTO_TEST_CASE( simple ) {
                 });
             c->set_v5_puback_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -145,7 +145,7 @@ BOOST_AUTO_TEST_CASE( simple ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -161,7 +161,7 @@ BOOST_AUTO_TEST_CASE( simple ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
@@ -292,7 +292,7 @@ BOOST_AUTO_TEST_CASE( overwrite ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -306,25 +306,25 @@ BOOST_AUTO_TEST_CASE( overwrite ) {
                 });
             c->set_v5_puback_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -333,7 +333,7 @@ BOOST_AUTO_TEST_CASE( overwrite ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
@@ -349,7 +349,7 @@ BOOST_AUTO_TEST_CASE( overwrite ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
@@ -512,7 +512,7 @@ BOOST_AUTO_TEST_CASE( retain_and_publish ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c, &pid_sub]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -521,25 +521,25 @@ BOOST_AUTO_TEST_CASE( retain_and_publish ) {
                 });
             c->set_v5_puback_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubrec_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_pubcomp_handler(
                 []
-                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_CHECK(false);
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c, &pid_sub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
                     BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_0);
@@ -559,7 +559,7 @@ BOOST_AUTO_TEST_CASE( retain_and_publish ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c, &pid_sub, &pid_unsub]
-                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     BOOST_TEST(packet_id == pid_unsub);
                     BOOST_TEST(reasons.size() == 1U);
                     BOOST_TEST(reasons[0] == MQTT_NS::v5::unsuback_reason_code::success);
@@ -586,7 +586,7 @@ BOOST_AUTO_TEST_CASE( retain_and_publish ) {
                  MQTT_NS::optional<packet_id_t> packet_id,
                  MQTT_NS::string_view topic,
                  MQTT_NS::string_view contents,
-                 std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                 MQTT_NS::v5::properties /*props*/) {
                     BOOST_TEST(is_dup == false);
                     BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
                     BOOST_CHECK(!packet_id);
@@ -655,7 +655,7 @@ BOOST_AUTO_TEST_CASE( prop ) {
             cont("h_close"),
         };
 
-        std::vector<MQTT_NS::v5::property_variant> ps {
+        MQTT_NS::v5::properties ps {
             MQTT_NS::v5::property::payload_format_indicator(MQTT_NS::v5::property::payload_format_indicator::string),
             MQTT_NS::v5::property::message_expiry_interval(0x12345678UL),
             MQTT_NS::v5::property::topic_alias(0x1234U),
@@ -671,7 +671,7 @@ BOOST_AUTO_TEST_CASE( prop ) {
 
         c->set_v5_connack_handler(
             [&chk, &c, &pid_sub, ps = std::move(ps)]
-            (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_connack");
                 BOOST_TEST(sp == false);
                 BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -683,25 +683,25 @@ BOOST_AUTO_TEST_CASE( prop ) {
             });
         c->set_v5_puback_handler(
             []
-            (packet_id_t, MQTT_NS::v5::puback_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                 BOOST_CHECK(false);
                 return true;
             });
         c->set_v5_pubrec_handler(
             []
-            (packet_id_t, MQTT_NS::v5::pubrec_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
                 BOOST_CHECK(false);
                 return true;
             });
         c->set_v5_pubcomp_handler(
             []
-            (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                 BOOST_CHECK(false);
                 return true;
             });
         c->set_v5_suback_handler(
             [&chk, &pid_sub]
-            (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_suback");
                 BOOST_TEST(packet_id == pid_sub);
                 BOOST_TEST(reasons.size() == 1U);
@@ -710,7 +710,7 @@ BOOST_AUTO_TEST_CASE( prop ) {
             });
         c->set_v5_unsuback_handler(
             [&chk, &c, &pid_unsub]
-            (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_unsuback");
                 BOOST_TEST(packet_id == pid_unsub);
                 BOOST_TEST(reasons.size() == 1U);
@@ -726,7 +726,7 @@ BOOST_AUTO_TEST_CASE( prop ) {
              MQTT_NS::optional<packet_id_t> packet_id,
              MQTT_NS::string_view topic,
              MQTT_NS::string_view contents,
-             std::vector<MQTT_NS::v5::property_variant> props) {
+             MQTT_NS::v5::properties props) {
                 MQTT_CHK("h_publish");
                 BOOST_TEST(is_dup == false);
                 BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);

--- a/test/sub.cpp
+++ b/test/sub.cpp
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_single ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -71,14 +71,14 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_single ) {
                 });
             c->set_v5_suback_handler(
                 [&chk, &c]
-                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::suback_reason_code> /*reasons*/, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::suback_reason_code> /*reasons*/, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     c->unsubscribe("topic1");
                     return true;
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c]
-                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::unsuback_reason_code> /*reasons*/, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::unsuback_reason_code> /*reasons*/, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     c->disconnect();
                     return true;
@@ -153,7 +153,7 @@ BOOST_AUTO_TEST_CASE( sub_v5_options ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -165,14 +165,14 @@ BOOST_AUTO_TEST_CASE( sub_v5_options ) {
                 });
             c->set_v5_suback_handler(
                 [&chk, &c]
-                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::suback_reason_code> /*reasons*/, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::suback_reason_code> /*reasons*/, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     c->unsubscribe("topic1");
                     return true;
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c]
-                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::unsuback_reason_code> /*reasons*/, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::unsuback_reason_code> /*reasons*/, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     c->disconnect();
                     return true;
@@ -252,7 +252,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -266,14 +266,14 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg ) {
                 });
             c->set_v5_suback_handler(
                 [&chk, &c]
-                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::suback_reason_code> /*reasons*/, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::suback_reason_code> /*reasons*/, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     c->unsubscribe( { MQTT_NS::string_view{"topic1"}, MQTT_NS::string_view{"topic2"} });
                     return true;
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c]
-                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::unsuback_reason_code> /*reasons*/, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::unsuback_reason_code> /*reasons*/, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     c->disconnect();
                     return true;
@@ -356,7 +356,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -368,7 +368,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec ) {
                 });
             c->set_v5_suback_handler(
                 [&chk, &c]
-                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::suback_reason_code> /*reasons*/, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::suback_reason_code> /*reasons*/, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     std::vector<MQTT_NS::string_view> v
                         {
@@ -380,7 +380,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c]
-                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::unsuback_reason_code> /*reasons*/, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::unsuback_reason_code> /*reasons*/, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     c->disconnect();
                     return true;
@@ -455,7 +455,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_single_async ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -464,14 +464,14 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_single_async ) {
                 });
             c->set_v5_suback_handler(
                 [&chk, &c]
-                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::suback_reason_code> /*reasons*/, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::suback_reason_code> /*reasons*/, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     c->async_unsubscribe("topic1", [](boost::system::error_code const&) {});
                     return true;
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c]
-                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::unsuback_reason_code> /*reasons*/, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::unsuback_reason_code> /*reasons*/, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     c->async_disconnect();
                     return true;
@@ -558,7 +558,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg_async ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -573,7 +573,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg_async ) {
                 });
             c->set_v5_suback_handler(
                 [&chk, &c]
-                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::suback_reason_code> /*reasons*/, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::suback_reason_code> /*reasons*/, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     c->async_unsubscribe(
                         std::vector<std::string> {
@@ -586,7 +586,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg_async ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c]
-                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::unsuback_reason_code> /*reasons*/, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::unsuback_reason_code> /*reasons*/, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     c->async_disconnect();
                     return true;
@@ -675,7 +675,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec_async ) {
         case MQTT_NS::protocol_version::v5:
             c->set_v5_connack_handler(
                 [&chk, &c]
-                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -690,7 +690,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec_async ) {
                 });
             c->set_v5_suback_handler(
                 [&chk, &c]
-                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::suback_reason_code> /*reasons*/, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::suback_reason_code> /*reasons*/, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
                     std::vector<std::string> v
                         {
@@ -705,7 +705,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec_async ) {
                 });
             c->set_v5_unsuback_handler(
                 [&chk, &c]
-                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::unsuback_reason_code> /*reasons*/, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::unsuback_reason_code> /*reasons*/, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_unsuback");
                     c->async_disconnect();
                     return true;
@@ -753,13 +753,13 @@ BOOST_AUTO_TEST_CASE( sub_unsub_prop ) {
             cont("h_close"),
         };
 
-        std::vector<MQTT_NS::v5::property_variant> subps {
+        MQTT_NS::v5::properties subps {
             MQTT_NS::v5::property::subscription_identifier(268435455UL),
             MQTT_NS::v5::property::user_property("key1"_mb, "val1"_mb),
             MQTT_NS::v5::property::user_property("key2"_mb, "val2"_mb)
         };
 
-        std::vector<MQTT_NS::v5::property_variant> unsubps {
+        MQTT_NS::v5::properties unsubps {
             MQTT_NS::v5::property::user_property("key1"_mb, "val1"_mb),
             MQTT_NS::v5::property::user_property("key2"_mb, "val2"_mb)
         };
@@ -768,7 +768,7 @@ BOOST_AUTO_TEST_CASE( sub_unsub_prop ) {
         std::size_t unsub_user_prop_count = 0;
 
         b.set_subscribe_props_handler(
-            [&sub_user_prop_count, size = subps.size()] (std::vector<MQTT_NS::v5::property_variant> const& props) {
+            [&sub_user_prop_count, size = subps.size()] (MQTT_NS::v5::properties const& props) {
                 BOOST_TEST(props.size() == size);
                 for (auto const& p : props) {
                     MQTT_NS::visit(
@@ -802,7 +802,7 @@ BOOST_AUTO_TEST_CASE( sub_unsub_prop ) {
         );
 
         b.set_unsubscribe_props_handler(
-            [&unsub_user_prop_count, size = unsubps.size()] (std::vector<MQTT_NS::v5::property_variant> const& props) {
+            [&unsub_user_prop_count, size = unsubps.size()] (MQTT_NS::v5::properties const& props) {
                 BOOST_TEST(props.size() == size);
                 for (auto const& p : props) {
                     MQTT_NS::visit(
@@ -834,7 +834,7 @@ BOOST_AUTO_TEST_CASE( sub_unsub_prop ) {
 
         c->set_v5_connack_handler(
             [&chk, &c, &subps]
-            (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_connack");
                 BOOST_TEST(sp == false);
                 BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -843,14 +843,14 @@ BOOST_AUTO_TEST_CASE( sub_unsub_prop ) {
             });
         c->set_v5_suback_handler(
             [&chk, &c, &unsubps]
-            (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::suback_reason_code> /*reasons*/, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::suback_reason_code> /*reasons*/, MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_suback");
                 c->unsubscribe("topic1", unsubps);
                 return true;
             });
         c->set_v5_unsuback_handler(
             [&chk, &c]
-            (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::unsuback_reason_code> /*reasons*/, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::unsuback_reason_code> /*reasons*/, MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_unsuback");
                 c->disconnect();
                 return true;
@@ -892,7 +892,7 @@ BOOST_AUTO_TEST_CASE( suback_unsuback_prop ) {
             cont("h_close"),
         };
 
-        std::vector<MQTT_NS::v5::property_variant> subackps {
+        MQTT_NS::v5::properties subackps {
             MQTT_NS::v5::property::reason_string("test success"_mb),
             MQTT_NS::v5::property::user_property("key1"_mb, "val1"_mb),
             MQTT_NS::v5::property::user_property("key2"_mb, "val2"_mb),
@@ -900,7 +900,7 @@ BOOST_AUTO_TEST_CASE( suback_unsuback_prop ) {
         auto suback_prop_size = subackps.size();
         b.set_suback_props(std::move(subackps));
 
-        std::vector<MQTT_NS::v5::property_variant> unsubackps {
+        MQTT_NS::v5::properties unsubackps {
             MQTT_NS::v5::property::reason_string("test success"_mb),
             MQTT_NS::v5::property::user_property("key1"_mb, "val1"_mb),
             MQTT_NS::v5::property::user_property("key2"_mb, "val2"_mb),
@@ -913,7 +913,7 @@ BOOST_AUTO_TEST_CASE( suback_unsuback_prop ) {
 
         c->set_v5_connack_handler(
             [&chk, &c]
-            (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+            (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_connack");
                 BOOST_TEST(sp == false);
                 BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -922,7 +922,7 @@ BOOST_AUTO_TEST_CASE( suback_unsuback_prop ) {
             });
         c->set_v5_suback_handler(
             [&chk, &c, &sub_user_prop_count, suback_prop_size]
-            (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::suback_reason_code> /*reasons*/, std::vector<MQTT_NS::v5::property_variant> props) {
+            (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::suback_reason_code> /*reasons*/, MQTT_NS::v5::properties props) {
                 MQTT_CHK("h_suback");
                 BOOST_TEST(props.size() == suback_prop_size);
                 for (auto const& p : props) {
@@ -959,7 +959,7 @@ BOOST_AUTO_TEST_CASE( suback_unsuback_prop ) {
             });
         c->set_v5_unsuback_handler(
             [&chk, &c, &unsub_user_prop_count, unsuback_prop_size]
-            (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::unsuback_reason_code> /*reasons*/, std::vector<MQTT_NS::v5::property_variant> props) {
+            (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::unsuback_reason_code> /*reasons*/, MQTT_NS::v5::properties props) {
                 MQTT_CHK("h_unsuback");
                 BOOST_TEST(props.size() == unsuback_prop_size);
                 for (auto const& p : props) {

--- a/test/test_broker.hpp
+++ b/test/test_broker.hpp
@@ -129,7 +129,7 @@ public:
              MQTT_NS::optional<MQTT_NS::will> will,
              bool clean_session,
              std::uint16_t keep_alive,
-             std::vector<MQTT_NS::v5::property_variant> props) {
+             MQTT_NS::v5::properties props) {
                 con_sp_t sp = wp.lock();
                 BOOST_ASSERT(sp);
                 return
@@ -156,7 +156,7 @@ public:
         );
         ep.set_v5_disconnect_handler(
             [this, wp]
-            (MQTT_NS::v5::disconnect_reason_code /*reason_code*/, std::vector<MQTT_NS::v5::property_variant> props) {
+            (MQTT_NS::v5::disconnect_reason_code /*reason_code*/, MQTT_NS::v5::properties props) {
                 if (h_disconnect_props_) h_disconnect_props_(std::move(props));
                 con_sp_t sp = wp.lock();
                 BOOST_ASSERT(sp);
@@ -173,7 +173,7 @@ public:
             []
             (packet_id_t /*packet_id*/,
              MQTT_NS::v5::puback_reason_code /*reason_code*/,
-             std::vector<MQTT_NS::v5::property_variant> /*props*/){
+             MQTT_NS::v5::properties /*props*/){
                 return true;
             });
         ep.set_pubrec_handler(
@@ -188,7 +188,7 @@ public:
             [this, wp]
             (packet_id_t packet_id,
              MQTT_NS::v5::pubrec_reason_code /*reason_code*/,
-             std::vector<MQTT_NS::v5::property_variant> /*props*/){
+             MQTT_NS::v5::properties /*props*/){
                 con_sp_t sp = wp.lock();
                 BOOST_ASSERT(sp);
                 sp->pubrel(packet_id, MQTT_NS::v5::pubrel_reason_code::success, pubrel_props_);
@@ -206,7 +206,7 @@ public:
             [this, wp]
             (packet_id_t packet_id,
              MQTT_NS::v5::pubrel_reason_code /*reason_code*/,
-             std::vector<MQTT_NS::v5::property_variant> /*props*/){
+             MQTT_NS::v5::properties /*props*/){
                 con_sp_t sp = wp.lock();
                 BOOST_ASSERT(sp);
                 sp->pubcomp(packet_id, MQTT_NS::v5::pubcomp_reason_code::success, pubcomp_props_);
@@ -221,7 +221,7 @@ public:
             []
             (packet_id_t /*packet_id*/,
              MQTT_NS::v5::pubcomp_reason_code /*reason_code*/,
-             std::vector<MQTT_NS::v5::property_variant> /*props*/){
+             MQTT_NS::v5::properties /*props*/){
                 return true;
             });
         ep.set_publish_handler(
@@ -253,7 +253,7 @@ public:
              MQTT_NS::optional<packet_id_t> packet_id,
              MQTT_NS::buffer topic_name,
              MQTT_NS::buffer contents,
-             std::vector<MQTT_NS::v5::property_variant> props
+             MQTT_NS::v5::properties props
             ) {
                 if (h_publish_props_) h_publish_props_(props);
                 con_sp_t sp = wp.lock();
@@ -287,7 +287,7 @@ public:
             [this, wp]
             (packet_id_t packet_id,
              std::vector<std::tuple<MQTT_NS::buffer, MQTT_NS::subscribe_options>> entries,
-             std::vector<MQTT_NS::v5::property_variant> props
+             MQTT_NS::v5::properties props
             ) {
                 con_sp_t sp = wp.lock();
                 BOOST_ASSERT(sp);
@@ -317,7 +317,7 @@ public:
             [this, wp]
             (packet_id_t packet_id,
              std::vector<MQTT_NS::buffer> topics,
-             std::vector<MQTT_NS::v5::property_variant> props
+             MQTT_NS::v5::properties props
             ) {
                 con_sp_t sp = wp.lock();
                 BOOST_ASSERT(sp);
@@ -340,7 +340,7 @@ public:
         ep.set_v5_auth_handler(
             [this]
             (MQTT_NS::v5::auth_reason_code /*reason_code*/,
-             std::vector<MQTT_NS::v5::property_variant> props
+             MQTT_NS::v5::properties props
             ) {
                 if (h_auth_props_) h_auth_props_(std::move(props));
                 return true;
@@ -348,71 +348,71 @@ public:
         );
     }
 
-    void set_connack_props(std::vector<MQTT_NS::v5::property_variant> props) {
+    void set_connack_props(MQTT_NS::v5::properties props) {
         connack_props_ = std::move(props);
     }
 
-    void set_suback_props(std::vector<MQTT_NS::v5::property_variant> props) {
+    void set_suback_props(MQTT_NS::v5::properties props) {
         suback_props_ = std::move(props);
     }
 
-    void set_unsuback_props(std::vector<MQTT_NS::v5::property_variant> props) {
+    void set_unsuback_props(MQTT_NS::v5::properties props) {
         unsuback_props_ = std::move(props);
     }
 
-    void set_puback_props(std::vector<MQTT_NS::v5::property_variant> props) {
+    void set_puback_props(MQTT_NS::v5::properties props) {
         puback_props_ = std::move(props);
     }
 
-    void set_pubrec_props(std::vector<MQTT_NS::v5::property_variant> props) {
+    void set_pubrec_props(MQTT_NS::v5::properties props) {
         pubrec_props_ = std::move(props);
     }
 
-    void set_pubrel_props(std::vector<MQTT_NS::v5::property_variant> props) {
+    void set_pubrel_props(MQTT_NS::v5::properties props) {
         pubrel_props_ = std::move(props);
     }
 
-    void set_pubcomp_props(std::vector<MQTT_NS::v5::property_variant> props) {
+    void set_pubcomp_props(MQTT_NS::v5::properties props) {
         pubcomp_props_ = std::move(props);
     }
 
-    void set_connect_props_handler(std::function<void(std::vector<MQTT_NS::v5::property_variant> const&)> h) {
+    void set_connect_props_handler(std::function<void(MQTT_NS::v5::properties const&)> h) {
         h_connect_props_ = std::move(h);
     }
 
-    void set_disconnect_props_handler(std::function<void(std::vector<MQTT_NS::v5::property_variant> const&)> h) {
+    void set_disconnect_props_handler(std::function<void(MQTT_NS::v5::properties const&)> h) {
         h_disconnect_props_ = std::move(h);
     }
 
-    void set_publish_props_handler(std::function<void(std::vector<MQTT_NS::v5::property_variant> const&)> h) {
+    void set_publish_props_handler(std::function<void(MQTT_NS::v5::properties const&)> h) {
         h_publish_props_ = std::move(h);
     }
 
-    void set_puback_props_handler(std::function<void(std::vector<MQTT_NS::v5::property_variant> const&)> h) {
+    void set_puback_props_handler(std::function<void(MQTT_NS::v5::properties const&)> h) {
         h_puback_props_ = std::move(h);
     }
 
-    void set_pubrec_props_handler(std::function<void(std::vector<MQTT_NS::v5::property_variant> const&)> h) {
+    void set_pubrec_props_handler(std::function<void(MQTT_NS::v5::properties const&)> h) {
         h_pubrec_props_ = std::move(h);
     }
 
-    void set_pubrel_props_handler(std::function<void(std::vector<MQTT_NS::v5::property_variant> const&)> h) {
+    void set_pubrel_props_handler(std::function<void(MQTT_NS::v5::properties const&)> h) {
         h_pubrel_props_ = std::move(h);
     }
 
-    void set_pubcomp_props_handler(std::function<void(std::vector<MQTT_NS::v5::property_variant> const&)> h) {
+    void set_pubcomp_props_handler(std::function<void(MQTT_NS::v5::properties const&)> h) {
         h_pubcomp_props_ = std::move(h);
     }
 
-    void set_subscribe_props_handler(std::function<void(std::vector<MQTT_NS::v5::property_variant> const&)> h) {
+    void set_subscribe_props_handler(std::function<void(MQTT_NS::v5::properties const&)> h) {
         h_subscribe_props_ = std::move(h);
     }
 
-    void set_unsubscribe_props_handler(std::function<void(std::vector<MQTT_NS::v5::property_variant> const&)> h) {
+    void set_unsubscribe_props_handler(std::function<void(MQTT_NS::v5::properties const&)> h) {
         h_unsubscribe_props_ = std::move(h);
     }
 
-    void set_auth_props_handler(std::function<void(std::vector<MQTT_NS::v5::property_variant> const&)> h) {
+    void set_auth_props_handler(std::function<void(MQTT_NS::v5::properties const&)> h) {
         h_auth_props_ = std::move(h);
     }
 
@@ -442,7 +442,7 @@ private:
         MQTT_NS::optional<MQTT_NS::will> will,
         bool clean_session,
         std::uint16_t /*keep_alive*/,
-        std::vector<MQTT_NS::v5::property_variant> props
+        MQTT_NS::v5::properties props
     ) {
 
         MQTT_NS::optional<boost::posix_time::time_duration> session_expiry_interval;
@@ -651,7 +651,7 @@ private:
         MQTT_NS::optional<packet_id_t> packet_id,
         MQTT_NS::buffer topic_name,
         MQTT_NS::buffer contents,
-        std::vector<MQTT_NS::v5::property_variant> props) {
+        MQTT_NS::v5::properties props) {
         (void)is_dup;
 
         auto& ep = *spep;
@@ -699,7 +699,7 @@ private:
         con_sp_t spep,
         packet_id_t packet_id,
         std::vector<std::tuple<MQTT_NS::buffer, MQTT_NS::subscribe_options>> entries,
-        std::vector<MQTT_NS::v5::property_variant> props) {
+        MQTT_NS::v5::properties props) {
 
         auto& ep = *spep;
 
@@ -768,7 +768,7 @@ private:
         con_sp_t spep,
         packet_id_t packet_id,
         std::vector<MQTT_NS::buffer> topics,
-        std::vector<MQTT_NS::v5::property_variant> props) {
+        MQTT_NS::v5::properties props) {
 
         auto& ep = *spep;
 
@@ -838,7 +838,7 @@ private:
         MQTT_NS::buffer contents,
         MQTT_NS::qos qos_value,
         bool is_retain,
-        std::vector<MQTT_NS::v5::property_variant> props) {
+        MQTT_NS::v5::properties props) {
         // For each active subscription registered for this topic
         for(auto const& sub : boost::make_iterator_range(subs_.get<tag_topic>().equal_range(topic))) {
             // publish the message to subscribers.
@@ -865,7 +865,7 @@ private:
             auto & idx = saved_subs_.get<tag_topic>();
             auto range = boost::make_iterator_range(idx.equal_range(topic));
             if( ! range.empty()) {
-                auto sp_props = std::make_shared<std::vector<MQTT_NS::v5::property_variant>>(props);
+                auto sp_props = std::make_shared<MQTT_NS::v5::properties>(props);
                 for(auto it = range.begin(); it != range.end(); std::advance(it, 1)) {
                     idx.modify(it,
                                [&](session_subscription & val)
@@ -1152,12 +1152,12 @@ private:
         retain(
             MQTT_NS::buffer topic,
             MQTT_NS::buffer contents,
-            std::vector<MQTT_NS::v5::property_variant> props,
+            MQTT_NS::v5::properties props,
             MQTT_NS::qos qos_value)
             :topic(std::move(topic)), contents(std::move(contents)), props(std::move(props)), qos_value(qos_value) {}
         MQTT_NS::buffer topic;
         MQTT_NS::buffer contents;
-        std::vector<MQTT_NS::v5::property_variant> props;
+        MQTT_NS::v5::properties props;
         MQTT_NS::qos qos_value;
     };
     using mi_retain = mi::multi_index_container<
@@ -1177,11 +1177,11 @@ private:
     struct saved_message {
         saved_message(
             MQTT_NS::buffer contents,
-            std::shared_ptr<std::vector<MQTT_NS::v5::property_variant>> props,
+            std::shared_ptr<MQTT_NS::v5::properties> props,
             MQTT_NS::qos qos_value)
             : contents(std::move(contents)), props(std::move(props)), qos_value(qos_value) {}
         MQTT_NS::buffer contents;
-        std::shared_ptr<std::vector<MQTT_NS::v5::property_variant>> props;
+        std::shared_ptr<MQTT_NS::v5::properties> props;
         MQTT_NS::qos qos_value;
     };
 
@@ -1237,23 +1237,23 @@ private:
     mi_retain retains_; ///< A list of messages retained so they can be sent to newly subscribed clients.
 
     // MQTTv5 members
-    std::vector<MQTT_NS::v5::property_variant> connack_props_;
-    std::vector<MQTT_NS::v5::property_variant> suback_props_;
-    std::vector<MQTT_NS::v5::property_variant> unsuback_props_;
-    std::vector<MQTT_NS::v5::property_variant> puback_props_;
-    std::vector<MQTT_NS::v5::property_variant> pubrec_props_;
-    std::vector<MQTT_NS::v5::property_variant> pubrel_props_;
-    std::vector<MQTT_NS::v5::property_variant> pubcomp_props_;
-    std::function<void(std::vector<MQTT_NS::v5::property_variant> const&)> h_connect_props_;
-    std::function<void(std::vector<MQTT_NS::v5::property_variant> const&)> h_disconnect_props_;
-    std::function<void(std::vector<MQTT_NS::v5::property_variant> const&)> h_publish_props_;
-    std::function<void(std::vector<MQTT_NS::v5::property_variant> const&)> h_puback_props_;
-    std::function<void(std::vector<MQTT_NS::v5::property_variant> const&)> h_pubrec_props_;
-    std::function<void(std::vector<MQTT_NS::v5::property_variant> const&)> h_pubrel_props_;
-    std::function<void(std::vector<MQTT_NS::v5::property_variant> const&)> h_pubcomp_props_;
-    std::function<void(std::vector<MQTT_NS::v5::property_variant> const&)> h_subscribe_props_;
-    std::function<void(std::vector<MQTT_NS::v5::property_variant> const&)> h_unsubscribe_props_;
-    std::function<void(std::vector<MQTT_NS::v5::property_variant> const&)> h_auth_props_;
+    MQTT_NS::v5::properties connack_props_;
+    MQTT_NS::v5::properties suback_props_;
+    MQTT_NS::v5::properties unsuback_props_;
+    MQTT_NS::v5::properties puback_props_;
+    MQTT_NS::v5::properties pubrec_props_;
+    MQTT_NS::v5::properties pubrel_props_;
+    MQTT_NS::v5::properties pubcomp_props_;
+    std::function<void(MQTT_NS::v5::properties const&)> h_connect_props_;
+    std::function<void(MQTT_NS::v5::properties const&)> h_disconnect_props_;
+    std::function<void(MQTT_NS::v5::properties const&)> h_publish_props_;
+    std::function<void(MQTT_NS::v5::properties const&)> h_puback_props_;
+    std::function<void(MQTT_NS::v5::properties const&)> h_pubrec_props_;
+    std::function<void(MQTT_NS::v5::properties const&)> h_pubrel_props_;
+    std::function<void(MQTT_NS::v5::properties const&)> h_pubcomp_props_;
+    std::function<void(MQTT_NS::v5::properties const&)> h_subscribe_props_;
+    std::function<void(MQTT_NS::v5::properties const&)> h_unsubscribe_props_;
+    std::function<void(MQTT_NS::v5::properties const&)> h_auth_props_;
 };
 
 #endif // MQTT_TEST_BROKER_HPP

--- a/test/test_util.hpp
+++ b/test/test_util.hpp
@@ -20,7 +20,7 @@ inline void connect_no_clean(Client& c) {
     case MQTT_NS::protocol_version::v5:
         // set session_expiry_interval as infinity.
         c->connect(
-            std::vector<MQTT_NS::v5::property_variant>{
+            MQTT_NS::v5::properties{
                 MQTT_NS::v5::property::session_expiry_interval(0xFFFFFFFFUL)
                     }
         );

--- a/test/will.cpp
+++ b/test/will.cpp
@@ -603,7 +603,7 @@ BOOST_AUTO_TEST_CASE( will_prop ) {
     c1->set_client_id("cid1");
     c1->set_clean_session(true);
 
-    std::vector<MQTT_NS::v5::property_variant> ps {
+    MQTT_NS::v5::properties ps {
         MQTT_NS::v5::property::payload_format_indicator(MQTT_NS::v5::property::payload_format_indicator::string),
         MQTT_NS::v5::property::message_expiry_interval(0x12345678UL),
         MQTT_NS::v5::property::will_delay_interval(0x12345678UL),
@@ -658,7 +658,7 @@ BOOST_AUTO_TEST_CASE( will_prop ) {
 
     c1->set_v5_connack_handler(
         [&chk, &c1_force_disconnect]
-        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
             MQTT_CHK("h_connack_1");
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -686,7 +686,7 @@ BOOST_AUTO_TEST_CASE( will_prop ) {
 
     c2->set_v5_connack_handler(
         [&chk, &c2, &pid_sub2]
-        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
             MQTT_CHK("h_connack_2");
             BOOST_TEST(sp == false);
             BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
@@ -706,7 +706,7 @@ BOOST_AUTO_TEST_CASE( will_prop ) {
         });
     c2->set_v5_suback_handler(
         [&chk, &c1_force_disconnect, &pid_sub2]
-        (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+        (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
             MQTT_CHK("h_suback_2");
             BOOST_TEST(packet_id == pid_sub2);
             BOOST_TEST(reasons.size() == 1U);
@@ -716,7 +716,7 @@ BOOST_AUTO_TEST_CASE( will_prop ) {
         });
     c2->set_v5_unsuback_handler(
         [&chk, &c2, &pid_unsub2]
-        (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, std::vector<MQTT_NS::v5::property_variant> /*props*/) {
+        (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
             MQTT_CHK("h_unsuback_2");
             BOOST_TEST(packet_id == pid_unsub2);
             BOOST_TEST(reasons.size() == 1U);
@@ -732,7 +732,7 @@ BOOST_AUTO_TEST_CASE( will_prop ) {
          MQTT_NS::optional<packet_id_t> packet_id,
          MQTT_NS::string_view topic,
          MQTT_NS::string_view contents,
-         std::vector<MQTT_NS::v5::property_variant> props) {
+         MQTT_NS::v5::properties props) {
             MQTT_CHK("h_publish_2");
             BOOST_TEST(is_dup == false);
             BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);


### PR DESCRIPTION
This is purely a cosmetic change.

It just replaces the longer name, with the name of the typedef, in the whole codebase.

The goal is to make functions a bit easier to read by using the shorter name.