### PR TITLE
Remove the acquired_*** family of functions, in favor of always needi…

### DIFF
--- a/example/no_tls_both.cpp
+++ b/example/no_tls_both.cpp
@@ -39,6 +39,7 @@ void client_proc(
             if (connack_return_code == MQTT_NS::connect_return_code::accepted) {
                 pid_sub1 = c->subscribe("mqtt_client_cpp/topic1", MQTT_NS::qos::at_most_once);
                 pid_sub2 = c->subscribe(
+                    std::vector<std::tuple<MQTT_NS::string_view, MQTT_NS::subscribe_options>>
                     {
                         { "mqtt_client_cpp/topic2_1", MQTT_NS::qos::at_least_once },
                         { "mqtt_client_cpp/topic2_2", MQTT_NS::qos::exactly_once }

--- a/example/no_tls_client.cpp
+++ b/example/no_tls_client.cpp
@@ -45,6 +45,7 @@ int main(int argc, char** argv) {
             if (connack_return_code == MQTT_NS::connect_return_code::accepted) {
                 pid_sub1 = c->subscribe("mqtt_client_cpp/topic1", MQTT_NS::qos::at_most_once);
                 pid_sub2 = c->subscribe(
+                    std::vector<std::tuple<MQTT_NS::string_view, MQTT_NS::subscribe_options>>
                     {
                         { "mqtt_client_cpp/topic2_1", MQTT_NS::qos::at_least_once },
                         { "mqtt_client_cpp/topic2_2", MQTT_NS::qos::exactly_once }

--- a/example/no_tls_ws_both.cpp
+++ b/example/no_tls_ws_both.cpp
@@ -39,6 +39,7 @@ void client_proc(
             if (connack_return_code == MQTT_NS::connect_return_code::accepted) {
                 pid_sub1 = c->subscribe("mqtt_client_cpp/topic1", MQTT_NS::qos::at_most_once);
                 pid_sub2 = c->subscribe(
+                    std::vector<std::tuple<MQTT_NS::string_view, MQTT_NS::subscribe_options>>
                     {
                         { "mqtt_client_cpp/topic2_1", MQTT_NS::qos::at_least_once },
                         { "mqtt_client_cpp/topic2_2", MQTT_NS::qos::exactly_once }

--- a/example/no_tls_ws_client.cpp
+++ b/example/no_tls_ws_client.cpp
@@ -45,6 +45,7 @@ int main(int argc, char** argv) {
             if (connack_return_code == MQTT_NS::connect_return_code::accepted) {
                 pid_sub1 = c->subscribe("mqtt_client_cpp/topic1", MQTT_NS::qos::at_most_once);
                 pid_sub2 = c->subscribe(
+                    std::vector<std::tuple<MQTT_NS::string_view, MQTT_NS::subscribe_options>>
                     {
                         { "mqtt_client_cpp/topic2_1", MQTT_NS::qos::at_least_once },
                         { "mqtt_client_cpp/topic2_2", MQTT_NS::qos::exactly_once }

--- a/example/tls_both.cpp
+++ b/example/tls_both.cpp
@@ -40,6 +40,7 @@ void client_proc(
             if (connack_return_code == MQTT_NS::connect_return_code::accepted) {
                 pid_sub1 = c->subscribe("mqtt_client_cpp/topic1", MQTT_NS::qos::at_most_once);
                 pid_sub2 = c->subscribe(
+                    std::vector<std::tuple<MQTT_NS::string_view, MQTT_NS::subscribe_options>>
                     {
                         { "mqtt_client_cpp/topic2_1", MQTT_NS::qos::at_least_once },
                         { "mqtt_client_cpp/topic2_2", MQTT_NS::qos::exactly_once }

--- a/example/tls_client.cpp
+++ b/example/tls_client.cpp
@@ -61,6 +61,7 @@ int main(int argc, char** argv) {
             if (connack_return_code == MQTT_NS::connect_return_code::accepted) {
                 pid_sub1 = c->subscribe("mqtt_client_cpp/topic1", MQTT_NS::qos::at_most_once);
                 pid_sub2 = c->subscribe(
+                    std::vector<std::tuple<MQTT_NS::string_view, MQTT_NS::subscribe_options>>
                     {
                         { "mqtt_client_cpp/topic2_1", MQTT_NS::subscribe_options(MQTT_NS::qos::at_least_once) },
                         { "mqtt_client_cpp/topic2_2", MQTT_NS::subscribe_options(MQTT_NS::qos::exactly_once) }

--- a/example/tls_ws_both.cpp
+++ b/example/tls_ws_both.cpp
@@ -39,6 +39,7 @@ void client_proc(
             if (connack_return_code == MQTT_NS::connect_return_code::accepted) {
                 pid_sub1 = c->subscribe("mqtt_client_cpp/topic1", MQTT_NS::qos::at_most_once);
                 pid_sub2 = c->subscribe(
+                    std::vector<std::tuple<MQTT_NS::string_view, MQTT_NS::subscribe_options>>
                     {
                         { "mqtt_client_cpp/topic2_1", MQTT_NS::qos::at_least_once },
                         { "mqtt_client_cpp/topic2_2", MQTT_NS::qos::exactly_once }

--- a/example/tls_ws_client.cpp
+++ b/example/tls_ws_client.cpp
@@ -51,6 +51,7 @@ int main(int argc, char** argv) {
             if (connack_return_code == MQTT_NS::connect_return_code::accepted) {
                 pid_sub1 = c->subscribe("mqtt_client_cpp/topic1", MQTT_NS::qos::at_most_once);
                 pid_sub2 = c->subscribe(
+                    std::vector<std::tuple<MQTT_NS::string_view, MQTT_NS::subscribe_options>>
                     {
                         { "mqtt_client_cpp/topic2_1", MQTT_NS::qos::at_least_once },
                         { "mqtt_client_cpp/topic2_2", MQTT_NS::qos::exactly_once }

--- a/example/v5_no_tls_both.cpp
+++ b/example/v5_no_tls_both.cpp
@@ -38,6 +38,7 @@ void client_proc(
             if (reason_code == MQTT_NS::v5::connect_reason_code::success) {
                 pid_sub1 = c->subscribe("mqtt_client_cpp/topic1", MQTT_NS::qos::at_most_once);
                 pid_sub2 = c->subscribe(
+                    std::vector<std::tuple<MQTT_NS::string_view, MQTT_NS::subscribe_options>>
                     {
                         { "mqtt_client_cpp/topic2_1", MQTT_NS::qos::at_least_once },
                         { "mqtt_client_cpp/topic2_2", MQTT_NS::qos::exactly_once }

--- a/example/v5_no_tls_client.cpp
+++ b/example/v5_no_tls_client.cpp
@@ -45,6 +45,7 @@ int main(int argc, char** argv) {
             if (reason_code == MQTT_NS::v5::connect_reason_code::success) {
                 pid_sub1 = c->subscribe("mqtt_client_cpp/topic1", MQTT_NS::qos::at_most_once);
                 pid_sub2 = c->subscribe(
+                    std::vector<std::tuple<MQTT_NS::string_view, MQTT_NS::subscribe_options>>
                     {
                         { "mqtt_client_cpp/topic2_1", MQTT_NS::qos::at_least_once },
                         { "mqtt_client_cpp/topic2_2", MQTT_NS::qos::exactly_once }

--- a/include/mqtt/async_client.hpp
+++ b/include/mqtt/async_client.hpp
@@ -235,13 +235,6 @@ public:
     void subscribe() = delete;
     void unsubscribe() = delete;
     void publish_dup() = delete;
-    void acquired_publish_at_least_once() = delete;
-    void acquired_publish_exactly_once() = delete;
-    void acquired_publish() = delete;
-    void acquired_publish_dup() = delete;
-    void acquired_subscribe() = delete;
-    void acquired_unsubscribe() = delete;
-    void acquired_pingreq() = delete;
     void pingresp() = delete;
     void connack() = delete;
     void puback() = delete;

--- a/include/mqtt/sync_client.hpp
+++ b/include/mqtt/sync_client.hpp
@@ -234,13 +234,6 @@ public:
     void async_subscribe() = delete;
     void async_unsubscribe() = delete;
     void async_publish_dup() = delete;
-    void acquired_async_publish_at_least_once() = delete;
-    void acquired_async_publish_exactly_once() = delete;
-    void acquired_async_publish() = delete;
-    void acquired_async_publish_dup() = delete;
-    void acquired_async_subscribe() = delete;
-    void acquired_async_unsubscribe() = delete;
-    void acquired_pingreq() = delete;
     void async_pingresp() = delete;
     void async_connack() = delete;
     void async_puback() = delete;

--- a/test/as_buffer_async_pubsub_1.cpp
+++ b/test/as_buffer_async_pubsub_1.cpp
@@ -44,7 +44,9 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_sub = c->async_subscribe(
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(
+                        pid_sub,
                         as::buffer(*topic1),
                         MQTT_NS::qos::at_most_once,
                         [topic1](MQTT_NS::error_code) {}
@@ -109,7 +111,9 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_unsub = c->async_unsubscribe(
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(
+                        pid_unsub,
                         as::buffer(*topic1),
                         [topic1](MQTT_NS::error_code) {}
                     );
@@ -124,7 +128,9 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_sub = c->async_subscribe(
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(
+                        pid_sub,
                         as::buffer(*topic1),
                         MQTT_NS::qos::at_most_once,
                         [topic1](MQTT_NS::error_code) {}
@@ -192,7 +198,9 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_unsub = c->async_unsubscribe(
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(
+                        pid_unsub,
                         as::buffer(*topic1),
                         [topic1](MQTT_NS::error_code) {}
                     );
@@ -258,7 +266,9 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_sub = c->async_subscribe(
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(
+                        pid_sub,
                         as::buffer(*topic1),
                         MQTT_NS::qos::at_most_once,
                         [topic1](MQTT_NS::error_code) {}
@@ -271,7 +281,9 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                     MQTT_CHK("h_puback");
                     BOOST_TEST(packet_id == pid_pub);
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_unsub = c->async_unsubscribe(
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(
+                        pid_unsub,
                         as::buffer(*topic1),
                         [topic1](MQTT_NS::error_code) {}
                     );
@@ -298,7 +310,9 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                     BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
                     auto topic1 = std::make_shared<std::string>("topic1");
                     auto contents = std::make_shared<std::string>("topic1_contents");
-                    pid_pub = c->async_publish(
+                    pid_pub = c->acquire_unique_packet_id();
+                    c->async_publish(
+                        pid_pub,
                         as::buffer(*topic1),
                         as::buffer(*contents),
                         std::make_pair(topic1, contents),
@@ -340,7 +354,9 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_sub = c->async_subscribe(
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(
+                        pid_sub,
                         as::buffer(*topic1),
                         MQTT_NS::qos::at_most_once,
                         [topic1](MQTT_NS::error_code) {}
@@ -353,7 +369,9 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                     MQTT_CHK("h_puback");
                     BOOST_TEST(packet_id == pid_pub);
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_unsub = c->async_unsubscribe(
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(
+                        pid_unsub,
                         as::buffer(*topic1),
                         [topic1](MQTT_NS::error_code) {}
                     );
@@ -380,7 +398,9 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                     BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_0);
                     auto topic1 = std::make_shared<std::string>("topic1");
                     auto contents = std::make_shared<std::string>("topic1_contents");
-                    pid_pub = c->async_publish(
+                    pid_pub = c->acquire_unique_packet_id();
+                    c->async_publish(
+                        pid_pub,
                         as::buffer(*topic1),
                         as::buffer(*contents),
                         std::make_pair(topic1, contents),
@@ -477,7 +497,9 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_sub = c->async_subscribe(
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(
+                        pid_sub,
                         as::buffer(*topic1),
                         MQTT_NS::qos::at_most_once,
                         [topic1](MQTT_NS::error_code) {}
@@ -503,7 +525,9 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                     MQTT_CHK("h_pubcomp");
                     BOOST_TEST(packet_id == pid_pub);
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_unsub = c->async_unsubscribe(
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(
+                        pid_unsub,
                         as::buffer(*topic1),
                         [topic1](MQTT_NS::error_code) {}
                     );
@@ -518,7 +542,9 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                     BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
                     auto topic1 = std::make_shared<std::string>("topic1");
                     auto contents = std::make_shared<std::string>("topic1_contents");
-                    pid_pub = c->async_publish(
+                    pid_pub = c->acquire_unique_packet_id();
+                    c->async_publish(
+                        pid_pub,
                         as::buffer(*topic1),
                         as::buffer(*contents),
                         std::make_pair(topic1, contents),
@@ -560,7 +586,9 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_sub = c->async_subscribe(
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(
+                        pid_sub,
                         as::buffer(*topic1),
                         MQTT_NS::qos::at_most_once,
                         [topic1](MQTT_NS::error_code) {}
@@ -586,7 +614,9 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                     MQTT_CHK("h_pubcomp");
                     BOOST_TEST(packet_id == pid_pub);
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_unsub = c->async_unsubscribe(
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(
+                        pid_unsub,
                         as::buffer(*topic1),
                         [topic1](MQTT_NS::error_code) {}
                     );
@@ -601,7 +631,9 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                     BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_0);
                     auto topic1 = std::make_shared<std::string>("topic1");
                     auto contents = std::make_shared<std::string>("topic1_contents");
-                    pid_pub = c->async_publish(
+                    pid_pub = c->acquire_unique_packet_id();
+                    c->async_publish(
+                        pid_pub,
                         as::buffer(*topic1),
                         as::buffer(*contents),
                         std::make_pair(topic1, contents),
@@ -694,7 +726,9 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_sub = c->async_subscribe(
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(
+                        pid_sub,
                         as::buffer(*topic1),
                         MQTT_NS::qos::at_least_once,
                         [topic1](MQTT_NS::error_code) {}
@@ -759,7 +793,9 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_unsub = c->async_unsubscribe(
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(
+                        pid_unsub,
                         as::buffer(*topic1),
                         [topic1](MQTT_NS::error_code) {}
                     );
@@ -774,7 +810,9 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_sub = c->async_subscribe(
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(
+                        pid_sub,
                         as::buffer(*topic1),
                         MQTT_NS::qos::at_least_once,
                         [topic1](MQTT_NS::error_code) {}
@@ -842,7 +880,9 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_unsub = c->async_unsubscribe(
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(
+                        pid_unsub,
                         as::buffer(*topic1),
                         [topic1](MQTT_NS::error_code) {}
                     );
@@ -906,7 +946,9 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                 MQTT_CHK("h_pub_res_sent");
                 BOOST_TEST(*recv_packet_id == packet_id);
                 auto topic1 = std::make_shared<std::string>("topic1");
-                pid_unsub = c->async_unsubscribe(
+                pid_unsub = c->acquire_unique_packet_id();
+                c->async_unsubscribe(
+                    pid_unsub,
                     as::buffer(*topic1),
                     [topic1](MQTT_NS::error_code) {}
                 );
@@ -921,7 +963,9 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_sub = c->async_subscribe(
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(
+                        pid_sub,
                         as::buffer(*topic1),
                         MQTT_NS::qos::at_least_once,
                         [topic1](MQTT_NS::error_code) {}
@@ -956,7 +1000,9 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                     BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
                     auto topic1 = std::make_shared<std::string>("topic1");
                     auto contents = std::make_shared<std::string>("topic1_contents");
-                    pid_pub = c->async_publish(
+                    pid_pub = c->acquire_unique_packet_id();
+                    c->async_publish(
+                        pid_pub,
                         as::buffer(*topic1),
                         as::buffer(*contents),
                         std::make_pair(topic1, contents),
@@ -999,7 +1045,9 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_sub = c->async_subscribe(
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(
+                        pid_sub,
                         as::buffer(*topic1),
                         MQTT_NS::qos::at_least_once,
                         [topic1](MQTT_NS::error_code) {}
@@ -1034,7 +1082,9 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                     BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_1);
                     auto topic1 = std::make_shared<std::string>("topic1");
                     auto contents = std::make_shared<std::string>("topic1_contents");
-                    pid_pub = c->async_publish(
+                    pid_pub = c->acquire_unique_packet_id();
+                    c->async_publish(
+                        pid_pub,
                         as::buffer(*topic1),
                         as::buffer(*contents),
                         std::make_pair(topic1, contents),
@@ -1135,7 +1185,9 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_sub = c->async_subscribe(
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(
+                        pid_sub,
                         as::buffer(*topic1),
                         MQTT_NS::qos::at_least_once,
                         [topic1](MQTT_NS::error_code) {}
@@ -1161,7 +1213,9 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                     MQTT_CHK("h_pubcomp");
                     BOOST_TEST(packet_id == pid_pub);
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_unsub = c->async_unsubscribe(
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(
+                        pid_unsub,
                         as::buffer(*topic1),
                         [topic1](MQTT_NS::error_code) {}
                     );
@@ -1176,7 +1230,9 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                     BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
                     auto topic1 = std::make_shared<std::string>("topic1");
                     auto contents = std::make_shared<std::string>("topic1_contents");
-                    pid_pub = c->async_publish(
+                    pid_pub = c->acquire_unique_packet_id();
+                    c->async_publish(
+                        pid_pub,
                         as::buffer(*topic1),
                         as::buffer(*contents),
                         std::make_pair(topic1, contents),
@@ -1219,7 +1275,9 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_sub = c->async_subscribe(
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(
+                        pid_sub,
                         as::buffer(*topic1),
                         MQTT_NS::qos::at_least_once,
                         [topic1](MQTT_NS::error_code) {}
@@ -1245,7 +1303,9 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                     MQTT_CHK("h_pubcomp");
                     BOOST_TEST(packet_id == pid_pub);
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_unsub = c->async_unsubscribe(
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(
+                        pid_unsub,
                         as::buffer(*topic1),
                         [topic1](MQTT_NS::error_code) {}
                     );
@@ -1260,7 +1320,9 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                     BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_1);
                     auto topic1 = std::make_shared<std::string>("topic1");
                     auto contents = std::make_shared<std::string>("topic1_contents");
-                    pid_pub = c->async_publish(
+                    pid_pub = c->acquire_unique_packet_id();
+                    c->async_publish(
+                        pid_pub,
                         as::buffer(*topic1),
                         as::buffer(*contents),
                         std::make_pair(topic1, contents),

--- a/test/as_buffer_async_pubsub_2.cpp
+++ b/test/as_buffer_async_pubsub_2.cpp
@@ -45,7 +45,9 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_sub = c->async_subscribe(
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(
+                        pid_sub,
                         as::buffer(*topic1),
                         MQTT_NS::qos::exactly_once,
                         [topic1](MQTT_NS::error_code) {}
@@ -112,7 +114,9 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_unsub = c->async_unsubscribe(
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(
+                        pid_unsub,
                         as::buffer(*topic1),
                         [topic1](MQTT_NS::error_code) {}
                     );
@@ -127,7 +131,9 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_sub = c->async_subscribe(
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(
+                        pid_sub,
                         as::buffer(*topic1),
                         MQTT_NS::qos::exactly_once,
                         [topic1](MQTT_NS::error_code) {}
@@ -197,7 +203,9 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_unsub = c->async_unsubscribe(
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(
+                        pid_unsub,
                         as::buffer(*topic1),
                         [topic1](MQTT_NS::error_code) {}
                     );
@@ -272,7 +280,9 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_sub = c->async_subscribe(
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(
+                        pid_sub,
                         as::buffer(*topic1),
                         MQTT_NS::qos::exactly_once,
                         [topic1](MQTT_NS::error_code) {}
@@ -285,7 +295,9 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                     MQTT_CHK("h_puback");
                     BOOST_TEST(packet_id == pid_pub);
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_unsub = c->async_unsubscribe(
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(
+                        pid_unsub,
                         as::buffer(*topic1),
                         [topic1](MQTT_NS::error_code) {}
                     );
@@ -312,7 +324,9 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                     BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_2);
                     auto topic1 = std::make_shared<std::string>("topic1");
                     auto contents = std::make_shared<std::string>("topic1_contents");
-                    pid_pub = c->async_publish(
+                    pid_pub = c->acquire_unique_packet_id();
+                    c->async_publish(
+                        pid_pub,
                         as::buffer(*topic1),
                         as::buffer(*contents),
                         std::make_pair(topic1, contents),
@@ -355,7 +369,9 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_sub = c->async_subscribe(
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(
+                        pid_sub,
                         as::buffer(*topic1),
                         MQTT_NS::qos::exactly_once,
                         [topic1](MQTT_NS::error_code) {}
@@ -368,7 +384,9 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                     MQTT_CHK("h_puback");
                     BOOST_TEST(packet_id == pid_pub);
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_unsub = c->async_unsubscribe(
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(
+                        pid_unsub,
                         as::buffer(*topic1),
                         [topic1](MQTT_NS::error_code) {}
                     );
@@ -395,7 +413,9 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                     BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_2);
                     auto topic1 = std::make_shared<std::string>("topic1");
                     auto contents = std::make_shared<std::string>("topic1_contents");
-                    pid_pub = c->async_publish(
+                    pid_pub = c->acquire_unique_packet_id();
+                    c->async_publish(
+                        pid_pub,
                         as::buffer(*topic1),
                         as::buffer(*contents),
                         std::make_pair(topic1, contents),
@@ -498,7 +518,9 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_sub = c->async_subscribe(
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(
+                        pid_sub,
                         as::buffer(*topic1),
                         MQTT_NS::qos::exactly_once,
                         [topic1](MQTT_NS::error_code) {}
@@ -524,7 +546,9 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                     MQTT_CHK("h_pubcomp");
                     BOOST_TEST(packet_id == pid_pub);
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_unsub = c->async_unsubscribe(
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(
+                        pid_unsub,
                         as::buffer(*topic1),
                         [topic1](MQTT_NS::error_code) {}
                     );
@@ -539,7 +563,9 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                     BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_2);
                     auto topic1 = std::make_shared<std::string>("topic1");
                     auto contents = std::make_shared<std::string>("topic1_contents");
-                    pid_pub = c->async_publish(
+                    pid_pub = c->acquire_unique_packet_id();
+                    c->async_publish(
+                        pid_pub,
                         as::buffer(*topic1),
                         as::buffer(*contents),
                         std::make_pair(topic1, contents),
@@ -582,7 +608,9 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_sub = c->async_subscribe(
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(
+                        pid_sub,
                         as::buffer(*topic1),
                         MQTT_NS::qos::exactly_once,
                         [topic1](MQTT_NS::error_code) {}
@@ -608,7 +636,9 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                     MQTT_CHK("h_pubcomp");
                     BOOST_TEST(packet_id == pid_pub);
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_unsub = c->async_unsubscribe(
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(
+                        pid_unsub,
                         as::buffer(*topic1),
                         [topic1](MQTT_NS::error_code) {}
                     );
@@ -623,7 +653,9 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                     BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_2);
                     auto topic1 = std::make_shared<std::string>("topic1");
                     auto contents = std::make_shared<std::string>("topic1_contents");
-                    pid_pub = c->async_publish(
+                    pid_pub = c->acquire_unique_packet_id();
+                    c->async_publish(
+                        pid_pub,
                         as::buffer(*topic1),
                         as::buffer(*contents),
                         std::make_pair(topic1, contents),
@@ -713,7 +745,9 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_sub = c->async_subscribe(
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(
+                        pid_sub,
                         as::buffer(*topic1),
                         MQTT_NS::qos::at_most_once,
                         [topic1](MQTT_NS::error_code) {}
@@ -779,7 +813,9 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_unsub = c->async_unsubscribe(
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(
+                        pid_unsub,
                         as::buffer(*topic1),
                         [topic1](MQTT_NS::error_code) {}
                     );
@@ -794,7 +830,9 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_sub = c->async_subscribe(
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(
+                        pid_sub,
                         as::buffer(*topic1),
                         MQTT_NS::qos::at_most_once,
                         [topic1](MQTT_NS::error_code) {}
@@ -863,7 +901,9 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_unsub = c->async_unsubscribe(
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(
+                        pid_unsub,
                         as::buffer(*topic1),
                         [topic1](MQTT_NS::error_code) {}
                     );
@@ -922,7 +962,9 @@ BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
                     auto topic1 = MQTT_NS::allocate_buffer("topic1");
-                    pid_sub = c->async_subscribe(
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(
+                        pid_sub,
                         std::move(topic1),
                         MQTT_NS::qos::at_most_once,
                         [topic1](MQTT_NS::error_code) {}
@@ -987,7 +1029,9 @@ BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
                     auto topic1 = MQTT_NS::allocate_buffer("topic1");
-                    pid_unsub = c->async_unsubscribe(
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(
+                        pid_unsub,
                         std::move(topic1),
                         [topic1](MQTT_NS::error_code) {}
                     );
@@ -1002,7 +1046,9 @@ BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
                     auto topic1 = MQTT_NS::allocate_buffer("topic1");
-                    pid_sub = c->async_subscribe(
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(
+                        pid_sub,
                         std::move(topic1),
                         MQTT_NS::qos::at_most_once,
                         [topic1](MQTT_NS::error_code) {}
@@ -1070,7 +1116,9 @@ BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
                     auto topic1 = MQTT_NS::allocate_buffer("topic1");
-                    pid_unsub = c->async_unsubscribe(
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(
+                        pid_unsub,
                         std::move(topic1),
                         [topic1](MQTT_NS::error_code) {}
                     );
@@ -1130,7 +1178,9 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_sub = c->async_subscribe(
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(
+                        pid_sub,
                         as::buffer(*topic1),
                         MQTT_NS::qos::at_least_once,
                         [topic1](MQTT_NS::error_code) {}
@@ -1143,7 +1193,9 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                     MQTT_CHK("h_puback");
                     BOOST_TEST(packet_id == 1);
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_unsub = c->async_unsubscribe(
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(
+                        pid_unsub,
                         as::buffer(*topic1),
                         [topic1](MQTT_NS::error_code) {}
                     );
@@ -1170,14 +1222,14 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                     BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
                     auto topic1 = std::make_shared<std::string>("topic1");
                     auto contents = std::make_shared<std::string>("topic1_contents");
-                    auto ret = c->async_publish_dup(
+                    c->register_packet_id(1);
+                    c->async_publish_dup(
                         1,
                         as::buffer(*topic1),
                         as::buffer(*contents),
                         std::make_pair(topic1, contents),
                         MQTT_NS::qos::at_least_once
                     );
-                    BOOST_TEST(ret == true);
                     return true;
                 });
             c->set_unsuback_handler(
@@ -1214,7 +1266,9 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_sub = c->async_subscribe(
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(
+                        pid_sub,
                         as::buffer(*topic1),
                         MQTT_NS::qos::at_least_once,
                         [topic1](MQTT_NS::error_code) {}
@@ -1227,7 +1281,9 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                     MQTT_CHK("h_puback");
                     BOOST_TEST(packet_id == 1);
                     auto topic1 = std::make_shared<std::string>("topic1");
-                    pid_unsub = c->async_unsubscribe(
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(
+                        pid_unsub,
                         as::buffer(*topic1),
                         [topic1](MQTT_NS::error_code) {}
                     );
@@ -1254,14 +1310,14 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                     BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_1);
                     auto topic1 = std::make_shared<std::string>("topic1");
                     auto contents = std::make_shared<std::string>("topic1_contents");
-                    auto ret = c->async_publish_dup(
+                    c->register_packet_id(1);
+                    c->async_publish_dup(
                         1,
                         as::buffer(*topic1),
                         as::buffer(*contents),
                         std::make_pair(topic1, contents),
                         MQTT_NS::qos::at_least_once
                     );
-                    BOOST_TEST(ret == true);
                     return true;
                 });
             c->set_v5_unsuback_handler(

--- a/test/as_buffer_pubsub.cpp
+++ b/test/as_buffer_pubsub.cpp
@@ -1978,8 +1978,8 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
                     BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
-                    auto ret = c->publish_dup(1, "topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(ret == true);
+                    BOOST_TEST(c->register_packet_id(1) == true);
+                    c->publish_dup(1, "topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
                     return true;
                 });
             c->set_unsuback_handler(
@@ -2045,8 +2045,8 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
                     BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_1);
-                    auto ret = c->publish_dup(1, "topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(ret == true);
+                    BOOST_TEST(c->register_packet_id(1) == true);
+                    c->publish_dup(1, "topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
                     return true;
                 });
             c->set_v5_unsuback_handler(

--- a/test/as_buffer_sub.cpp
+++ b/test/as_buffer_sub.cpp
@@ -131,6 +131,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg ) {
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
                     c->subscribe(
+                        std::vector<std::tuple<MQTT_NS::string_view, MQTT_NS::subscribe_options>>
                         {
                             {"topic1", MQTT_NS::qos::at_most_once},
                             {"topic2", MQTT_NS::qos::exactly_once}
@@ -142,7 +143,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg ) {
                 [&chk, &c]
                 (packet_id_t /*packet_id*/, std::vector<MQTT_NS::suback_return_code> /*results*/) {
                     MQTT_CHK("h_suback");
-                    c->unsubscribe({"topic1"s, "topic2"s});
+                    c->unsubscribe( std::vector<MQTT_NS::string_view>{"topic1", "topic2"} );
                     return true;
                 });
             c->set_unsuback_handler(
@@ -161,6 +162,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg ) {
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
                     c->subscribe(
+                        std::vector<std::tuple<MQTT_NS::string_view, MQTT_NS::subscribe_options>>
                         {
                             {"topic1", MQTT_NS::qos::at_most_once},
                             {"topic2", MQTT_NS::qos::exactly_once}
@@ -172,7 +174,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg ) {
                 [&chk, &c]
                 (packet_id_t, std::vector<MQTT_NS::v5::suback_reason_code>, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
-                    c->unsubscribe({"topic1"s, "topic2"s});
+                    c->unsubscribe( std::vector<MQTT_NS::string_view>{"topic1", "topic2"});
                     return true;
                 });
             c->set_v5_unsuback_handler(
@@ -439,6 +441,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg_async ) {
                     auto topic1 = std::make_shared<std::string>("topic1");
                     auto topic2 = std::make_shared<std::string>("topic2");
                     c->async_subscribe(
+                        std::vector<std::tuple<as::const_buffer, MQTT_NS::subscribe_options>>
                         {
                             {as::buffer(*topic1), MQTT_NS::qos::at_most_once},
                             {as::buffer(*topic2), MQTT_NS::qos::exactly_once}
@@ -454,10 +457,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg_async ) {
                     auto topic1 = std::make_shared<std::string>("topic1");
                     auto topic2 = std::make_shared<std::string>("topic2");
                     c->async_unsubscribe(
-                        {
-                            {as::buffer(*topic1)},
-                            {as::buffer(*topic2)}
-                        },
+                        std::vector<as::const_buffer>{ as::buffer(*topic1), as::buffer(*topic2) },
                         [topic1, topic2](MQTT_NS::error_code) {}
                     );
                     return true;
@@ -480,6 +480,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg_async ) {
                     auto topic1 = std::make_shared<std::string>("topic1");
                     auto topic2 = std::make_shared<std::string>("topic2");
                     c->async_subscribe(
+                        std::vector<std::tuple<as::const_buffer, MQTT_NS::subscribe_options>>
                         {
                             {as::buffer(*topic1), MQTT_NS::qos::at_most_once},
                             {as::buffer(*topic2), MQTT_NS::qos::exactly_once}
@@ -495,10 +496,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg_async ) {
                     auto topic1 = std::make_shared<std::string>("topic1");
                     auto topic2 = std::make_shared<std::string>("topic2");
                     c->async_unsubscribe(
-                        {
-                            {as::buffer(*topic1)},
-                            {as::buffer(*topic2)}
-                        },
+                        std::vector<as::const_buffer>{ as::buffer(*topic1), as::buffer(*topic2) },
                         [topic1, topic2](MQTT_NS::error_code) {}
                     );
                     return true;

--- a/test/async_pubsub_1.cpp
+++ b/test/async_pubsub_1.cpp
@@ -44,7 +44,8 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
-                    pid_sub = c->async_subscribe("topic1", MQTT_NS::qos::at_most_once);
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(pid_sub, "topic1", MQTT_NS::qos::at_most_once);
                     return true;
                 });
             c->set_suback_handler(
@@ -80,7 +81,8 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
-                    pid_unsub = c->async_unsubscribe("topic1");
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(pid_unsub, "topic1");
                     return true;
                 });
             c->set_puback_handler(
@@ -109,7 +111,8 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
-                    pid_sub = c->async_subscribe("topic1", MQTT_NS::qos::at_most_once);
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(pid_sub, "topic1", MQTT_NS::qos::at_most_once);
                     return true;
                 });
             c->set_v5_suback_handler(
@@ -148,7 +151,8 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
-                    pid_unsub = c->async_unsubscribe("topic1");
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(pid_unsub, "topic1");
                     return true;
                 });
             c->set_v5_puback_handler(
@@ -229,7 +233,9 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
-                    pid_sub = c->async_subscribe(
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(
+                        pid_sub,
                         std::vector<std::tuple<std::string, MQTT_NS::subscribe_options>> {
                             std::make_tuple("topic1", MQTT_NS::qos::at_most_once)
                         }
@@ -241,8 +247,8 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                 (packet_id_t packet_id) {
                     MQTT_CHK("h_puback");
                     BOOST_TEST(packet_id == pid_pub);
-                    pid_unsub = c->async_unsubscribe(
-                        std::vector<std::string> {"topic1"});
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(pid_unsub, std::vector<std::string>{"topic1"});
                     return true;
                 });
             c->set_pubrec_handler(
@@ -264,7 +270,8 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
                     BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
-                    pid_pub = c->async_publish("topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
+                    pid_pub = c->acquire_unique_packet_id();
+                    c->async_publish(pid_pub, "topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
                     return true;
                 });
             c->set_unsuback_handler(
@@ -300,7 +307,9 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
-                    pid_sub = c->async_subscribe(
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(
+                        pid_sub,
                         std::vector<std::tuple<std::string, MQTT_NS::subscribe_options>> {
                             std::make_tuple("topic1", MQTT_NS::qos::at_most_once)
                         }
@@ -312,8 +321,8 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                 (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_puback");
                     BOOST_TEST(packet_id == pid_pub);
-                    pid_unsub = c->async_unsubscribe(
-                        std::vector<std::string> {"topic1"});
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(pid_unsub, std::vector<std::string>{"topic1"});
                     return true;
                 });
             c->set_v5_pubrec_handler(
@@ -335,7 +344,8 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
                     BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_0);
-                    pid_pub = c->async_publish("topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
+                    pid_pub = c->acquire_unique_packet_id();
+                    c->async_publish(pid_pub, "topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
                     return true;
                 });
             c->set_v5_unsuback_handler(
@@ -427,7 +437,8 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
-                    pid_sub = c->async_subscribe("topic1", MQTT_NS::qos::at_most_once);
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(pid_sub, "topic1", MQTT_NS::qos::at_most_once);
                     return true;
                 });
             c->set_puback_handler(
@@ -448,7 +459,8 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                 (packet_id_t packet_id) {
                     MQTT_CHK("h_pubcomp");
                     BOOST_TEST(packet_id == pid_pub);
-                    pid_unsub = c->async_unsubscribe("topic1");
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(pid_unsub, "topic1");
                     return true;
                 });
             c->set_suback_handler(
@@ -458,7 +470,8 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                     BOOST_TEST(packet_id == 1);
                     BOOST_TEST(results.size() == 1U);
                     BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
-                    pid_pub = c->async_publish("topic1", "topic1_contents", MQTT_NS::qos::exactly_once);
+                    pid_pub = c->acquire_unique_packet_id();
+                    c->async_publish(pid_pub, "topic1", "topic1_contents", MQTT_NS::qos::exactly_once);
                     return true;
                 });
             c->set_unsuback_handler(
@@ -494,7 +507,8 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
-                    pid_sub = c->async_subscribe("topic1", MQTT_NS::qos::at_most_once);
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(pid_sub, "topic1", MQTT_NS::qos::at_most_once);
                     return true;
                 });
             c->set_v5_puback_handler(
@@ -515,7 +529,8 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                 (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_pubcomp");
                     BOOST_TEST(packet_id == pid_pub);
-                    pid_unsub = c->async_unsubscribe("topic1");
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(pid_unsub, "topic1");
                     return true;
                 });
             c->set_v5_suback_handler(
@@ -525,7 +540,8 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                     BOOST_TEST(packet_id == 1);
                     BOOST_TEST(reasons.size() == 1U);
                     BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_0);
-                    pid_pub = c->async_publish("topic1", "topic1_contents", MQTT_NS::qos::exactly_once);
+                    pid_pub = c->acquire_unique_packet_id();
+                    c->async_publish(pid_pub, "topic1", "topic1_contents", MQTT_NS::qos::exactly_once);
                     return true;
                 });
             c->set_v5_unsuback_handler(
@@ -614,7 +630,8 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
-                    pid_sub = c->async_subscribe("topic1", MQTT_NS::qos::at_least_once);
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(pid_sub, "topic1", MQTT_NS::qos::at_least_once);
                     return true;
                 });
             c->set_puback_handler(
@@ -668,7 +685,8 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
-                    pid_unsub = c->async_unsubscribe("topic1");
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(pid_unsub, "topic1");
                     return true;
                 });
             break;
@@ -679,7 +697,8 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
-                    pid_sub = c->async_subscribe("topic1", MQTT_NS::qos::at_least_once);
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(pid_sub, "topic1", MQTT_NS::qos::at_least_once);
                     return true;
                 });
             c->set_v5_puback_handler(
@@ -736,7 +755,8 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
-                    pid_unsub = c->async_unsubscribe("topic1");
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(pid_unsub, "topic1");
                     return true;
                 });
             break;
@@ -798,7 +818,8 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
             (packet_id_t packet_id) {
                 MQTT_CHK("h_pub_res_sent");
                 BOOST_TEST(*recv_packet_id == packet_id);
-                pid_unsub = c->async_unsubscribe("topic1");
+                pid_unsub = c->acquire_unique_packet_id();
+                c->async_unsubscribe(pid_unsub, "topic1");
             });
 
         switch (c->get_protocol_version()) {
@@ -809,7 +830,8 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
-                    pid_sub = c->async_subscribe("topic1", MQTT_NS::qos::at_least_once);
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(pid_sub, "topic1", MQTT_NS::qos::at_least_once);
                     return true;
                 });
             c->set_puback_handler(
@@ -838,7 +860,8 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
                     BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
-                    pid_pub = c->async_publish("topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
+                    pid_pub = c->acquire_unique_packet_id();
+                    c->async_publish(pid_pub, "topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
                     return true;
                 });
             c->set_unsuback_handler(
@@ -875,7 +898,8 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
-                    pid_sub = c->async_subscribe("topic1", MQTT_NS::qos::at_least_once);
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(pid_sub, "topic1", MQTT_NS::qos::at_least_once);
                     return true;
                 });
             c->set_v5_puback_handler(
@@ -904,7 +928,8 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
                     BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_1);
-                    pid_pub = c->async_publish("topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
+                    pid_pub = c->acquire_unique_packet_id();
+                    c->async_publish(pid_pub, "topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
                     return true;
                 });
             c->set_v5_unsuback_handler(
@@ -1001,7 +1026,8 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
-                    pid_sub = c->async_subscribe("topic1", MQTT_NS::qos::at_least_once);
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(pid_sub, "topic1", MQTT_NS::qos::at_least_once);
                     return true;
                 });
             c->set_puback_handler(
@@ -1022,7 +1048,8 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                 (packet_id_t packet_id) {
                     MQTT_CHK("h_pubcomp");
                     BOOST_TEST(packet_id == pid_pub);
-                    pid_unsub = c->async_unsubscribe("topic1");
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(pid_unsub, "topic1");
                     return true;
                 });
             c->set_suback_handler(
@@ -1032,7 +1059,8 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
                     BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
-                    pid_pub = c->async_publish("topic1", "topic1_contents", MQTT_NS::qos::exactly_once);
+                    pid_pub = c->acquire_unique_packet_id();
+                    c->async_publish(pid_pub, "topic1", "topic1_contents", MQTT_NS::qos::exactly_once);
                     return true;
                 });
             c->set_unsuback_handler(
@@ -1069,7 +1097,8 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
-                    pid_sub = c->async_subscribe("topic1", MQTT_NS::qos::at_least_once);
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(pid_sub, "topic1", MQTT_NS::qos::at_least_once);
                     return true;
                 });
             c->set_v5_puback_handler(
@@ -1090,7 +1119,8 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                 (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_pubcomp");
                     BOOST_TEST(packet_id == pid_pub);
-                    pid_unsub = c->async_unsubscribe("topic1");
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(pid_unsub, "topic1");
                     return true;
                 });
             c->set_v5_suback_handler(
@@ -1100,7 +1130,8 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
                     BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_1);
-                    pid_pub = c->async_publish("topic1", "topic1_contents", MQTT_NS::qos::exactly_once);
+                    pid_pub = c->acquire_unique_packet_id();
+                    c->async_publish(pid_pub, "topic1", "topic1_contents", MQTT_NS::qos::exactly_once);
                     return true;
                 });
             c->set_v5_unsuback_handler(

--- a/test/async_pubsub_2.cpp
+++ b/test/async_pubsub_2.cpp
@@ -46,7 +46,8 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
-                    pid_sub = c->async_subscribe("topic1", MQTT_NS::qos::exactly_once);
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(pid_sub, "topic1", MQTT_NS::qos::exactly_once);
                     return true;
                 });
             c->set_puback_handler(
@@ -100,7 +101,8 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
-                    pid_unsub = c->async_unsubscribe("topic1");
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(pid_unsub, "topic1");
                     return true;
                 });
             break;
@@ -111,7 +113,8 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
-                    pid_sub = c->async_subscribe("topic1", MQTT_NS::qos::exactly_once);
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(pid_sub, "topic1", MQTT_NS::qos::exactly_once);
                     return true;
                 });
             c->set_v5_puback_handler(
@@ -168,7 +171,8 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
-                    pid_unsub = c->async_unsubscribe("topic1");
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(pid_unsub, "topic1");
                     return true;
                 });
             break;
@@ -240,7 +244,8 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
-                    pid_sub = c->async_subscribe("topic1", MQTT_NS::qos::exactly_once);
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(pid_sub, "topic1", MQTT_NS::qos::exactly_once);
                     return true;
                 });
             c->set_puback_handler(
@@ -248,7 +253,8 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                 (packet_id_t packet_id) {
                     MQTT_CHK("h_puback");
                     BOOST_TEST(packet_id == pid_pub);
-                    pid_unsub = c->async_unsubscribe("topic1");
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(pid_unsub, "topic1");
                     return true;
                 });
             c->set_pubrec_handler(
@@ -270,7 +276,8 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
                     BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_2);
-                    pid_pub = c->async_publish("topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
+                    pid_pub = c->acquire_unique_packet_id();
+                    c->async_publish(pid_pub, "topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
                     return true;
                 });
             c->set_unsuback_handler(
@@ -307,7 +314,8 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
-                    pid_sub = c->async_subscribe("topic1", MQTT_NS::qos::exactly_once);
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(pid_sub, "topic1", MQTT_NS::qos::exactly_once);
                     return true;
                 });
             c->set_v5_puback_handler(
@@ -315,7 +323,8 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                 (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_puback");
                     BOOST_TEST(packet_id == pid_pub);
-                    pid_unsub = c->async_unsubscribe("topic1");
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(pid_unsub, "topic1");
                     return true;
                 });
             c->set_v5_pubrec_handler(
@@ -337,7 +346,8 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
                     BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_2);
-                    pid_pub = c->async_publish("topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
+                    pid_pub = c->acquire_unique_packet_id();
+                    c->async_publish(pid_pub, "topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
                     return true;
                 });
             c->set_v5_unsuback_handler(
@@ -435,7 +445,8 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
-                    pid_sub = c->async_subscribe("topic1", MQTT_NS::qos::exactly_once);
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(pid_sub, "topic1", MQTT_NS::qos::exactly_once);
                     return true;
                 });
             c->set_puback_handler(
@@ -456,7 +467,8 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                 (packet_id_t packet_id) {
                     MQTT_CHK("h_pubcomp");
                     BOOST_TEST(packet_id == pid_pub);
-                    pid_unsub = c->async_unsubscribe("topic1");
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(pid_unsub, "topic1");
                     return true;
                 });
             c->set_suback_handler(
@@ -466,7 +478,8 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
                     BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_2);
-                    pid_pub = c->async_publish("topic1", "topic1_contents", MQTT_NS::qos::exactly_once);
+                    pid_pub = c->acquire_unique_packet_id();
+                    c->async_publish(pid_pub, "topic1", "topic1_contents", MQTT_NS::qos::exactly_once);
                     return true;
                 });
             c->set_unsuback_handler(
@@ -503,7 +516,8 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
-                    pid_sub = c->async_subscribe("topic1", MQTT_NS::qos::exactly_once);
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(pid_sub, "topic1", MQTT_NS::qos::exactly_once);
                     return true;
                 });
             c->set_v5_puback_handler(
@@ -524,7 +538,8 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                 (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_pubcomp");
                     BOOST_TEST(packet_id == pid_pub);
-                    pid_unsub = c->async_unsubscribe("topic1");
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(pid_unsub, "topic1");
                     return true;
                 });
             c->set_v5_suback_handler(
@@ -534,7 +549,8 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
                     BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_2);
-                    pid_pub = c->async_publish("topic1", "topic1_contents", MQTT_NS::qos::exactly_once);
+                    pid_pub = c->acquire_unique_packet_id();
+                    c->async_publish(pid_pub, "topic1", "topic1_contents", MQTT_NS::qos::exactly_once);
                     return true;
                 });
             c->set_v5_unsuback_handler(
@@ -619,7 +635,8 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
-                    pid_sub = c->async_subscribe("topic1", MQTT_NS::qos::at_most_once);
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(pid_sub, "topic1", MQTT_NS::qos::at_most_once);
                     return true;
                 });
             c->set_puback_handler(
@@ -673,7 +690,8 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
-                    pid_unsub = c->async_unsubscribe("topic1");
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(pid_unsub, "topic1");
                     return true;
                 });
             break;
@@ -684,7 +702,8 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
-                    pid_sub = c->async_subscribe("topic1", MQTT_NS::qos::at_most_once);
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(pid_sub, "topic1", MQTT_NS::qos::at_most_once);
                     return true;
                 });
             c->set_v5_puback_handler(
@@ -741,7 +760,8 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
-                    pid_unsub = c->async_unsubscribe("topic1");
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(pid_unsub, "topic1");
                     return true;
                 });
             break;
@@ -798,7 +818,8 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
-                    pid_sub = c->async_subscribe("topic1", MQTT_NS::qos::at_least_once);
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(pid_sub, "topic1", MQTT_NS::qos::at_least_once);
                     return true;
                 });
             c->set_puback_handler(
@@ -806,7 +827,8 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                 (packet_id_t packet_id) {
                     MQTT_CHK("h_puback");
                     BOOST_TEST(packet_id == 1);
-                    pid_unsub = c->async_unsubscribe("topic1");
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(pid_unsub, "topic1");
                     return true;
                 });
             c->set_pubrec_handler(
@@ -828,9 +850,8 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
                     BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
-                    auto ret =
-                        c->async_publish_dup(1, "topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(ret == true);
+                    c->register_packet_id(1);
+                    c->async_publish_dup(1, "topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
                     return true;
                 });
             c->set_unsuback_handler(
@@ -866,7 +887,8 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
-                    pid_sub = c->async_subscribe("topic1", MQTT_NS::qos::at_least_once);
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(pid_sub, "topic1", MQTT_NS::qos::at_least_once);
                     return true;
                 });
             c->set_v5_puback_handler(
@@ -874,7 +896,8 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                 (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_puback");
                     BOOST_TEST(packet_id == 1);
-                    pid_unsub = c->async_unsubscribe("topic1");
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(pid_unsub, "topic1");
                     return true;
                 });
             c->set_v5_pubrec_handler(
@@ -896,9 +919,8 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
                     BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_1);
-                    auto ret =
-                        c->async_publish_dup(1, "topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(ret == true);
+                    c->register_packet_id(1);
+                    c->async_publish_dup(1, "topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
                     return true;
                 });
             c->set_v5_unsuback_handler(
@@ -983,7 +1005,8 @@ BOOST_AUTO_TEST_CASE( publish_dup_function_buffer ) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
-                    pid_sub = c->async_subscribe("topic1"_mb, MQTT_NS::qos::at_least_once);
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(pid_sub, "topic1"_mb, MQTT_NS::qos::at_least_once);
                     return true;
                 });
             c->set_puback_handler(
@@ -991,7 +1014,8 @@ BOOST_AUTO_TEST_CASE( publish_dup_function_buffer ) {
                 (packet_id_t packet_id) {
                     MQTT_CHK("h_puback");
                     BOOST_TEST(packet_id == 1);
-                    pid_unsub = c->async_unsubscribe("topic1");
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(pid_unsub, "topic1");
                     return true;
                 });
             c->set_pubrec_handler(
@@ -1013,9 +1037,8 @@ BOOST_AUTO_TEST_CASE( publish_dup_function_buffer ) {
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
                     BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
-                    auto ret =
-                        c->async_publish_dup(1, "topic1"_mb, "topic1_contents"_mb, MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(ret == true);
+                    c->register_packet_id(1);
+                    c->async_publish_dup(1, "topic1"_mb, "topic1_contents"_mb, MQTT_NS::qos::at_least_once);
                     return true;
                 });
             c->set_unsuback_handler(
@@ -1051,7 +1074,8 @@ BOOST_AUTO_TEST_CASE( publish_dup_function_buffer ) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
-                    pid_sub = c->async_subscribe("topic1"_mb, MQTT_NS::qos::at_least_once);
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(pid_sub, "topic1"_mb, MQTT_NS::qos::at_least_once);
                     return true;
                 });
             c->set_v5_puback_handler(
@@ -1059,7 +1083,8 @@ BOOST_AUTO_TEST_CASE( publish_dup_function_buffer ) {
                 (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_puback");
                     BOOST_TEST(packet_id == 1);
-                    pid_unsub = c->async_unsubscribe("topic1");
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(pid_unsub, "topic1");
                     return true;
                 });
             c->set_v5_pubrec_handler(
@@ -1081,9 +1106,8 @@ BOOST_AUTO_TEST_CASE( publish_dup_function_buffer ) {
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
                     BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_1);
-                    auto ret =
-                        c->async_publish_dup(1, "topic1"_mb, "topic1_contents"_mb, MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(ret == true);
+                    c->register_packet_id(1);
+                    c->async_publish_dup(1, "topic1"_mb, "topic1_contents"_mb, MQTT_NS::qos::at_least_once);
                     return true;
                 });
             c->set_v5_unsuback_handler(
@@ -1184,7 +1208,8 @@ BOOST_AUTO_TEST_CASE( pub_sub_prop ) {
                 MQTT_CHK("h_connack");
                 BOOST_TEST(sp == false);
                 BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
-                pid_sub = c->async_subscribe("topic1", MQTT_NS::qos::at_most_once);
+                pid_sub = c->acquire_unique_packet_id();
+                c->async_subscribe(pid_sub, "topic1", MQTT_NS::qos::at_most_once);
                 return true;
             });
         c->set_v5_suback_handler(
@@ -1270,7 +1295,8 @@ BOOST_AUTO_TEST_CASE( pub_sub_prop ) {
                     );
                 }
 
-                pid_unsub = c->async_unsubscribe("topic1");
+                pid_unsub = c->acquire_unique_packet_id();
+                c->async_unsubscribe(pid_unsub, "topic1");
                 return true;
             });
         c->set_v5_puback_handler(
@@ -1391,7 +1417,8 @@ BOOST_AUTO_TEST_CASE( puback_props ) {
             (packet_id_t packet_id) {
                 MQTT_CHK("h_pub_res_sent");
                 BOOST_TEST(*recv_packet_id == packet_id);
-                pid_unsub = c->async_unsubscribe("topic1");
+                pid_unsub = c->acquire_unique_packet_id();
+                c->async_unsubscribe(pid_unsub, "topic1");
             });
 
         c->set_v5_connack_handler(
@@ -1400,7 +1427,8 @@ BOOST_AUTO_TEST_CASE( puback_props ) {
                 MQTT_CHK("h_connack");
                 BOOST_TEST(sp == false);
                 BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
-                pid_sub = c->async_subscribe("topic1", MQTT_NS::qos::at_least_once);
+                pid_sub = c->acquire_unique_packet_id();
+                c->async_subscribe(pid_sub, "topic1", MQTT_NS::qos::at_least_once);
                 return true;
             });
         c->set_v5_puback_handler(
@@ -1429,7 +1457,8 @@ BOOST_AUTO_TEST_CASE( puback_props ) {
                 BOOST_TEST(packet_id == pid_sub);
                 BOOST_TEST(reasons.size() == 1U);
                 BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_1);
-                pid_pub = c->async_publish("topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
+                pid_pub = c->acquire_unique_packet_id();
+                c->async_publish(pid_pub, "topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
                 return true;
             });
         c->set_v5_unsuback_handler(
@@ -1662,7 +1691,8 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
                 MQTT_CHK("h_connack");
                 BOOST_TEST(sp == false);
                 BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
-                pid_sub = c->async_subscribe("topic1", MQTT_NS::qos::exactly_once);
+                pid_sub = c->acquire_unique_packet_id();
+                c->async_subscribe(pid_sub, "topic1", MQTT_NS::qos::exactly_once);
                 return true;
             });
         c->set_v5_puback_handler(
@@ -1684,7 +1714,8 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
             (packet_id_t packet_id, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_pubcomp");
                 BOOST_TEST(packet_id == pid_pub);
-                pid_unsub = c->async_unsubscribe("topic1");
+                pid_unsub = c->acquire_unique_packet_id();
+                c->async_unsubscribe(pid_unsub, "topic1");
                 return true;
             });
         c->set_v5_suback_handler(
@@ -1694,7 +1725,8 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
                 BOOST_TEST(packet_id == pid_sub);
                 BOOST_TEST(reasons.size() == 1U);
                 BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_2);
-                pid_pub = c->async_publish("topic1", "topic1_contents", MQTT_NS::qos::exactly_once);
+                pid_pub = c->acquire_unique_packet_id();
+                c->async_publish(pid_pub, "topic1", "topic1_contents", MQTT_NS::qos::exactly_once);
                 return true;
             });
         c->set_v5_unsuback_handler(

--- a/test/manual_publish.cpp
+++ b/test/manual_publish.cpp
@@ -39,21 +39,10 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
-                    BOOST_TEST(
-                        c->subscribe(
-                            0,
-                            "topic1",
-                            MQTT_NS::qos::at_most_once) == false);
-                    BOOST_TEST(
-                        c->subscribe(
-                            1,
-                            "topic1",
-                            MQTT_NS::qos::at_most_once) == true);
-                    BOOST_TEST(
-                        c->subscribe(
-                            1,
-                            "topic1",
-                            MQTT_NS::qos::at_most_once) == false);
+                    BOOST_TEST(c->register_packet_id(0) == false);
+                    BOOST_TEST(c->register_packet_id(1) == true);
+                    BOOST_TEST(c->register_packet_id(1) == false);
+                    c->subscribe(1, "topic1", MQTT_NS::qos::at_most_once);
                     return true;
                 });
             c->set_puback_handler(
@@ -61,15 +50,10 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                 (packet_id_t packet_id) {
                     BOOST_TEST(packet_id == 1);
                     MQTT_CHK("h_puback");
-                    {
-                        packet_id_t packet_id = 0;
-                        BOOST_TEST(
-                            c->unsubscribe(packet_id, "topic1") == false);
-                    }
-                    BOOST_TEST(
-                        c->unsubscribe(1, "topic1") == true);
-                    BOOST_TEST(
-                        c->unsubscribe(1, "topic1") == false);
+                    BOOST_TEST(c->register_packet_id(0) == false);
+                    BOOST_TEST(c->register_packet_id(1) == true);
+                    BOOST_TEST(c->register_packet_id(1) == false);
+                    c->unsubscribe(1, "topic1");
                     return true;
                 });
             c->set_pubrec_handler(
@@ -91,21 +75,10 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                     BOOST_TEST(packet_id == 1);
                     BOOST_TEST(results.size() == 1U);
                     BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
-                    BOOST_TEST(c->publish(
-                                   0,
-                                   "topic1",
-                                   "topic1_contents",
-                                   MQTT_NS::qos::at_least_once) == false);
-                    BOOST_TEST(c->publish(
-                                   1,
-                                   "topic1",
-                                   "topic1_contents",
-                                   MQTT_NS::qos::at_least_once) == true);
-                    BOOST_TEST(c->publish(
-                                   1,
-                                   "topic1",
-                                   "topic1_contents",
-                                   MQTT_NS::qos::at_least_once) == false);
+                    BOOST_TEST(c->register_packet_id(0) == false);
+                    BOOST_TEST(c->register_packet_id(1) == true);
+                    BOOST_TEST(c->register_packet_id(1) == false);
+                    c->publish(1, "topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
                     return true;
                 });
             c->set_unsuback_handler(
@@ -141,21 +114,10 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                     MQTT_CHK("h_connack");
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
-                    BOOST_TEST(
-                        c->subscribe(
-                            0,
-                            "topic1",
-                            MQTT_NS::qos::at_most_once) == false);
-                    BOOST_TEST(
-                        c->subscribe(
-                            1,
-                            "topic1",
-                            MQTT_NS::qos::at_most_once) == true);
-                    BOOST_TEST(
-                        c->subscribe(
-                            1,
-                            "topic1",
-                            MQTT_NS::qos::at_most_once) == false);
+                    BOOST_TEST(c->register_packet_id(0) == false);
+                    BOOST_TEST(c->register_packet_id(1) == true);
+                    BOOST_TEST(c->register_packet_id(1) == false);
+                    c->subscribe(1, "topic1", MQTT_NS::qos::at_most_once);
                     return true;
                 });
             c->set_v5_puback_handler(
@@ -163,15 +125,10 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                 (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_TEST(packet_id == 1);
                     MQTT_CHK("h_puback");
-                    {
-                        packet_id_t packet_id = 0;
-                        BOOST_TEST(
-                            c->unsubscribe(packet_id, "topic1") == false);
-                    }
-                    BOOST_TEST(
-                        c->unsubscribe(1, "topic1") == true);
-                    BOOST_TEST(
-                        c->unsubscribe(1, "topic1") == false);
+                    BOOST_TEST(c->register_packet_id(0) == false);
+                    BOOST_TEST(c->register_packet_id(1) == true);
+                    BOOST_TEST(c->register_packet_id(1) == false);
+                    c->unsubscribe(1, "topic1");
                     return true;
                 });
             c->set_v5_pubrec_handler(
@@ -193,21 +150,10 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                     BOOST_TEST(packet_id == 1);
                     BOOST_TEST(reasons.size() == 1U);
                     BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_0);
-                    BOOST_TEST(c->publish(
-                                   0,
-                                   "topic1",
-                                   "topic1_contents",
-                                   MQTT_NS::qos::at_least_once) == false);
-                    BOOST_TEST(c->publish(
-                                   1,
-                                   "topic1",
-                                   "topic1_contents",
-                                   MQTT_NS::qos::at_least_once) == true);
-                    BOOST_TEST(c->publish(
-                                   1,
-                                   "topic1",
-                                   "topic1_contents",
-                                   MQTT_NS::qos::at_least_once) == false);
+                    BOOST_TEST(c->register_packet_id(0) == false);
+                    BOOST_TEST(c->register_packet_id(1) == true);
+                    BOOST_TEST(c->register_packet_id(1) == false);
+                    c->publish(1, "topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
                     return true;
                 });
             c->set_v5_unsuback_handler(

--- a/test/multi_sub.cpp
+++ b/test/multi_sub.cpp
@@ -49,6 +49,7 @@ BOOST_AUTO_TEST_CASE( multi_channel ) {
                 BOOST_TEST(sp == false);
                 BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
                 pid_sub = c->subscribe(
+                    std::vector<std::tuple<MQTT_NS::string_view, MQTT_NS::subscribe_options>>
                     {
                         {"topic1", MQTT_NS::qos::at_most_once},
                         {"topic2", MQTT_NS::qos::at_most_once}
@@ -131,9 +132,10 @@ BOOST_AUTO_TEST_CASE( multi_channel ) {
                         BOOST_TEST(topic == "topic2");
                         BOOST_TEST(contents == "topic2_contents");
                         pid_unsub = c->unsubscribe(
+                            std::vector<MQTT_NS::string_view>
                             {
-                                "topic1"s,
-                                "topic2"s
+                                "topic1",
+                                "topic2"
                             }
                         );
                     }

--- a/test/offline.cpp
+++ b/test/offline.cpp
@@ -544,7 +544,9 @@ BOOST_AUTO_TEST_CASE( async_publish_qos1 ) {
                     [&] {
                         MQTT_CHK("h_close1");
                         // offline publish
-                        pid_pub = c->async_publish(
+                        pid_pub = c->acquire_unique_packet_id();
+                        c->async_publish(
+                            pid_pub,
                             "topic1",
                             "topic1_contents",
                             MQTT_NS::qos::at_least_once,

--- a/test/pubsub.cpp
+++ b/test/pubsub.cpp
@@ -2164,9 +2164,8 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
                     BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
-                    auto ret =
-                        c->publish_dup(1, "topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(ret == true);
+                    BOOST_TEST(c->register_packet_id(1) == true);
+                    c->publish_dup(1, "topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
                     return true;
                 });
             c->set_unsuback_handler(
@@ -2232,9 +2231,8 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
                     BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_1);
-                    auto ret =
-                        c->publish_dup(1, "topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(ret == true);
+                    BOOST_TEST(c->register_packet_id(1) == true);
+                    c->publish_dup(1, "topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
                     return true;
                 });
             c->set_v5_unsuback_handler(
@@ -2349,9 +2347,8 @@ BOOST_AUTO_TEST_CASE( publish_dup_function_buffer ) {
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(results.size() == 1U);
                     BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
-                    auto ret =
-                        c->publish_dup(1, "topic1"_mb, "topic1_contents"_mb, MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(ret == true);
+                    BOOST_TEST(c->register_packet_id(1) == true);
+                    c->publish_dup(1, "topic1"_mb, "topic1_contents"_mb, MQTT_NS::qos::at_least_once);
                     return true;
                 });
             c->set_unsuback_handler(
@@ -2417,9 +2414,8 @@ BOOST_AUTO_TEST_CASE( publish_dup_function_buffer ) {
                     BOOST_TEST(packet_id == pid_sub);
                     BOOST_TEST(reasons.size() == 1U);
                     BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_1);
-                    auto ret =
-                        c->publish_dup(1, "topic1"_mb, "topic1_contents"_mb, MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(ret == true);
+                    BOOST_TEST(c->register_packet_id(1) == true);
+                    c->publish_dup(1, "topic1"_mb, "topic1_contents"_mb, MQTT_NS::qos::at_least_once);
                     return true;
                 });
             c->set_v5_unsuback_handler(

--- a/test/sub.cpp
+++ b/test/sub.cpp
@@ -227,6 +227,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg ) {
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
                     c->subscribe(
+                        std::vector<std::tuple<MQTT_NS::string_view, MQTT_NS::subscribe_options>>
                         {
                             {"topic1", MQTT_NS::qos::at_most_once},
                             {"topic2", MQTT_NS::qos::exactly_once}
@@ -238,7 +239,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg ) {
                 [&chk, &c]
                 (packet_id_t /*packet_id*/, std::vector<MQTT_NS::suback_return_code> /*results*/) {
                     MQTT_CHK("h_suback");
-                    c->unsubscribe( { MQTT_NS::string_view{"topic1"}, MQTT_NS::string_view{"topic2"} } );
+                    c->unsubscribe( std::vector<MQTT_NS::string_view>{ MQTT_NS::string_view{"topic1"}, MQTT_NS::string_view{"topic2"} } );
                     return true;
                 });
             c->set_unsuback_handler(
@@ -257,6 +258,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg ) {
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
                     c->subscribe(
+                        std::vector<std::tuple<MQTT_NS::string_view, MQTT_NS::subscribe_options>>
                         {
                             {"topic1", MQTT_NS::qos::at_most_once},
                             {"topic2", MQTT_NS::qos::exactly_once}
@@ -268,7 +270,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg ) {
                 [&chk, &c]
                 (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::suback_reason_code> /*reasons*/, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_suback");
-                    c->unsubscribe( { MQTT_NS::string_view{"topic1"}, MQTT_NS::string_view{"topic2"} });
+                    c->unsubscribe( std::vector<MQTT_NS::string_view>{ MQTT_NS::string_view{"topic1"}, MQTT_NS::string_view{"topic2"} });
                     return true;
                 });
             c->set_v5_unsuback_handler(
@@ -526,6 +528,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg_async ) {
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
                     c->async_subscribe(
+                        std::vector<std::tuple<std::string, MQTT_NS::subscribe_options>>
                         {
                             {"topic1", MQTT_NS::qos::at_most_once},
                             {"topic2", MQTT_NS::qos::exactly_once}
@@ -563,6 +566,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg_async ) {
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
                     c->async_subscribe(
+                        std::vector<std::tuple<std::string, MQTT_NS::subscribe_options>>
                         {
                             {"topic1", MQTT_NS::qos::at_most_once},
                             {"topic2", MQTT_NS::qos::exactly_once}


### PR DESCRIPTION
…ng to register a provided packet id, or always getting an automatically acquired packet id, to simplify the API

Do not merge yet.

Please review.

More changes to come.