### PR TITLE
Fixed #526.

### DIFF
--- a/include/mqtt/endpoint.hpp
+++ b/include/mqtt/endpoint.hpp
@@ -6735,6 +6735,10 @@ public:
         return socket_.value();
     }
 
+    auto get_executor() {
+        return socket_.value().get_executor();
+    }
+
 protected:
 
     /**

--- a/include/mqtt/tcp_endpoint.hpp
+++ b/include/mqtt/tcp_endpoint.hpp
@@ -34,8 +34,8 @@ public:
         tcp_.lowest_layer().close(std::forward<Args>(args)...);
     }
 
-    as::io_context& get_io_context() {
-        return tcp_.get_io_context();
+    typename Socket::executor_type get_executor() {
+        return tcp_.get_executor();
     }
 
     Socket& socket() { return tcp_; }

--- a/include/mqtt/tcp_endpoint.hpp
+++ b/include/mqtt/tcp_endpoint.hpp
@@ -34,8 +34,8 @@ public:
         tcp_.lowest_layer().close(std::forward<Args>(args)...);
     }
 
-    typename Socket::executor_type get_executor() {
-        return tcp_.get_executor();
+    auto get_executor() {
+        return lowest_layer().get_executor();
     }
 
     Socket& socket() { return tcp_; }

--- a/include/mqtt/type_erased_socket.hpp
+++ b/include/mqtt/type_erased_socket.hpp
@@ -27,6 +27,7 @@ BOOST_TYPE_ERASURE_MEMBER((MQTT_NS)(has_write), write, 2)
 BOOST_TYPE_ERASURE_MEMBER((MQTT_NS)(has_post), post, 1)
 BOOST_TYPE_ERASURE_MEMBER((MQTT_NS)(has_lowest_layer), lowest_layer, 0)
 BOOST_TYPE_ERASURE_MEMBER((MQTT_NS)(has_close), close, 1)
+BOOST_TYPE_ERASURE_MEMBER((MQTT_NS)(has_get_executor), get_executor, 0)
 
 namespace MQTT_NS {
 
@@ -50,7 +51,8 @@ using socket = shared_any<
         has_write<std::size_t(std::vector<as::const_buffer>, boost::system::error_code&)>,
         has_post<void(std::function<void()>)>,
         has_lowest_layer<as::ip::tcp::socket::lowest_layer_type&()>,
-        has_close<void(boost::system::error_code&)>
+        has_close<void(boost::system::error_code&)>,
+        has_get_executor<as::executor()>
     >
 >;
 

--- a/include/mqtt/ws_endpoint.hpp
+++ b/include/mqtt/ws_endpoint.hpp
@@ -42,8 +42,8 @@ public:
         ec = boost::system::errc::make_error_code(boost::system::errc::success);
     }
 
-    typename Socket::executor_type get_executor() {
-        return ws_.get_executor();
+    auto get_executor() {
+        return lowest_layer().get_executor();
     }
 
 #if BOOST_VERSION >= 107000

--- a/include/mqtt/ws_endpoint.hpp
+++ b/include/mqtt/ws_endpoint.hpp
@@ -42,8 +42,8 @@ public:
         ec = boost::system::errc::make_error_code(boost::system::errc::success);
     }
 
-    as::io_context& get_io_context() {
-        return ws_.get_io_context();
+    typename Socket::executor_type get_executor() {
+        return ws_.get_executor();
     }
 
 #if BOOST_VERSION >= 107000


### PR DESCRIPTION
User can get executor_type as follows:

```cpp
auto exe = c->socket()->get_executor();
```

And user can use it as

```cpp
boost::deadline_timer tim(exe);
```