### PR TITLE
Use MQTT_NS::error_code instead of boost::system::error_code for error_codes

### DIFF
--- a/example/no_tls_both.cpp
+++ b/example/no_tls_both.cpp
@@ -54,7 +54,7 @@ void client_proc(
         });
     c->set_error_handler(
         []
-        (boost::system::error_code const& ec){
+        (MQTT_NS::error_code ec){
             locked_cout() << "[client] error: " << ec.message() << std::endl;
         });
     c->set_puback_handler(
@@ -164,7 +164,7 @@ inline void close_proc(std::set<con_sp_t>& cons, mi_sub_con& subs, con_sp_t cons
 template <typename Server>
 void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
     s.set_error_handler(
-        [](boost::system::error_code const& ec) {
+        [](MQTT_NS::error_code ec) {
             locked_cout() << "[server] error: " << ec.message() << std::endl;
         }
     );
@@ -199,7 +199,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                 });
             ep.set_error_handler(
                 [&connections, &subs, wp]
-                (boost::system::error_code const& ec){
+                (MQTT_NS::error_code ec){
                     locked_cout() << "[server] error: " << ec.message() << std::endl;
                     auto sp = wp.lock();
                     BOOST_ASSERT(sp);

--- a/example/no_tls_client.cpp
+++ b/example/no_tls_client.cpp
@@ -60,7 +60,7 @@ int main(int argc, char** argv) {
         });
     c->set_error_handler(
         []
-        (boost::system::error_code const& ec){
+        (MQTT_NS::error_code ec){
             std::cout << "error: " << ec.message() << std::endl;
         });
     c->set_puback_handler(

--- a/example/no_tls_server.cpp
+++ b/example/no_tls_server.cpp
@@ -70,7 +70,7 @@ int main(int argc, char** argv) {
     );
 
     s.set_error_handler(
-        [](boost::system::error_code const& ec) {
+        [](MQTT_NS::error_code ec) {
             std::cout << "error: " << ec.message() << std::endl;
         }
     );
@@ -102,7 +102,7 @@ int main(int argc, char** argv) {
                 });
             ep.set_error_handler(
                 [&connections, &subs, wp]
-                (boost::system::error_code const& ec){
+                (MQTT_NS::error_code ec){
                     std::cout << "[server] error: " << ec.message() << std::endl;
                     auto sp = wp.lock();
                     BOOST_ASSERT(sp);

--- a/example/no_tls_ws_both.cpp
+++ b/example/no_tls_ws_both.cpp
@@ -54,7 +54,7 @@ void client_proc(
         });
     c->set_error_handler(
         []
-        (boost::system::error_code const& ec){
+        (MQTT_NS::error_code ec){
             locked_cout() << "[client] error: " << ec.message() << std::endl;
         });
     c->set_puback_handler(
@@ -164,7 +164,7 @@ inline void close_proc(std::set<con_sp_t>& cons, mi_sub_con& subs, con_sp_t cons
 template <typename Server>
 void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
     s.set_error_handler(
-        [](boost::system::error_code const& ec) {
+        [](MQTT_NS::error_code ec) {
             locked_cout() << "[server] error: " << ec.message() << std::endl;
         }
     );
@@ -198,7 +198,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                 });
             ep.set_error_handler(
                 [&connections, &subs, wp]
-                (boost::system::error_code const& ec){
+                (MQTT_NS::error_code ec){
                     locked_cout() << "[server] error: " << ec.message() << std::endl;
                     auto sp = wp.lock();
                     BOOST_ASSERT(sp);

--- a/example/no_tls_ws_client.cpp
+++ b/example/no_tls_ws_client.cpp
@@ -60,7 +60,7 @@ int main(int argc, char** argv) {
         });
     c->set_error_handler(
         []
-        (boost::system::error_code const& ec){
+        (MQTT_NS::error_code ec){
             std::cout << "error: " << ec.message() << std::endl;
         });
     c->set_puback_handler(

--- a/example/no_tls_ws_server.cpp
+++ b/example/no_tls_ws_server.cpp
@@ -70,7 +70,7 @@ int main(int argc, char** argv) {
     );
 
     s.set_error_handler(
-        [](boost::system::error_code const& ec) {
+        [](MQTT_NS::error_code ec) {
             std::cout << "error: " << ec.message() << std::endl;
         }
     );
@@ -102,7 +102,7 @@ int main(int argc, char** argv) {
                 });
             ep.set_error_handler(
                 [&connections, &subs, wp]
-                (boost::system::error_code const& ec){
+                (MQTT_NS::error_code ec){
                     std::cout << "[server] error: " << ec.message() << std::endl;
                     auto sp = wp.lock();
                     BOOST_ASSERT(sp);

--- a/example/tls_both.cpp
+++ b/example/tls_both.cpp
@@ -55,7 +55,7 @@ void client_proc(
         });
     c->set_error_handler(
         []
-        (boost::system::error_code const& ec){
+        (MQTT_NS::error_code ec){
             locked_cout() << "[client] error: " << ec.message() << std::endl;
         });
     c->set_puback_handler(
@@ -166,7 +166,7 @@ inline void close_proc(std::set<con_sp_t>& cons, mi_sub_con& subs, con_sp_t cons
 template <typename Server>
 void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
     s.set_error_handler(
-        [](boost::system::error_code const& ec) {
+        [](MQTT_NS::error_code ec) {
             locked_cout() << "[server] error: " << ec.message() << std::endl;
         }
     );
@@ -200,7 +200,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                 });
             ep.set_error_handler(
                 [&connections, &subs, wp]
-                (boost::system::error_code const& ec){
+                (MQTT_NS::error_code ec){
                     locked_cout() << "[server] error: " << ec.message() << std::endl;
                     auto sp = wp.lock();
                     BOOST_ASSERT(sp);

--- a/example/tls_client.cpp
+++ b/example/tls_client.cpp
@@ -76,7 +76,7 @@ int main(int argc, char** argv) {
         });
     c->set_error_handler(
         []
-        (boost::system::error_code const& ec){
+        (MQTT_NS::error_code ec){
             std::cout << "error: " << ec.message() << std::endl;
         });
     c->set_puback_handler(

--- a/example/tls_server.cpp
+++ b/example/tls_server.cpp
@@ -82,7 +82,7 @@ int main(int argc, char** argv) {
     );
 
     s.set_error_handler(
-        [](boost::system::error_code const& ec) {
+        [](MQTT_NS::error_code ec) {
             std::cout << "error: " << ec.message() << std::endl;
         }
     );
@@ -114,7 +114,7 @@ int main(int argc, char** argv) {
                 });
             ep.set_error_handler(
                 [&connections, &subs, wp]
-                (boost::system::error_code const& ec){
+                (MQTT_NS::error_code ec){
                     std::cout << "[server] error: " << ec.message() << std::endl;
                     auto sp = wp.lock();
                     BOOST_ASSERT(sp);

--- a/example/tls_ws_both.cpp
+++ b/example/tls_ws_both.cpp
@@ -54,7 +54,7 @@ void client_proc(
         });
     c->set_error_handler(
         []
-        (boost::system::error_code const& ec){
+        (MQTT_NS::error_code ec){
             locked_cout() << "[client] error: " << ec.message() << std::endl;
         });
     c->set_puback_handler(
@@ -165,7 +165,7 @@ inline void close_proc(std::set<con_sp_t>& cons, mi_sub_con& subs, con_sp_t cons
 template <typename Server>
 void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
     s.set_error_handler(
-        [](boost::system::error_code const& ec) {
+        [](MQTT_NS::error_code ec) {
             locked_cout() << "[server] error: " << ec.message() << std::endl;
         }
     );
@@ -199,7 +199,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                 });
             ep.set_error_handler(
                 [&connections, &subs, wp]
-                (boost::system::error_code const& ec){
+                (MQTT_NS::error_code ec){
                     locked_cout() << "[server] error: " << ec.message() << std::endl;
                     auto sp = wp.lock();
                     BOOST_ASSERT(sp);

--- a/example/tls_ws_client.cpp
+++ b/example/tls_ws_client.cpp
@@ -66,7 +66,7 @@ int main(int argc, char** argv) {
         });
     c->set_error_handler(
         []
-        (boost::system::error_code const& ec){
+        (MQTT_NS::error_code ec){
             std::cout << "error: " << ec.message() << std::endl;
         });
     c->set_puback_handler(

--- a/example/tls_ws_server.cpp
+++ b/example/tls_ws_server.cpp
@@ -82,7 +82,7 @@ int main(int argc, char** argv) {
     );
 
     s.set_error_handler(
-        [](boost::system::error_code const& ec) {
+        [](MQTT_NS::error_code ec) {
             std::cout << "error: " << ec.message() << std::endl;
         }
     );
@@ -114,7 +114,7 @@ int main(int argc, char** argv) {
                 });
             ep.set_error_handler(
                 [&connections, &subs, wp]
-                (boost::system::error_code const& ec){
+                (MQTT_NS::error_code ec){
                     std::cout << "[server] error: " << ec.message() << std::endl;
                     auto sp = wp.lock();
                     BOOST_ASSERT(sp);

--- a/example/v5_no_tls_both.cpp
+++ b/example/v5_no_tls_both.cpp
@@ -53,7 +53,7 @@ void client_proc(
         });
     c->set_error_handler( // this handler doesn't depend on MQTT protocol version
         []
-        (boost::system::error_code const& ec){
+        (MQTT_NS::error_code ec){
             locked_cout() << "[client] error: " << ec.message() << std::endl;
         });
     c->set_v5_puback_handler( // use v5 handler
@@ -185,7 +185,7 @@ inline void close_proc(std::set<con_sp_t>& cons, mi_sub_con& subs, con_sp_t cons
 template <typename Server>
 void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
     s.set_error_handler( // this handler doesn't depend on MQTT protocol version
-        [](boost::system::error_code const& ec) {
+        [](MQTT_NS::error_code ec) {
             locked_cout() << "[server] error: " << ec.message() << std::endl;
         }
     );
@@ -219,7 +219,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                 });
             ep.set_error_handler(
                 [&connections, &subs, wp]
-                (boost::system::error_code const& ec){
+                (MQTT_NS::error_code ec){
                     locked_cout() << "[server] error: " << ec.message() << std::endl;
                     auto sp = wp.lock();
                     BOOST_ASSERT(sp);

--- a/example/v5_no_tls_client.cpp
+++ b/example/v5_no_tls_client.cpp
@@ -60,7 +60,7 @@ int main(int argc, char** argv) {
         });
     c->set_error_handler( // this handler doesn't depend on MQTT protocol version
         []
-        (boost::system::error_code const& ec){
+        (MQTT_NS::error_code ec){
             std::cout << "[client] error: " << ec.message() << std::endl;
         });
     c->set_v5_puback_handler( // use v5 handler

--- a/example/v5_no_tls_prop.cpp
+++ b/example/v5_no_tls_prop.cpp
@@ -106,7 +106,7 @@ void client_proc(Client& c) {
         });
     c->set_error_handler( // this handler doesn't depend on MQTT protocol version
         []
-        (boost::system::error_code const& ec){
+        (MQTT_NS::error_code ec){
             locked_cout() << "[client] error: " << ec.message() << std::endl;
         });
 
@@ -145,7 +145,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections) {
     using namespace MQTT_NS::literals; // for ""_mb
 
     s.set_error_handler( // this handler doesn't depend on MQTT protocol version
-        [](boost::system::error_code const& ec) {
+        [](MQTT_NS::error_code ec) {
             locked_cout() << "[server] error: " << ec.message() << std::endl;
         }
     );
@@ -178,7 +178,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections) {
                 });
             ep.set_error_handler( // this handler doesn't depend on MQTT protocol version
                 [&connections, wp]
-                (boost::system::error_code const& ec){
+                (MQTT_NS::error_code ec){
                     locked_cout() << "[server] error: " << ec.message() << std::endl;
                     auto sp = wp.lock();
                     BOOST_ASSERT(sp);

--- a/example/v5_no_tls_server.cpp
+++ b/example/v5_no_tls_server.cpp
@@ -70,7 +70,7 @@ int main(int argc, char** argv) {
     );
 
     s.set_error_handler(
-        [](boost::system::error_code const& ec) {
+        [](MQTT_NS::error_code ec) {
             std::cout << "error: " << ec.message() << std::endl;
         }
     );
@@ -101,7 +101,7 @@ int main(int argc, char** argv) {
                 });
             ep.set_error_handler(
                 [&connections, &subs, wp]
-                (boost::system::error_code const& ec){
+                (MQTT_NS::error_code ec){
                     std::cout << "[server] error: " << ec.message() << std::endl;
                     auto sp = wp.lock();
                     BOOST_ASSERT(sp);

--- a/include/mqtt/callable_overlay.hpp
+++ b/include/mqtt/callable_overlay.hpp
@@ -643,7 +643,7 @@ struct callable_overlay final : public Impl
      *
      * @param ec error code
      */
-    MQTT_ALWAYS_INLINE void on_error(boost::system::error_code const& ec) override final {
+    MQTT_ALWAYS_INLINE void on_error(error_code ec) override final {
         if(h_error_) h_error_(ec);
     }
 
@@ -1284,7 +1284,7 @@ struct callable_overlay final : public Impl
      *
      * @param ec error code
      */
-    using error_handler = std::function<void(boost::system::error_code const& ec)>;
+    using error_handler = std::function<void(error_code ec)>;
 
     /**
      * @brief Publish response sent handler

--- a/include/mqtt/client.hpp
+++ b/include/mqtt/client.hpp
@@ -597,7 +597,7 @@ public:
                 r = force_move(r)
             ]
             (
-                boost::system::error_code const& ec,
+                error_code ec,
                 as::ip::tcp::resolver::results_type eps
             ) mutable {
                 if (ec) {
@@ -731,7 +731,7 @@ public:
                 r = force_move(r)
             ]
             (
-                boost::system::error_code const& ec,
+                error_code ec,
                 as::ip::tcp::resolver::results_type eps
             ) mutable {
                 if (ec) {
@@ -771,7 +771,7 @@ public:
             std::weak_ptr<this_type> wp(std::static_pointer_cast<this_type>(this->shared_from_this()));
             tim_close_.expires_from_now(timeout);
             tim_close_.async_wait(
-                [wp = force_move(wp)](boost::system::error_code const& ec) {
+                [wp = force_move(wp)](error_code ec) {
                     if (auto sp = wp.lock()) {
                         if (!ec) {
                             sp->force_disconnect();
@@ -825,7 +825,7 @@ public:
             std::weak_ptr<this_type> wp(std::static_pointer_cast<this_type>(this->shared_from_this()));
             tim_close_.expires_from_now(timeout);
             tim_close_.async_wait(
-                [wp = force_move(wp)](boost::system::error_code const& ec) {
+                [wp = force_move(wp)](error_code ec) {
                     if (auto sp = wp.lock()) {
                         if (!ec) {
                             sp->force_disconnect();
@@ -864,7 +864,7 @@ public:
             std::weak_ptr<this_type> wp(std::static_pointer_cast<this_type>(this->shared_from_this()));
             tim_close_.expires_from_now(timeout);
             tim_close_.async_wait(
-                [wp = force_move(wp)](boost::system::error_code const& ec) {
+                [wp = force_move(wp)](error_code ec) {
                     if (auto sp = wp.lock()) {
                         if (!ec) {
                             sp->force_disconnect();
@@ -1158,7 +1158,7 @@ private:
                 props = force_move(props),
                 func = force_move(func)
             ]
-            (boost::system::error_code const& ec) mutable {
+            (error_code ec) mutable {
                 if (func) func(ec);
                 if (ec) return;
                 start_session(force_move(props), force_move(session_life_keeper));
@@ -1183,7 +1183,7 @@ private:
                 props = force_move(props),
                 func = force_move(func)
             ]
-            (boost::system::error_code const& ec) mutable {
+            (error_code ec) mutable {
                 if (func) func(ec);
                 if (ec) return;
                 start_session(force_move(props), force_move(session_life_keeper));
@@ -1207,7 +1207,7 @@ private:
                 props = force_move(props),
                 func = force_move(func)
             ]
-            (boost::system::error_code const& ec) mutable {
+            (error_code ec) mutable {
                 if (ec) {
                     if (func) func(ec);
                     return;
@@ -1222,7 +1222,7 @@ private:
                         props = force_move(props),
                         func = force_move(func)
                     ]
-                    (boost::system::error_code const& ec) mutable {
+                    (error_code ec) mutable {
                         if (func) func(ec);
                         if (ec) return;
                         start_session(force_move(props), force_move(session_life_keeper));
@@ -1283,7 +1283,7 @@ private:
                 props = force_move(props),
                 func = force_move(func)
             ]
-            (boost::system::error_code const& ec, Iterator) mutable {
+            (error_code ec, Iterator) mutable {
                 if (ec) {
                     if (func) func(ec);
                     return;
@@ -1303,7 +1303,7 @@ private:
         }
     }
 
-    void handle_timer(boost::system::error_code const& ec) {
+    void handle_timer(error_code ec) {
         if (!ec) {
             if (async_pingreq_) {
                 base::async_pingreq();
@@ -1318,7 +1318,7 @@ private:
         tim_ping_.expires_from_now(boost::posix_time::milliseconds(ping_duration_ms_));
         std::weak_ptr<this_type> wp(std::static_pointer_cast<this_type>(this->shared_from_this()));
         tim_ping_.async_wait(
-            [wp = force_move(wp)](boost::system::error_code const& ec) {
+            [wp = force_move(wp)](error_code ec) {
                 if (auto sp = wp.lock()) {
                     sp->handle_timer(ec);
                 }
@@ -1335,7 +1335,7 @@ private:
         if (ping_duration_ms_ != 0) tim_ping_.cancel();
     }
 
-    void on_error(boost::system::error_code const& ec) override {
+    void on_error(error_code ec) override {
         (void)ec;
         if (ping_duration_ms_ != 0) tim_ping_.cancel();
     }

--- a/include/mqtt/error_code.hpp
+++ b/include/mqtt/error_code.hpp
@@ -1,0 +1,20 @@
+// Copyright Takatoshi Kondo 2019
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(MQTT_ERROR_CODE_HPP)
+#define MQTT_ERROR_CODE_HPP
+
+#include <mqtt/namespace.hpp>
+
+#include <boost/system/error_code.hpp>
+
+namespace MQTT_NS {
+
+using error_code = boost::system::error_code;
+
+} // namespace MQTT_NS
+
+#endif // MQTT_ERROR_CODE_HPP

--- a/include/mqtt/server.hpp
+++ b/include/mqtt/server.hpp
@@ -54,7 +54,7 @@ public:
      * @brief Error handler
      * @param ec error code
      */
-    using error_handler = std::function<void(boost::system::error_code const& ec)>;
+    using error_handler = std::function<void(error_code ec)>;
 
     template <typename AsioEndpoint, typename AcceptorConfig>
     server(
@@ -148,7 +148,7 @@ private:
         acceptor_.value().async_accept(
             socket->lowest_layer(),
             [this, socket]
-            (boost::system::error_code const& ec) mutable {
+            (error_code ec) mutable {
                 if (ec) {
                     acceptor_.reset();
                     if (h_error_) h_error_(ec);
@@ -196,7 +196,7 @@ public:
      * @brief Error handler
      * @param ec error code
      */
-    using error_handler = std::function<void(boost::system::error_code const& ec)>;
+    using error_handler = std::function<void(error_code ec)>;
 
     template <typename AsioEndpoint, typename AcceptorConfig>
     server_tls(
@@ -324,7 +324,7 @@ private:
         acceptor_.value().async_accept(
             ps->lowest_layer(),
             [this, socket = force_move(socket)]
-            (boost::system::error_code const& ec) mutable {
+            (error_code ec) mutable {
                 if (ec) {
                     acceptor_.reset();
                     if (h_error_) h_error_(ec);
@@ -335,7 +335,7 @@ private:
                 tim->expires_from_now(underlying_connect_timeout_);
                 tim->async_wait(
                     [socket, tim, underlying_finished]
-                    (boost::system::error_code ec) {
+                    (error_code ec) {
                         if (*underlying_finished) return;
                         if (ec) return;
                         boost::system::error_code close_ec;
@@ -346,7 +346,7 @@ private:
                 ps->async_handshake(
                     as::ssl::stream_base::server,
                     [this, socket = force_move(socket), tim, underlying_finished]
-                    (boost::system::error_code ec) mutable {
+                    (error_code ec) mutable {
                         *underlying_finished = true;
                         tim->cancel();
                         if (ec) {
@@ -415,7 +415,7 @@ public:
      * @brief Error handler
      * @param ec error code
      */
-    using error_handler = std::function<void(boost::system::error_code const& ec)>;
+    using error_handler = std::function<void(error_code ec)>;
 
     template <typename AsioEndpoint, typename AcceptorConfig>
     server_ws(
@@ -522,7 +522,7 @@ private:
         acceptor_.value().async_accept(
             ps->next_layer(),
             [this, socket = force_move(socket)]
-            (boost::system::error_code const& ec) mutable {
+            (error_code ec) mutable {
                 if (ec) {
                     acceptor_.reset();
                     if (h_error_) h_error_(ec);
@@ -533,7 +533,7 @@ private:
                 tim->expires_from_now(underlying_connect_timeout_);
                 tim->async_wait(
                     [socket, tim, underlying_finished]
-                    (boost::system::error_code ec) {
+                    (error_code ec) {
                         if (*underlying_finished) return;
                         if (ec) return;
                         boost::system::error_code close_ec;
@@ -549,7 +549,7 @@ private:
                     *sb,
                     *request,
                     [this, socket = force_move(socket), sb, request, tim, underlying_finished]
-                    (boost::system::error_code const& ec, std::size_t) mutable {
+                    (error_code ec, std::size_t) mutable {
                         if (ec) {
                             *underlying_finished = true;
                             tim->cancel();
@@ -571,7 +571,7 @@ private:
                                 }
                             },
                             [this, socket = force_move(socket), tim, underlying_finished]
-                            (boost::system::error_code const& ec) mutable {
+                            (error_code ec) mutable {
                                 *underlying_finished = true;
                                 tim->cancel();
                                 if (ec) {
@@ -625,7 +625,7 @@ public:
      * @brief Error handler
      * @param ec error code
      */
-    using error_handler = std::function<void(boost::system::error_code const& ec)>;
+    using error_handler = std::function<void(error_code ec)>;
 
     template <typename AsioEndpoint, typename AcceptorConfig>
     server_tls_ws(
@@ -752,7 +752,7 @@ private:
         acceptor_.value().async_accept(
             socket->next_layer().next_layer(),
             [this, socket]
-            (boost::system::error_code const& ec) {
+            (error_code ec) {
                 if (ec) {
                     acceptor_.reset();
                     if (h_error_) h_error_(ec);
@@ -763,7 +763,7 @@ private:
                 tim->expires_from_now(underlying_connect_timeout_);
                 tim->async_wait(
                     [socket, tim, underlying_finished]
-                    (boost::system::error_code ec) {
+                    (error_code ec) {
                         if (*underlying_finished) return;
                         if (ec) return;
                         boost::system::error_code close_ec;
@@ -773,7 +773,7 @@ private:
                 socket->next_layer().async_handshake(
                     as::ssl::stream_base::server,
                     [this, socket, tim, underlying_finished]
-                    (boost::system::error_code ec) {
+                    (error_code ec) {
                         if (ec) {
                             *underlying_finished = true;
                             tim->cancel();
@@ -786,7 +786,7 @@ private:
                             *sb,
                             *request,
                             [this, socket, sb, request, tim, underlying_finished]
-                            (boost::system::error_code const& ec, std::size_t) {
+                            (error_code ec, std::size_t) {
                                 if (ec) {
                                     *underlying_finished = true;
                                     tim->cancel();
@@ -807,7 +807,7 @@ private:
                                         }
                                     },
                                     [this, socket, tim, underlying_finished]
-                                    (boost::system::error_code const& ec) mutable {
+                                    (error_code ec) mutable {
                                         *underlying_finished = true;
                                         tim->cancel();
                                         if (ec) {

--- a/include/mqtt/type_erased_socket.hpp
+++ b/include/mqtt/type_erased_socket.hpp
@@ -16,6 +16,7 @@
 
 #include <mqtt/namespace.hpp>
 #include <mqtt/shared_any.hpp>
+#include <mqtt/error_code.hpp>
 
 // I intentionally use old style boost type_erasure member fucntion concept definition.
 // The new style requires compiler extension.
@@ -46,8 +47,8 @@ using namespace boost::type_erasure;
 using socket = shared_any<
     mpl::vector<
         destructible<>,
-        has_async_read<void(as::mutable_buffer, std::function<void(boost::system::error_code const&, std::size_t)>)>,
-        has_async_write<void(std::vector<as::const_buffer>, std::function<void(boost::system::error_code const&, std::size_t)>)>,
+        has_async_read<void(as::mutable_buffer, std::function<void(error_code, std::size_t)>)>,
+        has_async_write<void(std::vector<as::const_buffer>, std::function<void(error_code, std::size_t)>)>,
         has_write<std::size_t(std::vector<as::const_buffer>, boost::system::error_code&)>,
         has_post<void(std::function<void()>)>,
         has_lowest_layer<as::ip::tcp::socket::lowest_layer_type&()>,

--- a/include/mqtt/ws_endpoint.hpp
+++ b/include/mqtt/ws_endpoint.hpp
@@ -16,6 +16,7 @@
 
 #include <mqtt/namespace.hpp>
 #include <mqtt/string_view.hpp>
+#include <mqtt/error_code.hpp>
 
 namespace MQTT_NS {
 
@@ -101,7 +102,7 @@ public:
         auto req_size = as::buffer_size(buffers);
 
         using beast_read_handler_t =
-            std::function<void(boost::system::error_code const& ec, std::shared_ptr<void>)>;
+            std::function<void(error_code ec, std::shared_ptr<void>)>;
 
         std::shared_ptr<beast_read_handler_t> beast_read_handler;
         if (req_size <= buffer_.size()) {
@@ -114,7 +115,7 @@ public:
         beast_read_handler.reset(
             new beast_read_handler_t(
                 [this, req_size, buffers, handler = std::forward<ReadHandler>(handler)]
-                (boost::system::error_code const& ec, std::shared_ptr<void> const& v) mutable {
+                (error_code ec, std::shared_ptr<void> const& v) mutable {
                     if (ec) {
                         std::forward<ReadHandler>(handler)(ec, 0);
                         return;
@@ -132,7 +133,7 @@ public:
                             as::bind_executor(
                                 strand_,
                                 [beast_read_handler]
-                                (boost::system::error_code const& ec, std::size_t) {
+                                (error_code ec, std::size_t) {
                                     (*beast_read_handler)(ec, beast_read_handler);
                                 }
                             )
@@ -150,7 +151,7 @@ public:
             as::bind_executor(
                 strand_,
                 [beast_read_handler]
-                (boost::system::error_code const& ec, std::size_t) {
+                (error_code ec, std::size_t) {
                     (*beast_read_handler)(ec, beast_read_handler);
                 }
             )

--- a/test/as_buffer_async_pubsub_1.cpp
+++ b/test/as_buffer_async_pubsub_1.cpp
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                     pid_sub = c->async_subscribe(
                         as::buffer(*topic1),
                         MQTT_NS::qos::at_most_once,
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -111,7 +111,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                     auto topic1 = std::make_shared<std::string>("topic1");
                     pid_unsub = c->async_unsubscribe(
                         as::buffer(*topic1),
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -127,7 +127,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                     pid_sub = c->async_subscribe(
                         as::buffer(*topic1),
                         MQTT_NS::qos::at_most_once,
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                     auto topic1 = std::make_shared<std::string>("topic1");
                     pid_unsub = c->async_unsubscribe(
                         as::buffer(*topic1),
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -212,7 +212,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->set_pub_res_sent_handler(
@@ -261,7 +261,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                     pid_sub = c->async_subscribe(
                         as::buffer(*topic1),
                         MQTT_NS::qos::at_most_once,
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -273,7 +273,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                     auto topic1 = std::make_shared<std::string>("topic1");
                     pid_unsub = c->async_unsubscribe(
                         as::buffer(*topic1),
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -343,7 +343,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                     pid_sub = c->async_subscribe(
                         as::buffer(*topic1),
                         MQTT_NS::qos::at_most_once,
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -355,7 +355,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                     auto topic1 = std::make_shared<std::string>("topic1");
                     pid_unsub = c->async_unsubscribe(
                         as::buffer(*topic1),
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -430,7 +430,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->set_pub_res_sent_handler(
@@ -480,7 +480,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                     pid_sub = c->async_subscribe(
                         as::buffer(*topic1),
                         MQTT_NS::qos::at_most_once,
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -505,7 +505,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                     auto topic1 = std::make_shared<std::string>("topic1");
                     pid_unsub = c->async_unsubscribe(
                         as::buffer(*topic1),
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -563,7 +563,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                     pid_sub = c->async_subscribe(
                         as::buffer(*topic1),
                         MQTT_NS::qos::at_most_once,
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -588,7 +588,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                     auto topic1 = std::make_shared<std::string>("topic1");
                     pid_unsub = c->async_unsubscribe(
                         as::buffer(*topic1),
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -650,7 +650,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->set_pub_res_sent_handler(
@@ -697,7 +697,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                     pid_sub = c->async_subscribe(
                         as::buffer(*topic1),
                         MQTT_NS::qos::at_least_once,
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -761,7 +761,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                     auto topic1 = std::make_shared<std::string>("topic1");
                     pid_unsub = c->async_unsubscribe(
                         as::buffer(*topic1),
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -777,7 +777,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                     pid_sub = c->async_subscribe(
                         as::buffer(*topic1),
                         MQTT_NS::qos::at_least_once,
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -844,7 +844,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                     auto topic1 = std::make_shared<std::string>("topic1");
                     pid_unsub = c->async_unsubscribe(
                         as::buffer(*topic1),
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -861,7 +861,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->set_pub_res_sent_handler(
@@ -908,7 +908,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                 auto topic1 = std::make_shared<std::string>("topic1");
                 pid_unsub = c->async_unsubscribe(
                     as::buffer(*topic1),
-                    [topic1](boost::system::error_code const&) {}
+                    [topic1](MQTT_NS::error_code) {}
                 );
             });
 
@@ -924,7 +924,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                     pid_sub = c->async_subscribe(
                         as::buffer(*topic1),
                         MQTT_NS::qos::at_least_once,
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -1002,7 +1002,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                     pid_sub = c->async_subscribe(
                         as::buffer(*topic1),
                         MQTT_NS::qos::at_least_once,
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -1084,7 +1084,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->async_connect();
@@ -1138,7 +1138,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                     pid_sub = c->async_subscribe(
                         as::buffer(*topic1),
                         MQTT_NS::qos::at_least_once,
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -1163,7 +1163,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                     auto topic1 = std::make_shared<std::string>("topic1");
                     pid_unsub = c->async_unsubscribe(
                         as::buffer(*topic1),
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -1222,7 +1222,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                     pid_sub = c->async_subscribe(
                         as::buffer(*topic1),
                         MQTT_NS::qos::at_least_once,
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -1247,7 +1247,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                     auto topic1 = std::make_shared<std::string>("topic1");
                     pid_unsub = c->async_unsubscribe(
                         as::buffer(*topic1),
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -1310,7 +1310,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->async_connect();

--- a/test/as_buffer_async_pubsub_2.cpp
+++ b/test/as_buffer_async_pubsub_2.cpp
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                     pid_sub = c->async_subscribe(
                         as::buffer(*topic1),
                         MQTT_NS::qos::exactly_once,
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -114,7 +114,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                     auto topic1 = std::make_shared<std::string>("topic1");
                     pid_unsub = c->async_unsubscribe(
                         as::buffer(*topic1),
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -130,7 +130,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                     pid_sub = c->async_subscribe(
                         as::buffer(*topic1),
                         MQTT_NS::qos::exactly_once,
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -199,7 +199,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                     auto topic1 = std::make_shared<std::string>("topic1");
                     pid_unsub = c->async_unsubscribe(
                         as::buffer(*topic1),
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -216,7 +216,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->set_pub_res_sent_handler(
@@ -275,7 +275,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                     pid_sub = c->async_subscribe(
                         as::buffer(*topic1),
                         MQTT_NS::qos::exactly_once,
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -287,7 +287,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                     auto topic1 = std::make_shared<std::string>("topic1");
                     pid_unsub = c->async_unsubscribe(
                         as::buffer(*topic1),
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -358,7 +358,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                     pid_sub = c->async_subscribe(
                         as::buffer(*topic1),
                         MQTT_NS::qos::exactly_once,
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -370,7 +370,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                     auto topic1 = std::make_shared<std::string>("topic1");
                     pid_unsub = c->async_unsubscribe(
                         as::buffer(*topic1),
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -445,7 +445,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->async_connect();
@@ -501,7 +501,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                     pid_sub = c->async_subscribe(
                         as::buffer(*topic1),
                         MQTT_NS::qos::exactly_once,
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -526,7 +526,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                     auto topic1 = std::make_shared<std::string>("topic1");
                     pid_unsub = c->async_unsubscribe(
                         as::buffer(*topic1),
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -585,7 +585,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                     pid_sub = c->async_subscribe(
                         as::buffer(*topic1),
                         MQTT_NS::qos::exactly_once,
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -610,7 +610,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                     auto topic1 = std::make_shared<std::string>("topic1");
                     pid_unsub = c->async_unsubscribe(
                         as::buffer(*topic1),
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -673,7 +673,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->async_connect();
@@ -716,7 +716,7 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
                     pid_sub = c->async_subscribe(
                         as::buffer(*topic1),
                         MQTT_NS::qos::at_most_once,
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -781,7 +781,7 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
                     auto topic1 = std::make_shared<std::string>("topic1");
                     pid_unsub = c->async_unsubscribe(
                         as::buffer(*topic1),
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -797,7 +797,7 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
                     pid_sub = c->async_subscribe(
                         as::buffer(*topic1),
                         MQTT_NS::qos::at_most_once,
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -865,7 +865,7 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
                     auto topic1 = std::make_shared<std::string>("topic1");
                     pid_unsub = c->async_unsubscribe(
                         as::buffer(*topic1),
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -882,7 +882,7 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->async_connect();
@@ -925,7 +925,7 @@ BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
                     pid_sub = c->async_subscribe(
                         std::move(topic1),
                         MQTT_NS::qos::at_most_once,
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -989,7 +989,7 @@ BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
                     auto topic1 = MQTT_NS::allocate_buffer("topic1");
                     pid_unsub = c->async_unsubscribe(
                         std::move(topic1),
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -1005,7 +1005,7 @@ BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
                     pid_sub = c->async_subscribe(
                         std::move(topic1),
                         MQTT_NS::qos::at_most_once,
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -1072,7 +1072,7 @@ BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
                     auto topic1 = MQTT_NS::allocate_buffer("topic1");
                     pid_unsub = c->async_unsubscribe(
                         std::move(topic1),
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -1089,7 +1089,7 @@ BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->async_connect();
@@ -1133,7 +1133,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                     pid_sub = c->async_subscribe(
                         as::buffer(*topic1),
                         MQTT_NS::qos::at_least_once,
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -1145,7 +1145,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                     auto topic1 = std::make_shared<std::string>("topic1");
                     pid_unsub = c->async_unsubscribe(
                         as::buffer(*topic1),
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -1217,7 +1217,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                     pid_sub = c->async_subscribe(
                         as::buffer(*topic1),
                         MQTT_NS::qos::at_least_once,
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -1229,7 +1229,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                     auto topic1 = std::make_shared<std::string>("topic1");
                     pid_unsub = c->async_unsubscribe(
                         as::buffer(*topic1),
-                        [topic1](boost::system::error_code const&) {}
+                        [topic1](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -1305,7 +1305,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->async_connect();

--- a/test/as_buffer_pubsub.cpp
+++ b/test/as_buffer_pubsub.cpp
@@ -180,7 +180,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->set_pub_res_sent_handler(
@@ -372,7 +372,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->set_pub_res_sent_handler(
@@ -565,7 +565,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->set_pub_res_sent_handler(
@@ -748,7 +748,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->set_pub_res_sent_handler(
@@ -950,7 +950,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();
@@ -1150,7 +1150,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();
@@ -1328,7 +1328,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->set_pub_res_sent_handler(
@@ -1530,7 +1530,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();
@@ -1730,7 +1730,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();
@@ -1908,7 +1908,7 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();
@@ -2091,7 +2091,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();

--- a/test/as_buffer_sub.cpp
+++ b/test/as_buffer_sub.cpp
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_single ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();
@@ -196,7 +196,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();
@@ -297,7 +297,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();
@@ -335,7 +335,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_single_async ) {
                     c->async_subscribe(
                         as::buffer(*topic),
                         MQTT_NS::qos::at_most_once,
-                        [topic](boost::system::error_code const&) {});
+                        [topic](MQTT_NS::error_code) {});
                     return true;
                 });
             c->set_suback_handler(
@@ -345,7 +345,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_single_async ) {
                     auto topic = std::make_shared<std::string>("topic1");
                     c->async_unsubscribe(
                         as::buffer(*topic),
-                        [topic](boost::system::error_code const&) {});
+                        [topic](MQTT_NS::error_code) {});
                     return true;
                 });
             c->set_unsuback_handler(
@@ -367,7 +367,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_single_async ) {
                     c->async_subscribe(
                         as::buffer(*topic),
                         MQTT_NS::qos::at_most_once,
-                        [topic](boost::system::error_code const&) {});
+                        [topic](MQTT_NS::error_code) {});
                     return true;
                 });
             c->set_v5_suback_handler(
@@ -377,7 +377,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_single_async ) {
                     auto topic = std::make_shared<std::string>("topic1");
                     c->async_unsubscribe(
                         as::buffer(*topic),
-                        [topic](boost::system::error_code const&) {});
+                        [topic](MQTT_NS::error_code) {});
                     return true;
                 });
             c->set_v5_unsuback_handler(
@@ -401,7 +401,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_single_async ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->async_connect();
@@ -443,7 +443,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg_async ) {
                             {as::buffer(*topic1), MQTT_NS::qos::at_most_once},
                             {as::buffer(*topic2), MQTT_NS::qos::exactly_once}
                         },
-                        [topic1, topic2](boost::system::error_code const&) {}
+                        [topic1, topic2](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -458,7 +458,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg_async ) {
                             {as::buffer(*topic1)},
                             {as::buffer(*topic2)}
                         },
-                        [topic1, topic2](boost::system::error_code const&) {}
+                        [topic1, topic2](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -484,7 +484,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg_async ) {
                             {as::buffer(*topic1), MQTT_NS::qos::at_most_once},
                             {as::buffer(*topic2), MQTT_NS::qos::exactly_once}
                         },
-                        [topic1, topic2](boost::system::error_code const&) {}
+                        [topic1, topic2](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -499,7 +499,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg_async ) {
                             {as::buffer(*topic1)},
                             {as::buffer(*topic2)}
                         },
-                        [topic1, topic2](boost::system::error_code const&) {}
+                        [topic1, topic2](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -524,7 +524,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg_async ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->async_connect();
@@ -568,7 +568,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec_async ) {
                     };
                     c->async_subscribe(
                         std::move(v),
-                        [topic1, topic2](boost::system::error_code const&) {}
+                        [topic1, topic2](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -585,7 +585,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec_async ) {
                         };
                     c->async_unsubscribe(
                         std::move(v),
-                        [topic1, topic2](boost::system::error_code const&) {}
+                        [topic1, topic2](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -613,7 +613,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec_async ) {
                         };
                     c->async_subscribe(
                         std::move(v),
-                        [topic1, topic2](boost::system::error_code const&) {}
+                        [topic1, topic2](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -630,7 +630,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec_async ) {
                         };
                     c->async_unsubscribe(
                         std::move(v),
-                        [topic1, topic2](boost::system::error_code const&) {}
+                        [topic1, topic2](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -655,7 +655,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec_async ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->async_connect();

--- a/test/async_pubsub_1.cpp
+++ b/test/async_pubsub_1.cpp
@@ -183,7 +183,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->set_pub_res_sent_handler(
@@ -380,7 +380,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->set_pub_res_sent_handler(
@@ -570,7 +570,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->set_pub_res_sent_handler(
@@ -753,7 +753,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->set_pub_res_sent_handler(
@@ -950,7 +950,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->async_connect();
@@ -1146,7 +1146,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->async_connect();

--- a/test/async_pubsub_2.cpp
+++ b/test/async_pubsub_2.cpp
@@ -185,7 +185,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->set_pub_res_sent_handler(
@@ -383,7 +383,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->async_connect();
@@ -580,7 +580,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->async_connect();
@@ -758,7 +758,7 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->async_connect();
@@ -943,7 +943,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->async_connect();
@@ -1128,7 +1128,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function_buffer ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->async_connect();
@@ -1299,7 +1299,7 @@ BOOST_AUTO_TEST_CASE( pub_sub_prop ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->set_pub_res_sent_handler(
@@ -1471,7 +1471,7 @@ BOOST_AUTO_TEST_CASE( puback_props ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->async_connect();
@@ -1741,7 +1741,7 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->async_connect();

--- a/test/connect.cpp
+++ b/test/connect.cpp
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE( connect ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();
@@ -129,7 +129,7 @@ BOOST_AUTO_TEST_CASE( connect_no_strand ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();
@@ -186,7 +186,7 @@ BOOST_AUTO_TEST_CASE( keep_alive ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->set_pingresp_handler(
@@ -230,15 +230,15 @@ BOOST_AUTO_TEST_CASE( keep_alive_and_send_control_packet ) {
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
                     tim.expires_from_now(boost::posix_time::seconds(2));
                     tim.async_wait(
-                        [&chk, &c, &tim](boost::system::error_code const& ec) {
+                        [&chk, &c, &tim](MQTT_NS::error_code ec) {
                             MQTT_CHK("2sec");
                             BOOST_CHECK(!ec);
                             c->publish("topic1", "timer_reset", MQTT_NS::qos::at_most_once);
                             tim.expires_from_now(boost::posix_time::seconds(4));
                             tim.async_wait(
-                                [&chk](boost::system::error_code const& ec) {
+                                [&chk](MQTT_NS::error_code ec) {
                                     MQTT_CHK("4sec_cancelled");
-                                    BOOST_TEST(ec == boost::asio::error::operation_aborted );
+                                    BOOST_TEST(ec == boost::asio::error::operation_aborted);
                                 }
                             );
                         }
@@ -255,15 +255,15 @@ BOOST_AUTO_TEST_CASE( keep_alive_and_send_control_packet ) {
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
                     tim.expires_from_now(boost::posix_time::seconds(2));
                     tim.async_wait(
-                        [&chk, &c, &tim](boost::system::error_code const& ec) {
+                        [&chk, &c, &tim](MQTT_NS::error_code ec) {
                             MQTT_CHK("2sec");
                             BOOST_CHECK(!ec);
                             c->publish("topic1", "timer_reset", MQTT_NS::qos::at_most_once);
                             tim.expires_from_now(boost::posix_time::seconds(4));
                             tim.async_wait(
-                                [&chk](boost::system::error_code const& ec) {
+                                [&chk](MQTT_NS::error_code ec) {
                                     MQTT_CHK("4sec_cancelled");
-                                    BOOST_TEST(ec == boost::asio::error::operation_aborted );
+                                    BOOST_TEST(ec == boost::asio::error::operation_aborted);
                                 }
                             );
                         }
@@ -284,7 +284,7 @@ BOOST_AUTO_TEST_CASE( keep_alive_and_send_control_packet ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->set_pingresp_handler(
@@ -374,7 +374,7 @@ BOOST_AUTO_TEST_CASE( connect_again ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();
@@ -431,7 +431,7 @@ BOOST_AUTO_TEST_CASE( nocid ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();
@@ -484,7 +484,7 @@ BOOST_AUTO_TEST_CASE( nocid_noclean ) {
             });
         c->set_error_handler(
             [&chk, &finish]
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 MQTT_CHK("h_error");
                 finish();
             });
@@ -625,7 +625,7 @@ BOOST_AUTO_TEST_CASE( noclean ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();
@@ -684,7 +684,7 @@ BOOST_AUTO_TEST_CASE( disconnect_timeout ) {
             });
         c->set_error_handler(
             [&chk, &finish]
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 MQTT_CHK("h_error");
                 finish();
             });
@@ -745,7 +745,7 @@ BOOST_AUTO_TEST_CASE( disconnect_not_timeout ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();
@@ -804,7 +804,7 @@ BOOST_AUTO_TEST_CASE( async_disconnect_timeout ) {
             });
         c->set_error_handler(
             [&chk, &finish]
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 MQTT_CHK("h_error");
                 finish();
             });
@@ -876,15 +876,15 @@ BOOST_AUTO_TEST_CASE( async_disconnect_not_timeout ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         switch (c->get_protocol_version()) {
         case MQTT_NS::protocol_version::v3_1_1:
             c->async_connect(
                 []
-                (boost::system::error_code const& ec) {
-                    BOOST_TEST(ec == boost::system::errc::success);
+                (MQTT_NS::error_code ec) {
+                    BOOST_TEST( ! ec);
                 }
             );
             break;
@@ -892,8 +892,8 @@ BOOST_AUTO_TEST_CASE( async_disconnect_not_timeout ) {
             c->async_connect(
                 MQTT_NS::v5::properties(),
                 []
-                (boost::system::error_code const& ec) {
-                    BOOST_TEST(ec == boost::system::errc::success);
+                (MQTT_NS::error_code ec) {
+                    BOOST_TEST( ! ec);
                 }
             );
             break;
@@ -1066,7 +1066,7 @@ BOOST_AUTO_TEST_CASE( connect_disconnect_prop ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect(std::move(con_ps));
@@ -1217,7 +1217,7 @@ BOOST_AUTO_TEST_CASE( connack_prop ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();

--- a/test/length_check.cpp
+++ b/test/length_check.cpp
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
             });
         c->set_error_handler(
             [&chk, &c, &finish]
-            (boost::system::error_code const& ec) {
+            (MQTT_NS::error_code ec) {
                 MQTT_CHK("h_error");
                 BOOST_TEST(ec == boost::system::errc::message_size);
                 finish();

--- a/test/manual_publish.cpp
+++ b/test/manual_publish.cpp
@@ -252,7 +252,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();

--- a/test/multi_sub.cpp
+++ b/test/multi_sub.cpp
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE( multi_channel ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->set_puback_handler(
@@ -228,7 +228,7 @@ BOOST_AUTO_TEST_CASE( multi_client_qos0 ) {
         });
     c1->set_error_handler(
         []
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             BOOST_CHECK(false);
         });
     c1->set_puback_handler(
@@ -311,7 +311,7 @@ BOOST_AUTO_TEST_CASE( multi_client_qos0 ) {
         });
     c2->set_error_handler(
         []
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             BOOST_CHECK(false);
         });
     c2->set_puback_handler(
@@ -474,7 +474,7 @@ BOOST_AUTO_TEST_CASE( multi_client_qos1 ) {
         });
     c1->set_error_handler(
         []
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             BOOST_CHECK(false);
         });
     c1->set_suback_handler(
@@ -538,7 +538,7 @@ BOOST_AUTO_TEST_CASE( multi_client_qos1 ) {
         });
     c2->set_error_handler(
         []
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             BOOST_CHECK(false);
         });
     c2->set_suback_handler(
@@ -602,7 +602,7 @@ BOOST_AUTO_TEST_CASE( multi_client_qos1 ) {
         });
     c3->set_error_handler(
         []
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             BOOST_CHECK(false);
         });
     c3->set_puback_handler(

--- a/test/offline.cpp
+++ b/test/offline.cpp
@@ -146,7 +146,7 @@ BOOST_AUTO_TEST_CASE( publish_qos1 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         MQTT_CHK("start");
@@ -284,7 +284,7 @@ BOOST_AUTO_TEST_CASE( publish_qos2 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         MQTT_CHK("start");
@@ -433,7 +433,7 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         MQTT_CHK("start");
@@ -549,8 +549,8 @@ BOOST_AUTO_TEST_CASE( async_publish_qos1 ) {
                             "topic1_contents",
                             MQTT_NS::qos::at_least_once,
                             false, // retain
-                            [&chk](boost::system::error_code const& ec){
-                                BOOST_TEST(ec == boost::system::errc::success);
+                            [&chk](MQTT_NS::error_code ec){
+                                BOOST_TEST( ! ec);
                                 MQTT_CHK("h_pub_finish");
                             }
                         );
@@ -566,7 +566,7 @@ BOOST_AUTO_TEST_CASE( async_publish_qos1 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         MQTT_CHK("start");

--- a/test/pubsub.cpp
+++ b/test/pubsub.cpp
@@ -181,7 +181,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->set_pub_res_sent_handler(
@@ -381,7 +381,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->set_pub_res_sent_handler(
@@ -574,7 +574,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->set_pub_res_sent_handler(
@@ -756,7 +756,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->set_pub_res_sent_handler(
@@ -957,7 +957,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();
@@ -1157,7 +1157,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();
@@ -1341,7 +1341,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();
@@ -1538,7 +1538,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();
@@ -1738,7 +1738,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();
@@ -1916,7 +1916,7 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();
@@ -2094,7 +2094,7 @@ BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();
@@ -2279,7 +2279,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();
@@ -2464,7 +2464,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function_buffer ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();
@@ -2638,7 +2638,7 @@ BOOST_AUTO_TEST_CASE( pub_sub_prop ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->set_pub_res_sent_handler(
@@ -2809,7 +2809,7 @@ BOOST_AUTO_TEST_CASE( puback_prop ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();
@@ -3068,7 +3068,7 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();

--- a/test/pubsub_no_strand.cpp
+++ b/test/pubsub_no_strand.cpp
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
         });
     c->set_error_handler(
         []
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             BOOST_CHECK(false);
             return true;
         });
@@ -206,7 +206,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
         });
     c->set_error_handler(
         []
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             BOOST_CHECK(false);
         });
     c->set_puback_handler(
@@ -334,7 +334,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
         });
     c->set_error_handler(
         []
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             BOOST_CHECK(false);
         });
     c->set_puback_handler(
@@ -460,7 +460,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
         });
     c->set_error_handler(
         []
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             BOOST_CHECK(false);
         });
     c->set_puback_handler(
@@ -587,7 +587,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
         });
     c->set_error_handler(
         []
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             BOOST_CHECK(false);
         });
     c->set_puback_handler(
@@ -724,7 +724,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
         });
     c->set_error_handler(
         []
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             BOOST_CHECK(false);
         });
     c->set_puback_handler(
@@ -859,7 +859,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
         });
     c->set_error_handler(
         []
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             BOOST_CHECK(false);
         });
     c->set_puback_handler(
@@ -987,7 +987,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
         });
     c->set_error_handler(
         []
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             BOOST_CHECK(false);
         });
     c->set_puback_handler(
@@ -1125,7 +1125,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
         });
     c->set_error_handler(
         []
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             BOOST_CHECK(false);
         });
     c->set_puback_handler(
@@ -1260,7 +1260,7 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
         });
     c->set_error_handler(
         []
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             BOOST_CHECK(false);
         });
     c->set_puback_handler(

--- a/test/remaining_length.cpp
+++ b/test/remaining_length.cpp
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE( pub_sub_over_127 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->set_puback_handler(
@@ -172,7 +172,7 @@ BOOST_AUTO_TEST_CASE( pub_sub_over_16384 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->set_puback_handler(
@@ -286,7 +286,7 @@ BOOST_AUTO_TEST_CASE( pub_sub_over_2097152 ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->set_puback_handler(

--- a/test/resend.cpp
+++ b/test/resend.cpp
@@ -212,7 +212,7 @@ BOOST_AUTO_TEST_CASE( publish_qos1 ) {
             });
         c->set_error_handler(
             [&chk, &c, &tim]
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 MQTT_CHK("h_error");
                 // TCP level disconnection detecting timing is unpredictable.
                 // Sometimes broker first, sometimes the client (this test) first.
@@ -223,8 +223,8 @@ BOOST_AUTO_TEST_CASE( publish_qos1 ) {
                 // no corresponding connection exists
                 tim.expires_from_now(boost::posix_time::milliseconds(100));
                 tim.async_wait(
-                    [&c] (boost::system::error_code const& ec) {
-                        BOOST_ASSERT(ec == boost::system::errc::success);
+                    [&c] (MQTT_NS::error_code ec) {
+                        BOOST_ASSERT( ! ec);
                         connect_no_clean(c);
                     }
                 );
@@ -381,7 +381,7 @@ BOOST_AUTO_TEST_CASE( publish_qos2 ) {
             });
         c->set_error_handler(
             [&chk, &c, &tim]
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 MQTT_CHK("h_error");
                 // TCP level disconnection detecting timing is unpredictable.
                 // Sometimes broker first, sometimes the client (this test) first.
@@ -392,8 +392,8 @@ BOOST_AUTO_TEST_CASE( publish_qos2 ) {
                 // no corresponding connection exists
                 tim.expires_from_now(boost::posix_time::milliseconds(100));
                 tim.async_wait(
-                    [&c] (boost::system::error_code const& ec) {
-                        BOOST_ASSERT(ec == boost::system::errc::success);
+                    [&c] (MQTT_NS::error_code ec) {
+                        BOOST_ASSERT( ! ec);
                         connect_no_clean(c);
                     }
                 );
@@ -601,7 +601,7 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2 ) {
             });
         c->set_error_handler(
             [&chk, &c, &tim]
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 MQTT_CHK("h_error");
                 // TCP level disconnection detecting timing is unpredictable.
                 // Sometimes broker first, sometimes the client (this test) first.
@@ -612,8 +612,8 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2 ) {
                 // no corresponding connection exists
                 tim.expires_from_now(boost::posix_time::milliseconds(100));
                 tim.async_wait(
-                    [&c] (boost::system::error_code const& ec) {
-                        BOOST_ASSERT(ec == boost::system::errc::success);
+                    [&c] (MQTT_NS::error_code ec) {
+                        BOOST_ASSERT( ! ec);
                         connect_no_clean(c);
                     }
                 );
@@ -786,7 +786,7 @@ BOOST_AUTO_TEST_CASE( publish_pubrel_qos2 ) {
             });
         c->set_error_handler(
             [&chk, &c, &tim]
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 auto ret = chk.match(
                     "h_connack2",
                     [&] {
@@ -800,8 +800,8 @@ BOOST_AUTO_TEST_CASE( publish_pubrel_qos2 ) {
                         // no corresponding connection exists
                         tim.expires_from_now(boost::posix_time::milliseconds(100));
                         tim.async_wait(
-                            [&c] (boost::system::error_code const& ec) {
-                                BOOST_ASSERT(ec == boost::system::errc::success);
+                            [&c] (MQTT_NS::error_code ec) {
+                                BOOST_ASSERT( ! ec);
                                 connect_no_clean(c);
                             }
                         );
@@ -818,8 +818,8 @@ BOOST_AUTO_TEST_CASE( publish_pubrel_qos2 ) {
                         // no corresponding connection exists
                         tim.expires_from_now(boost::posix_time::milliseconds(100));
                         tim.async_wait(
-                            [&c] (boost::system::error_code const& ec) {
-                                BOOST_ASSERT(ec == boost::system::errc::success);
+                            [&c] (MQTT_NS::error_code ec) {
+                                BOOST_ASSERT( ! ec);
                                 connect_no_clean(c);
                             }
                         );
@@ -991,7 +991,7 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1 ) {
             });
         c->set_error_handler(
             [&chk, &c, &tim]
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 MQTT_CHK("h_error1");
                 // TCP level disconnection detecting timing is unpredictable.
                 // Sometimes broker first, sometimes the client (this test) first.
@@ -1002,8 +1002,8 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1 ) {
                 // no corresponding connection exists
                 tim.expires_from_now(boost::posix_time::milliseconds(100));
                 tim.async_wait(
-                    [&c] (boost::system::error_code const& ec) {
-                        BOOST_ASSERT(ec == boost::system::errc::success);
+                    [&c] (MQTT_NS::error_code ec) {
+                        BOOST_ASSERT( ! ec);
                         connect_no_clean(c);
                     }
                 );

--- a/test/resend_serialize.cpp
+++ b/test/resend_serialize.cpp
@@ -204,7 +204,7 @@ BOOST_AUTO_TEST_CASE( publish_qos1 ) {
         });
     c1->set_error_handler(
         [&chk, &c2, &serialized, &tim]
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             MQTT_CHK("h_error");
             for (auto const& e : serialized) {
                 auto const& packet = std::get<1>(e.second);
@@ -226,8 +226,8 @@ BOOST_AUTO_TEST_CASE( publish_qos1 ) {
             // no corresponding connection exists
             tim.expires_from_now(boost::posix_time::milliseconds(100));
             tim.async_wait(
-                [&c2] (boost::system::error_code const& ec) {
-                    BOOST_ASSERT(ec == boost::system::errc::success);
+                [&c2] (MQTT_NS::error_code ec) {
+                    BOOST_ASSERT( ! ec);
                     connect_no_clean(c2);
                 }
             );
@@ -363,7 +363,7 @@ BOOST_AUTO_TEST_CASE( publish_qos2 ) {
         });
     c1->set_error_handler(
         [&chk, &c2, &serialized, &tim]
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             MQTT_CHK("h_error");
             for (auto const& e : serialized) {
                 auto const& packet = std::get<1>(e.second);
@@ -385,8 +385,8 @@ BOOST_AUTO_TEST_CASE( publish_qos2 ) {
             // no corresponding connection exists
             tim.expires_from_now(boost::posix_time::milliseconds(100));
             tim.async_wait(
-                [&c2] (boost::system::error_code const& ec) {
-                    BOOST_ASSERT(ec == boost::system::errc::success);
+                [&c2] (MQTT_NS::error_code ec) {
+                    BOOST_ASSERT( ! ec);
                     connect_no_clean(c2);
                 }
             );
@@ -527,7 +527,7 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2 ) {
         });
     c1->set_error_handler(
         [&chk, &c2, &serialized, &tim]
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             MQTT_CHK("h_error");
             for (auto const& e : serialized) {
                 auto const& packet = std::get<1>(e.second);
@@ -549,8 +549,8 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2 ) {
             // no corresponding connection exists
             tim.expires_from_now(boost::posix_time::milliseconds(100));
             tim.async_wait(
-                [&c2] (boost::system::error_code const& ec) {
-                    BOOST_ASSERT(ec == boost::system::errc::success);
+                [&c2] (MQTT_NS::error_code ec) {
+                    BOOST_ASSERT( ! ec);
                     connect_no_clean(c2);
                 }
             );
@@ -696,7 +696,7 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1 ) {
         });
     c1->set_error_handler(
         [&chk, &c2, &serialized, &tim]
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             MQTT_CHK("h_error1");
             for (auto const& e : serialized) {
                 auto const& packet = std::get<1>(e.second);
@@ -718,8 +718,8 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1 ) {
             // no corresponding connection exists
             tim.expires_from_now(boost::posix_time::milliseconds(100));
             tim.async_wait(
-                [&c2] (boost::system::error_code const& ec) {
-                    BOOST_ASSERT(ec == boost::system::errc::success);
+                [&c2] (MQTT_NS::error_code ec) {
+                    BOOST_ASSERT( ! ec);
                     connect_no_clean(c2);
                 }
             );
@@ -1028,7 +1028,7 @@ BOOST_AUTO_TEST_CASE( publish_qos1_v5 ) {
         });
     c1->set_error_handler(
         [&chk, &c2, &serialized, &tim]
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             MQTT_CHK("h_error");
             for (auto const& e : serialized) {
                 auto const& packet = std::get<1>(e.second);
@@ -1050,8 +1050,8 @@ BOOST_AUTO_TEST_CASE( publish_qos1_v5 ) {
             // no corresponding connection exists
             tim.expires_from_now(boost::posix_time::milliseconds(100));
             tim.async_wait(
-                [&c2] (boost::system::error_code const& ec) {
-                    BOOST_ASSERT(ec == boost::system::errc::success);
+                [&c2] (MQTT_NS::error_code ec) {
+                    BOOST_ASSERT( ! ec);
                     connect_no_clean(c2);
                 }
             );
@@ -1189,7 +1189,7 @@ BOOST_AUTO_TEST_CASE( publish_qos2_v5 ) {
         });
     c1->set_error_handler(
         [&chk, &c2, &serialized, &tim]
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             MQTT_CHK("h_error");
             for (auto const& e : serialized) {
                 auto const& packet = std::get<1>(e.second);
@@ -1211,8 +1211,8 @@ BOOST_AUTO_TEST_CASE( publish_qos2_v5 ) {
             // no corresponding connection exists
             tim.expires_from_now(boost::posix_time::milliseconds(100));
             tim.async_wait(
-                [&c2] (boost::system::error_code const& ec) {
-                    BOOST_ASSERT(ec == boost::system::errc::success);
+                [&c2] (MQTT_NS::error_code ec) {
+                    BOOST_ASSERT( ! ec);
                     connect_no_clean(c2);
                 }
             );
@@ -1405,7 +1405,7 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2_v5 ) {
         });
     c1->set_error_handler(
         [&chk, &c2, &serialized, &tim]
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             MQTT_CHK("h_error");
             for (auto const& e : serialized) {
                 auto const& packet = std::get<1>(e.second);
@@ -1427,8 +1427,8 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2_v5 ) {
             // no corresponding connection exists
             tim.expires_from_now(boost::posix_time::milliseconds(100));
             tim.async_wait(
-                [&c2] (boost::system::error_code const& ec) {
-                    BOOST_ASSERT(ec == boost::system::errc::success);
+                [&c2] (MQTT_NS::error_code ec) {
+                    BOOST_ASSERT( ! ec);
                     connect_no_clean(c2);
                 }
             );
@@ -1577,7 +1577,7 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1_v5 ) {
         });
     c1->set_error_handler(
         [&chk, &c2, &serialized, &tim]
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             MQTT_CHK("h_error1");
             for (auto const& e : serialized) {
                 auto const& packet = std::get<1>(e.second);
@@ -1599,8 +1599,8 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1_v5 ) {
             // no corresponding connection exists
             tim.expires_from_now(boost::posix_time::milliseconds(100));
             tim.async_wait(
-                [&c2] (boost::system::error_code const& ec) {
-                    BOOST_ASSERT(ec == boost::system::errc::success);
+                [&c2] (MQTT_NS::error_code ec) {
+                    BOOST_ASSERT( ! ec);
                     connect_no_clean(c2);
                 }
             );

--- a/test/resend_serialize_ptr_size.cpp
+++ b/test/resend_serialize_ptr_size.cpp
@@ -130,7 +130,7 @@ BOOST_AUTO_TEST_CASE( publish_qos1 ) {
         });
     c1->set_error_handler(
         [&chk, &c2, &serialized, &tim]
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             MQTT_CHK("h_error");
             for (auto const& e : serialized) {
                 restore_serialized_message(c2, e);
@@ -144,8 +144,8 @@ BOOST_AUTO_TEST_CASE( publish_qos1 ) {
             // no corresponding connection exists
             tim.expires_from_now(boost::posix_time::milliseconds(100));
             tim.async_wait(
-                [&c2] (boost::system::error_code const& ec) {
-                    BOOST_ASSERT(ec == boost::system::errc::success);
+                [&c2] (MQTT_NS::error_code ec) {
+                    BOOST_ASSERT( ! ec);
                     connect_no_clean(c2);
                 }
             );
@@ -275,7 +275,7 @@ BOOST_AUTO_TEST_CASE( publish_qos2 ) {
         });
     c1->set_error_handler(
         [&chk, &c2, &serialized, &tim]
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             MQTT_CHK("h_error");
             for (auto const& e : serialized) {
                 restore_serialized_message(c2, e);
@@ -289,8 +289,8 @@ BOOST_AUTO_TEST_CASE( publish_qos2 ) {
             // no corresponding connection exists
             tim.expires_from_now(boost::posix_time::milliseconds(100));
             tim.async_wait(
-                [&c2] (boost::system::error_code const& ec) {
-                    BOOST_ASSERT(ec == boost::system::errc::success);
+                [&c2] (MQTT_NS::error_code ec) {
+                    BOOST_ASSERT( ! ec);
                     connect_no_clean(c2);
                 }
             );
@@ -425,7 +425,7 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2 ) {
         });
     c1->set_error_handler(
         [&chk, &c2, &serialized, &tim]
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             MQTT_CHK("h_error");
             for (auto const& e : serialized) {
                 restore_serialized_message(c2, e);
@@ -439,8 +439,8 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2 ) {
             // no corresponding connection exists
             tim.expires_from_now(boost::posix_time::milliseconds(100));
             tim.async_wait(
-                [&c2] (boost::system::error_code const& ec) {
-                    BOOST_ASSERT(ec == boost::system::errc::success);
+                [&c2] (MQTT_NS::error_code ec) {
+                    BOOST_ASSERT( ! ec);
                     connect_no_clean(c2);
                 }
             );
@@ -580,7 +580,7 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1 ) {
         });
     c1->set_error_handler(
         [&chk, &c2, &serialized, &tim]
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             MQTT_CHK("h_error1");
             for (auto const& e : serialized) {
                 restore_serialized_message(c2, e);
@@ -594,8 +594,8 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1 ) {
             // no corresponding connection exists
             tim.expires_from_now(boost::posix_time::milliseconds(100));
             tim.async_wait(
-                [&c2] (boost::system::error_code const& ec) {
-                    BOOST_ASSERT(ec == boost::system::errc::success);
+                [&c2] (MQTT_NS::error_code ec) {
+                    BOOST_ASSERT( ! ec);
                     connect_no_clean(c2);
                 }
             );
@@ -830,7 +830,7 @@ BOOST_AUTO_TEST_CASE( publish_qos1_v5 ) {
         });
     c1->set_error_handler(
         [&chk, &c2, &serialized, &tim]
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             MQTT_CHK("h_error");
             for (auto const& e : serialized) {
                 restore_serialized_message(c2, e);
@@ -844,8 +844,8 @@ BOOST_AUTO_TEST_CASE( publish_qos1_v5 ) {
             // no corresponding connection exists
             tim.expires_from_now(boost::posix_time::milliseconds(100));
             tim.async_wait(
-                [&c2] (boost::system::error_code const& ec) {
-                    BOOST_ASSERT(ec == boost::system::errc::success);
+                [&c2] (MQTT_NS::error_code ec) {
+                    BOOST_ASSERT( ! ec);
                     connect_no_clean(c2);
                 }
             );
@@ -977,7 +977,7 @@ BOOST_AUTO_TEST_CASE( publish_qos2_v5 ) {
         });
     c1->set_error_handler(
         [&chk, &c2, &serialized, &tim]
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             MQTT_CHK("h_error");
             for (auto const& e : serialized) {
                 restore_serialized_message(c2, e);
@@ -991,8 +991,8 @@ BOOST_AUTO_TEST_CASE( publish_qos2_v5 ) {
             // no corresponding connection exists
             tim.expires_from_now(boost::posix_time::milliseconds(100));
             tim.async_wait(
-                [&c2] (boost::system::error_code const& ec) {
-                    BOOST_ASSERT(ec == boost::system::errc::success);
+                [&c2] (MQTT_NS::error_code ec) {
+                    BOOST_ASSERT( ! ec);
                     connect_no_clean(c2);
                 }
             );
@@ -1179,7 +1179,7 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2_v5 ) {
         });
     c1->set_error_handler(
         [&chk, &c2, &serialized, &tim]
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             MQTT_CHK("h_error");
             for (auto const& e : serialized) {
                 restore_v5_serialized_message(c2, e);
@@ -1193,8 +1193,8 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2_v5 ) {
             // no corresponding connection exists
             tim.expires_from_now(boost::posix_time::milliseconds(100));
             tim.async_wait(
-                [&c2] (boost::system::error_code const& ec) {
-                    BOOST_ASSERT(ec == boost::system::errc::success);
+                [&c2] (MQTT_NS::error_code ec) {
+                    BOOST_ASSERT( ! ec);
                     connect_no_clean(c2);
                 }
             );
@@ -1337,7 +1337,7 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1_v5 ) {
         });
     c1->set_error_handler(
         [&chk, &c2, &serialized, &tim]
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             MQTT_CHK("h_error1");
             for (auto const& e : serialized) {
                 restore_serialized_message(c2, e);
@@ -1351,8 +1351,8 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1_v5 ) {
             // no corresponding connection exists
             tim.expires_from_now(boost::posix_time::milliseconds(100));
             tim.async_wait(
-                [&c2] (boost::system::error_code const& ec) {
-                    BOOST_ASSERT(ec == boost::system::errc::success);
+                [&c2] (MQTT_NS::error_code ec) {
+                    BOOST_ASSERT( ! ec);
                     connect_no_clean(c2);
                 }
             );

--- a/test/retain.cpp
+++ b/test/retain.cpp
@@ -186,7 +186,7 @@ BOOST_AUTO_TEST_CASE( simple ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();
@@ -374,7 +374,7 @@ BOOST_AUTO_TEST_CASE( overwrite ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();
@@ -622,7 +622,7 @@ BOOST_AUTO_TEST_CASE( retain_and_publish ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();
@@ -795,7 +795,7 @@ BOOST_AUTO_TEST_CASE( prop ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();

--- a/test/sub.cpp
+++ b/test/sub.cpp
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_single ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();
@@ -191,7 +191,7 @@ BOOST_AUTO_TEST_CASE( sub_v5_options ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();
@@ -292,7 +292,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();
@@ -399,7 +399,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();
@@ -434,14 +434,14 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_single_async ) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
-                    c->async_subscribe("topic1", MQTT_NS::qos::at_most_once, [](boost::system::error_code const&) {});
+                    c->async_subscribe("topic1", MQTT_NS::qos::at_most_once, [](MQTT_NS::error_code) {});
                     return true;
                 });
             c->set_suback_handler(
                 [&chk, &c]
                 (packet_id_t /*packet_id*/, std::vector<MQTT_NS::suback_return_code> /*results*/) {
                     MQTT_CHK("h_suback");
-                    c->async_unsubscribe("topic1", [](boost::system::error_code const&) {});
+                    c->async_unsubscribe("topic1", [](MQTT_NS::error_code) {});
                     return true;
                 });
             c->set_unsuback_handler(
@@ -459,14 +459,14 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_single_async ) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
-                    c->async_subscribe("topic1", MQTT_NS::qos::at_most_once, [](boost::system::error_code const&) {});
+                    c->async_subscribe("topic1", MQTT_NS::qos::at_most_once, [](MQTT_NS::error_code) {});
                     return true;
                 });
             c->set_v5_suback_handler(
                 [&chk, &c]
                 (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::suback_reason_code> /*reasons*/, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
-                    c->async_unsubscribe("topic1", [](boost::system::error_code const&) {});
+                    c->async_unsubscribe("topic1", [](MQTT_NS::error_code) {});
                     return true;
                 });
             c->set_v5_unsuback_handler(
@@ -490,7 +490,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_single_async ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->async_connect();
@@ -530,7 +530,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg_async ) {
                             {"topic1", MQTT_NS::qos::at_most_once},
                             {"topic2", MQTT_NS::qos::exactly_once}
                         },
-                        [](boost::system::error_code const&) {}
+                        [](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -543,7 +543,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg_async ) {
                             "topic1",
                             "topic2"
                         },
-                        [](boost::system::error_code const&) {}
+                        [](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -567,7 +567,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg_async ) {
                             {"topic1", MQTT_NS::qos::at_most_once},
                             {"topic2", MQTT_NS::qos::exactly_once}
                         },
-                        [](boost::system::error_code const&) {}
+                        [](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -580,7 +580,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg_async ) {
                             "topic1",
                             "topic2"
                         },
-                        [](boost::system::error_code const&) {}
+                        [](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -605,7 +605,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg_async ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->async_connect();
@@ -645,7 +645,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec_async ) {
                     v.emplace_back("topic2", MQTT_NS::qos::exactly_once);
                     c->async_subscribe(
                         v,
-                        [](boost::system::error_code const&) {}
+                        [](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -660,7 +660,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec_async ) {
                         };
                     c->async_unsubscribe(
                         v,
-                        [](boost::system::error_code const&) {}
+                        [](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -684,7 +684,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec_async ) {
                     v.emplace_back("topic2", MQTT_NS::qos::exactly_once);
                     c->async_subscribe(
                         v,
-                        [](boost::system::error_code const&) {}
+                        [](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -699,7 +699,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec_async ) {
                         };
                     c->async_unsubscribe(
                         v,
-                        [](boost::system::error_code const&) {}
+                        [](MQTT_NS::error_code) {}
                     );
                     return true;
                 });
@@ -724,7 +724,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec_async ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->async_connect();
@@ -866,7 +866,7 @@ BOOST_AUTO_TEST_CASE( sub_unsub_prop ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();
@@ -1007,7 +1007,7 @@ BOOST_AUTO_TEST_CASE( suback_unsuback_prop ) {
             });
         c->set_error_handler(
             []
-            (boost::system::error_code const&) {
+            (MQTT_NS::error_code) {
                 BOOST_CHECK(false);
             });
         c->connect();

--- a/test/test_broker.hpp
+++ b/test/test_broker.hpp
@@ -91,7 +91,7 @@ public:
             });
         ep.set_error_handler(
             [this, wp]
-            (boost::system::error_code const& /*ec*/){
+            (MQTT_NS::error_code /*ec*/){
                 con_sp_t sp = wp.lock();
                 BOOST_ASSERT(sp);
                 close_proc(MQTT_NS::force_move(sp), true);
@@ -629,7 +629,7 @@ private:
             con_wp_t wp(spep);
             tim_disconnect_.expires_from_now(delay_disconnect_.value());
             tim_disconnect_.async_wait(
-                [&, wp](boost::system::error_code const& ec) {
+                [&, wp](MQTT_NS::error_code ec) {
                     if (!ec) {
                         if (con_sp_t sp = wp.lock()) {
                             close_proc(MQTT_NS::force_move(sp), false);

--- a/test/test_server_no_tls.hpp
+++ b/test/test_server_no_tls.hpp
@@ -31,7 +31,7 @@ public:
             }
         ), b_(b) {
         server_.set_error_handler(
-            [](boost::system::error_code const& /*ec*/) {
+            [](MQTT_NS::error_code /*ec*/) {
             }
         );
 

--- a/test/test_server_no_tls_ws.hpp
+++ b/test/test_server_no_tls_ws.hpp
@@ -29,7 +29,7 @@ public:
             }
         ), b_(b) {
         server_.set_error_handler(
-            [](boost::system::error_code const& /*ec*/) {
+            [](MQTT_NS::error_code /*ec*/) {
             }
         );
 

--- a/test/test_server_tls.hpp
+++ b/test/test_server_tls.hpp
@@ -38,7 +38,7 @@ public:
             }
         ), b_(b) {
         server_.set_error_handler(
-            [](boost::system::error_code const& /*ec*/) {
+            [](MQTT_NS::error_code /*ec*/) {
             }
         );
 

--- a/test/test_server_tls_ws.hpp
+++ b/test/test_server_tls_ws.hpp
@@ -39,7 +39,7 @@ public:
             }
         ), b_(b) {
         server_.set_error_handler(
-            [](boost::system::error_code const& /*ec*/) {
+            [](MQTT_NS::error_code /*ec*/) {
             }
         );
 

--- a/test/underlying_timeout.cpp
+++ b/test/underlying_timeout.cpp
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE( connect_ws_upg ) {
 #endif // BOOST_VERSION >= 107000
         eps.begin(), eps.end(),
         [&]
-        (boost::system::error_code const& ec, auto) {
+        (MQTT_NS::error_code ec, auto) {
             if (ec) {
                 std::cout << ec.message() << std::endl;
             }
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE( connect_ws_upg ) {
                 socket,
                 as::buffer(&buf, 1),
                 [&]
-                (boost::system::error_code const& ec,
+                (MQTT_NS::error_code ec,
                  std::size_t /*bytes_transferred*/){
                     BOOST_TEST(ec);
                     server.close();
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_CASE( connect_tls_ws_ashs ) {
 #endif // BOOST_VERSION >= 107000
         eps.begin(), eps.end(),
         [&]
-        (boost::system::error_code const& ec, auto) {
+        (MQTT_NS::error_code ec, auto) {
             if (ec) {
                 std::cout << ec.message() << std::endl;
             }
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE( connect_tls_ws_ashs ) {
                 socket,
                 as::buffer(&buf, 1),
                 [&]
-                (boost::system::error_code const& ec,
+                (MQTT_NS::error_code ec,
                  std::size_t /*bytes_transferred*/){
                     BOOST_TEST(ec);
                     server.close();
@@ -192,7 +192,7 @@ BOOST_AUTO_TEST_CASE( connect_tls_ws_upg ) {
 #endif // BOOST_VERSION >= 107000
         eps.begin(), eps.end(),
         [&]
-        (boost::system::error_code const& ec, auto) {
+        (MQTT_NS::error_code ec, auto) {
             if (ec) {
                 std::cout << ec.message() << std::endl;
             }
@@ -201,7 +201,7 @@ BOOST_AUTO_TEST_CASE( connect_tls_ws_upg ) {
             socket.next_layer().async_handshake(
                 as::ssl::stream_base::client,
                 [&]
-                (boost::system::error_code const& ec) {
+                (MQTT_NS::error_code ec) {
                     if (ec) {
                         std::cout << ec.message() << std::endl;
                     }
@@ -211,7 +211,7 @@ BOOST_AUTO_TEST_CASE( connect_tls_ws_upg ) {
                         socket,
                         as::buffer(&buf, 1),
                         [&]
-                        (boost::system::error_code const& ec,
+                        (MQTT_NS::error_code ec,
                          std::size_t /*bytes_transferred*/){
                             BOOST_TEST(ec);
                             server.close();
@@ -271,7 +271,7 @@ BOOST_AUTO_TEST_CASE( connect_tls_ashs ) {
         socket.lowest_layer(),
         eps.begin(), eps.end(),
         [&]
-        (boost::system::error_code const& ec, auto) {
+        (MQTT_NS::error_code ec, auto) {
             if (ec) {
                 std::cout << ec.message() << std::endl;
             }
@@ -281,7 +281,7 @@ BOOST_AUTO_TEST_CASE( connect_tls_ashs ) {
                 socket,
                 as::buffer(&buf, 1),
                 [&]
-                (boost::system::error_code const& ec,
+                (MQTT_NS::error_code ec,
                  std::size_t /*bytes_transferred*/){
                     BOOST_TEST(ec);
                     server.close();

--- a/test/will.cpp
+++ b/test/will.cpp
@@ -93,7 +93,7 @@ BOOST_AUTO_TEST_CASE( will_qos0 ) {
         });
     c1->set_error_handler(
         [&chk]
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             MQTT_CHK("h_error_1");
         });
 
@@ -122,7 +122,7 @@ BOOST_AUTO_TEST_CASE( will_qos0 ) {
         });
     c2->set_error_handler(
         []
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             BOOST_CHECK(false);
         });
     c2->set_suback_handler(
@@ -246,7 +246,7 @@ BOOST_AUTO_TEST_CASE( will_qos1 ) {
         });
     c1->set_error_handler(
         [&chk]
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             MQTT_CHK("h_error_1");
         });
 
@@ -271,7 +271,7 @@ BOOST_AUTO_TEST_CASE( will_qos1 ) {
         });
     c2->set_error_handler(
         []
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             BOOST_CHECK(false);
         });
     c2->set_suback_handler(
@@ -396,7 +396,7 @@ BOOST_AUTO_TEST_CASE( will_qos2 ) {
         });
     c1->set_error_handler(
         [&chk]
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             MQTT_CHK("h_error_1");
         });
 
@@ -421,7 +421,7 @@ BOOST_AUTO_TEST_CASE( will_qos2 ) {
         });
     c2->set_error_handler(
         []
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             BOOST_CHECK(false);
         });
     c2->set_suback_handler(
@@ -555,7 +555,7 @@ BOOST_AUTO_TEST_CASE( will_retain ) {
         });
     c1->set_error_handler(
         [&chk]
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             MQTT_CHK("h_error_1");
         });
 
@@ -580,7 +580,7 @@ BOOST_AUTO_TEST_CASE( will_retain ) {
         });
     c2->set_error_handler(
         []
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             BOOST_CHECK(false);
         });
     c2->set_suback_handler(
@@ -805,7 +805,7 @@ BOOST_AUTO_TEST_CASE( will_prop ) {
         });
     c1->set_error_handler(
         [&chk]
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             MQTT_CHK("h_error_1");
         });
 
@@ -834,7 +834,7 @@ BOOST_AUTO_TEST_CASE( will_prop ) {
         });
     c2->set_error_handler(
         []
-        (boost::system::error_code const&) {
+        (MQTT_NS::error_code) {
             BOOST_CHECK(false);
         });
     c2->set_v5_suback_handler(


### PR DESCRIPTION
Replaces https://github.com/redboltz/mqtt_cpp/pull/525