### PR TITLE
Fixed #540.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 7.0.1
+* Fixed packet_id leak on QoS2 publish. (#541, #542)
+
 ## 7.0.0
 * Added explicit destructor to clients. (#481)
 * Fixed warnings. (#480)

--- a/include/mqtt/endpoint.hpp
+++ b/include/mqtt/endpoint.hpp
@@ -9885,8 +9885,7 @@ private:
                 auto& idx = store_.template get<tag_packet_id_type>();
                 auto r = idx.equal_range(std::make_tuple(info.packet_id, control_packet_type::pubcomp));
                 idx.erase(std::get<0>(r), std::get<1>(r));
-                // packet_id shouldn't be erased here.
-                // It is reused for pubrel/pubcomp.
+                packet_id_.erase(info.packet_id);
             }
             on_serialize_remove(info.packet_id);
             switch (version_) {


### PR DESCRIPTION
Fixed packet_id leak on QoS2 publish.