### PR TITLE
Fixed #540.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 6.0.7
+* Fixed packet_id leak on QoS2 publish. (backported) (#541, #542, #543)
+
 ## 6.0.6
 * Fixed server side endpoint lifetime management problem. (#439, #440)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MQTT client/server for C++14 based on Boost.Asio
 
-Version 6.0.6 [![Build Status](https://travis-ci.org/redboltz/mqtt_cpp.svg?branch=master)](https://travis-ci.org/redboltz/mqtt_cpp)[![Build Status](https://dev.azure.com/redboltz/redboltz/_apis/build/status/redboltz.mqtt_cpp?branchName=master)](https://dev.azure.com/redboltz/redboltz/_build/latest?definitionId=6&branchName=master)[![codecov](https://codecov.io/gh/redboltz/mqtt_cpp/branch/master/graph/badge.svg)](https://codecov.io/gh/redboltz/mqtt_cpp)
+Version 6.0.7 [![Build Status](https://travis-ci.org/redboltz/mqtt_cpp.svg?branch=master)](https://travis-ci.org/redboltz/mqtt_cpp)[![Build Status](https://dev.azure.com/redboltz/redboltz/_apis/build/status/redboltz.mqtt_cpp?branchName=master)](https://dev.azure.com/redboltz/redboltz/_build/latest?definitionId=6&branchName=master)[![codecov](https://codecov.io/gh/redboltz/mqtt_cpp/branch/master/graph/badge.svg)](https://codecov.io/gh/redboltz/mqtt_cpp)
 
 Important note https://github.com/redboltz/mqtt_cpp/wiki/News.
 

--- a/include/mqtt/endpoint.hpp
+++ b/include/mqtt/endpoint.hpp
@@ -13203,8 +13203,7 @@ private:
                 auto& idx = store_.template get<tag_packet_id_type>();
                 auto r = idx.equal_range(std::make_tuple(info.packet_id, control_packet_type::pubcomp));
                 idx.erase(std::get<0>(r), std::get<1>(r));
-                // packet_id shouldn't be erased here.
-                // It is reused for pubrel/pubcomp.
+                packet_id_.erase(info.packet_id);
             }
             if (h_serialize_remove_) h_serialize_remove_(info.packet_id);
             switch (version_) {


### PR DESCRIPTION
Fixed packet_id leak on QoS2 publish.