### PR TITLE
Add new publish_options struct, similar to subscribe_options struct. Remove ***_dup functions.

### DIFF
--- a/example/no_tls_both.cpp
+++ b/example/no_tls_both.cpp
@@ -96,16 +96,14 @@ void client_proc(
         });
     c->set_publish_handler(
         [&]
-        (bool dup,
-         MQTT_NS::qos qos_value,
-         bool retain,
-         MQTT_NS::optional<packet_id_t> packet_id,
+        (MQTT_NS::optional<packet_id_t> packet_id,
+         MQTT_NS::publish_options pubopts,
          MQTT_NS::buffer topic_name,
          MQTT_NS::buffer contents){
             locked_cout() << "[client] publish received. "
-                      << "dup: " << std::boolalpha << dup
-                      << " qos: " << qos_value
-                      << " retain: " << std::boolalpha << retain << std::endl;
+                          << " dup: "    << pubopts.get_dup()
+                          << " qos: "    << pubopts.get_qos()
+                          << " retain: " << pubopts.get_retain() << std::endl;
             if (packet_id)
                 locked_cout() << "[client] packet_id: " << *packet_id << std::endl;
             locked_cout() << "[client] topic_name: " << topic_name << std::endl;
@@ -263,16 +261,14 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                 });
             ep.set_publish_handler(
                 [&subs]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic_name,
                  MQTT_NS::buffer contents){
                     locked_cout() << "[server] publish received."
-                              << " dup: " << std::boolalpha << is_dup
-                              << " qos: " << qos_value
-                              << " retain: " << std::boolalpha << is_retain << std::endl;
+                                  << " dup: "    << pubopts.get_dup()
+                                  << " qos: "    << pubopts.get_qos()
+                                  << " retain: " << pubopts.get_retain() << std::endl;
                     if (packet_id)
                         locked_cout() << "[server] packet_id: " << *packet_id << std::endl;
                     locked_cout() << "[server] topic_name: " << topic_name << std::endl;
@@ -284,8 +280,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                             boost::asio::buffer(topic_name),
                             boost::asio::buffer(contents),
                             std::make_pair(topic_name, contents),
-                            std::min(r.first->qos_value, qos_value),
-                            is_retain
+                            std::min(r.first->qos_value, pubopts.get_qos()) | pubopts.get_retain()
                         );
                     }
                     return true;

--- a/example/no_tls_client.cpp
+++ b/example/no_tls_client.cpp
@@ -102,16 +102,14 @@ int main(int argc, char** argv) {
         });
     c->set_publish_handler(
         [&]
-        (bool is_dup,
-         MQTT_NS::qos qos_value,
-         bool is_retain,
-         MQTT_NS::optional<packet_id_t> packet_id,
+        (MQTT_NS::optional<packet_id_t> packet_id,
+         MQTT_NS::publish_options pubopts,
          MQTT_NS::buffer topic_name,
          MQTT_NS::buffer contents){
-            std::cout << "publish received. "
-                      << "dup: " << std::boolalpha << is_dup
-                      << " qos: " << qos_value
-                      << " retain: " << std::boolalpha << is_retain << std::endl;
+            std::cout << "publish received."
+                      << " dup: "    << pubopts.get_dup()
+                      << " qos: "    << pubopts.get_qos()
+                      << " retain: " << pubopts.get_retain() << std::endl;
             if (packet_id)
                 std::cout << "packet_id: " << *packet_id << std::endl;
             std::cout << "topic_name: " << topic_name << std::endl;

--- a/example/no_tls_server.cpp
+++ b/example/no_tls_server.cpp
@@ -165,16 +165,14 @@ int main(int argc, char** argv) {
                 });
             ep.set_publish_handler(
                 [&subs]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic_name,
                  MQTT_NS::buffer contents){
                     std::cout << "[server] publish received."
-                              << " dup: " << std::boolalpha << is_dup
-                              << " qos: " << qos_value
-                              << " retain: " << std::boolalpha << is_retain << std::endl;
+                              << " dup: "    << pubopts.get_dup()
+                              << " qos: "    << pubopts.get_qos()
+                              << " retain: " << pubopts.get_retain() << std::endl;
                     if (packet_id)
                         std::cout << "[server] packet_id: " << *packet_id << std::endl;
                     std::cout << "[server] topic_name: " << topic_name << std::endl;
@@ -186,8 +184,7 @@ int main(int argc, char** argv) {
                             boost::asio::buffer(topic_name),
                             boost::asio::buffer(contents),
                             std::make_pair(topic_name, contents),
-                            std::min(r.first->qos_value, qos_value),
-                            is_retain
+                            std::min(r.first->qos_value, pubopts.get_qos()) | pubopts.get_retain()
                         );
                     }
                     return true;

--- a/example/no_tls_ws_both.cpp
+++ b/example/no_tls_ws_both.cpp
@@ -96,16 +96,14 @@ void client_proc(
         });
     c->set_publish_handler(
         [&]
-        (bool is_dup,
-         MQTT_NS::qos qos_value,
-         bool is_retain,
-         MQTT_NS::optional<packet_id_t> packet_id,
+        (MQTT_NS::optional<packet_id_t> packet_id,
+         MQTT_NS::publish_options pubopts,
          MQTT_NS::buffer topic_name,
          MQTT_NS::buffer contents){
             locked_cout() << "[client] publish received. "
-                      << "dup: " << std::boolalpha << is_dup
-                      << " qos: " << qos_value
-                      << " retain: " << std::boolalpha << is_retain << std::endl;
+                          << " dup: "    << pubopts.get_dup()
+                          << " qos: "    << pubopts.get_qos()
+                          << " retain: " << pubopts.get_retain() << std::endl;
             if (packet_id)
                 locked_cout() << "[client] packet_id: " << *packet_id << std::endl;
             locked_cout() << "[client] topic_name: " << topic_name << std::endl;
@@ -262,16 +260,14 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                 });
             ep.set_publish_handler(
                 [&subs]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic_name,
                  MQTT_NS::buffer contents){
                     locked_cout() << "[server] publish received."
-                              << " dup: " << std::boolalpha << is_dup
-                              << " qos: " << qos_value
-                              << " retain: " << std::boolalpha << is_retain << std::endl;
+                                  << " dup: "    << pubopts.get_dup()
+                                  << " qos: "    << pubopts.get_qos()
+                                  << " retain: " << pubopts.get_retain() << std::endl;
                     if (packet_id)
                         locked_cout() << "[server] packet_id: " << *packet_id << std::endl;
                     locked_cout() << "[server] topic_name: " << topic_name << std::endl;
@@ -283,8 +279,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                             boost::asio::buffer(topic_name),
                             boost::asio::buffer(contents),
                             std::make_pair(topic_name, contents),
-                            std::min(r.first->qos_value, qos_value),
-                            is_retain
+                            std::min(r.first->qos_value, pubopts.get_qos()) | pubopts.get_retain()
                         );
                     }
                     return true;

--- a/example/no_tls_ws_client.cpp
+++ b/example/no_tls_ws_client.cpp
@@ -102,16 +102,14 @@ int main(int argc, char** argv) {
         });
     c->set_publish_handler(
         [&]
-        (bool is_dup,
-         MQTT_NS::qos qos_value,
-         bool is_retain,
-         MQTT_NS::optional<packet_id_t> packet_id,
+        (MQTT_NS::optional<packet_id_t> packet_id,
+         MQTT_NS::publish_options pubopts,
          MQTT_NS::buffer topic_name,
          MQTT_NS::buffer contents){
-            std::cout << "publish received. "
-                      << "dup: " << std::boolalpha << is_dup
-                      << " qos: " << qos_value
-                      << " retain: " << std::boolalpha << is_retain << std::endl;
+            std::cout << "publish received."
+                      << " dup: "    << pubopts.get_dup()
+                      << " qos: "    << pubopts.get_qos()
+                      << " retain: " << pubopts.get_retain() << std::endl;
             if (packet_id)
                 std::cout << "packet_id: " << *packet_id << std::endl;
             std::cout << "topic_name: " << topic_name << std::endl;

--- a/example/no_tls_ws_server.cpp
+++ b/example/no_tls_ws_server.cpp
@@ -165,16 +165,14 @@ int main(int argc, char** argv) {
                 });
             ep.set_publish_handler(
                 [&subs]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic_name,
                  MQTT_NS::buffer contents){
                     std::cout << "[server] publish received."
-                              << " dup: " << std::boolalpha << is_dup
-                              << " qos: " << qos_value
-                              << " retain: " << std::boolalpha << is_retain << std::endl;
+                              << " dup: "    << pubopts.get_dup()
+                              << " qos: "    << pubopts.get_qos()
+                              << " retain: " << pubopts.get_retain() << std::endl;
                     if (packet_id)
                         std::cout << "[server] packet_id: " << *packet_id << std::endl;
                     std::cout << "[server] topic_name: " << topic_name << std::endl;
@@ -186,8 +184,7 @@ int main(int argc, char** argv) {
                             boost::asio::buffer(topic_name),
                             boost::asio::buffer(contents),
                             std::make_pair(topic_name, contents),
-                            std::min(r.first->qos_value, qos_value),
-                            is_retain
+                            std::min(r.first->qos_value, pubopts.get_qos()) | pubopts.get_retain()
                         );
                     }
                     return true;

--- a/example/tls_both.cpp
+++ b/example/tls_both.cpp
@@ -97,16 +97,14 @@ void client_proc(
         });
     c->set_publish_handler(
         [&]
-        (bool is_dup,
-         MQTT_NS::qos qos_value,
-         bool is_retain,
-         MQTT_NS::optional<packet_id_t> packet_id,
+        (MQTT_NS::optional<packet_id_t> packet_id,
+         MQTT_NS::publish_options pubopts,
          MQTT_NS::buffer topic_name,
          MQTT_NS::buffer contents){
             locked_cout() << "[client] publish received. "
-                      << "dup: " << std::boolalpha << is_dup
-                      << " qos: " << qos_value
-                      << " retain: " << is_retain << std::endl;
+                          << " dup: "    << pubopts.get_dup()
+                          << " qos: "    << pubopts.get_qos()
+                          << " retain: " << pubopts.get_retain() << std::endl;
             if (packet_id)
                 locked_cout() << "[client] packet_id: " << *packet_id << std::endl;
             locked_cout() << "[client] topic_name: " << topic_name << std::endl;
@@ -264,16 +262,14 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                 });
             ep.set_publish_handler(
                 [&subs]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic_name,
                  MQTT_NS::buffer contents){
                     locked_cout() << "[server] publish received."
-                              << " dup: " << std::boolalpha << is_dup
-                              << " qos: " << qos_value
-                              << " retain: " << std::boolalpha << is_retain << std::endl;
+                                  << " dup: "    << pubopts.get_dup()
+                                  << " qos: "    << pubopts.get_qos()
+                                  << " retain: " << pubopts.get_retain() << std::endl;
                     if (packet_id)
                         locked_cout() << "[server] packet_id: " << *packet_id << std::endl;
                     locked_cout() << "[server] topic_name: " << topic_name << std::endl;
@@ -285,8 +281,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                             boost::asio::buffer(topic_name),
                             boost::asio::buffer(contents),
                             std::make_pair(topic_name, contents),
-                            std::min(r.first->qos_value, qos_value),
-                            is_retain
+                            std::min(r.first->qos_value, pubopts.get_qos()) | pubopts.get_retain()
                         );
                     }
                     return true;

--- a/example/tls_client.cpp
+++ b/example/tls_client.cpp
@@ -118,16 +118,14 @@ int main(int argc, char** argv) {
         });
     c->set_publish_handler(
         [&]
-        (bool is_dup,
-         MQTT_NS::qos qos_value,
-         bool is_retain,
-         MQTT_NS::optional<packet_id_t> packet_id,
+        (MQTT_NS::optional<packet_id_t> packet_id,
+         MQTT_NS::publish_options pubopts,
          MQTT_NS::buffer topic_name,
          MQTT_NS::buffer contents){
-            std::cout << "publish received. "
-                      << "dup: " << std::boolalpha << is_dup
-                      << " qos: " << qos_value
-                      << " retain: " << is_retain << std::endl;
+            std::cout << "publish received."
+                      << " dup: "    << pubopts.get_dup()
+                      << " qos: "    << pubopts.get_qos()
+                      << " retain: " << pubopts.get_retain() << std::endl;
             if (packet_id)
                 std::cout << "packet_id: " << *packet_id << std::endl;
             std::cout << "topic_name: " << topic_name << std::endl;

--- a/example/tls_server.cpp
+++ b/example/tls_server.cpp
@@ -177,16 +177,14 @@ int main(int argc, char** argv) {
                 });
             ep.set_publish_handler(
                 [&subs]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic_name,
                  MQTT_NS::buffer contents){
                     std::cout << "[server] publish received."
-                              << " dup: " << std::boolalpha << is_dup
-                              << " qos: " << qos_value
-                              << " retain: " << std::boolalpha << is_retain << std::endl;
+                              << " dup: "    << pubopts.get_dup()
+                              << " qos: "    << pubopts.get_qos()
+                              << " retain: " << pubopts.get_retain() << std::endl;
                     if (packet_id)
                         std::cout << "[server] packet_id: " << *packet_id << std::endl;
                     std::cout << "[server] topic_name: " << topic_name << std::endl;
@@ -198,8 +196,7 @@ int main(int argc, char** argv) {
                             boost::asio::buffer(topic_name),
                             boost::asio::buffer(contents),
                             std::make_pair(topic_name, contents),
-                            std::min(r.first->qos_value, qos_value),
-                            is_retain
+                            std::min(r.first->qos_value, pubopts.get_qos()) | pubopts.get_retain()
                         );
                     }
                     return true;

--- a/example/tls_ws_both.cpp
+++ b/example/tls_ws_both.cpp
@@ -96,16 +96,14 @@ void client_proc(
         });
     c->set_publish_handler(
         [&]
-        (bool is_dup,
-         MQTT_NS::qos qos_value,
-         bool is_retain,
-         MQTT_NS::optional<packet_id_t> packet_id,
+        (MQTT_NS::optional<packet_id_t> packet_id,
+         MQTT_NS::publish_options pubopts,
          MQTT_NS::buffer topic_name,
          MQTT_NS::buffer contents){
             locked_cout() << "[client] publish received. "
-                      << "dup: " << std::boolalpha << is_dup
-                      << " qos: " << qos_value
-                      << " retain: " << is_retain << std::endl;
+                          << " dup: "    << pubopts.get_dup()
+                          << " qos: "    << pubopts.get_qos()
+                          << " retain: " << pubopts.get_retain() << std::endl;
             if (packet_id)
                 locked_cout() << "[client] packet_id: " << *packet_id << std::endl;
             locked_cout() << "[client] topic_name: " << topic_name << std::endl;
@@ -263,16 +261,14 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                 });
             ep.set_publish_handler(
                 [&subs]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic_name,
                  MQTT_NS::buffer contents){
                     locked_cout() << "[server] publish received."
-                              << " dup: " << std::boolalpha << is_dup
-                              << " qos: " << qos_value
-                              << " retain: " << std::boolalpha << is_retain << std::endl;
+                                  << " dup: "    << pubopts.get_dup()
+                                  << " qos: "    << pubopts.get_qos()
+                                  << " retain: " << pubopts.get_retain() << std::endl;
                     if (packet_id)
                         locked_cout() << "[server] packet_id: " << *packet_id << std::endl;
                     locked_cout() << "[server] topic_name: " << topic_name << std::endl;
@@ -284,8 +280,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                             boost::asio::buffer(topic_name),
                             boost::asio::buffer(contents),
                             std::make_pair(topic_name, contents),
-                            std::min(r.first->qos_value, qos_value),
-                            is_retain
+                            std::min(r.first->qos_value, pubopts.get_qos()) | pubopts.get_retain()
                         );
                     }
                     return true;

--- a/example/tls_ws_client.cpp
+++ b/example/tls_ws_client.cpp
@@ -108,16 +108,14 @@ int main(int argc, char** argv) {
         });
     c->set_publish_handler(
         [&]
-        (bool is_dup,
-         MQTT_NS::qos qos_value,
-         bool is_retain,
-         MQTT_NS::optional<packet_id_t> packet_id,
+        (MQTT_NS::optional<packet_id_t> packet_id,
+         MQTT_NS::publish_options pubopts,
          MQTT_NS::buffer topic_name,
          MQTT_NS::buffer contents){
             std::cout << "publish received. "
-                      << "dup: " << std::boolalpha << is_dup
-                      << " qos: " << qos_value
-                      << " retain: " << is_retain << std::endl;
+                      << " dup: "    << pubopts.get_dup()
+                      << " qos: "    << pubopts.get_qos()
+                      << " retain: " << pubopts.get_retain() << std::endl;
             if (packet_id)
                 std::cout << "packet_id: " << *packet_id << std::endl;
             std::cout << "topic_name: " << topic_name << std::endl;

--- a/example/tls_ws_server.cpp
+++ b/example/tls_ws_server.cpp
@@ -177,16 +177,14 @@ int main(int argc, char** argv) {
                 });
             ep.set_publish_handler(
                 [&subs]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic_name,
                  MQTT_NS::buffer contents){
                     std::cout << "[server] publish received."
-                              << " dup: " << std::boolalpha << is_dup
-                              << " qos: " << qos_value
-                              << " retain: " << std::boolalpha << is_retain << std::endl;
+                              << " dup: "    << pubopts.get_dup()
+                              << " qos: "    << pubopts.get_qos()
+                              << " retain: " << pubopts.get_retain() << std::endl;
                     if (packet_id)
                         std::cout << "[server] packet_id: " << *packet_id << std::endl;
                     std::cout << "[server] topic_name: " << topic_name << std::endl;
@@ -198,8 +196,7 @@ int main(int argc, char** argv) {
                             boost::asio::buffer(topic_name),
                             boost::asio::buffer(contents),
                             std::make_pair(topic_name, contents),
-                            std::min(r.first->qos_value, qos_value),
-                            is_retain
+                            std::min(r.first->qos_value, pubopts.get_qos()) | pubopts.get_retain()
                         );
                     }
                     return true;

--- a/example/v5_no_tls_both.cpp
+++ b/example/v5_no_tls_both.cpp
@@ -116,17 +116,15 @@ void client_proc(
         });
     c->set_v5_publish_handler( // use v5 handler
         [&]
-        (bool is_dup,
-         MQTT_NS::qos qos_value,
-         bool is_retain,
-         MQTT_NS::optional<packet_id_t> packet_id,
+        (MQTT_NS::optional<packet_id_t> packet_id,
+         MQTT_NS::publish_options pubopts,
          MQTT_NS::buffer topic_name,
          MQTT_NS::buffer contents,
          MQTT_NS::v5::properties /*props*/){
             locked_cout() << "[client] publish received. "
-                      << "dup: " << std::boolalpha << is_dup
-                      << " qos: " << qos_value
-                      << " retain: " << std::boolalpha << is_retain << std::endl;
+                          << " dup: "    << pubopts.get_dup()
+                          << " qos: "    << pubopts.get_qos()
+                          << " retain: " << pubopts.get_retain() << std::endl;
             if (packet_id)
                 locked_cout() << "[client] packet_id: " << *packet_id << std::endl;
             locked_cout() << "[client] topic_name: " << topic_name << std::endl;
@@ -294,17 +292,15 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                 });
             ep.set_v5_publish_handler( // use v5 handler
                 [&subs]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic_name,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/){
                     locked_cout() << "[server] publish received."
-                              << " dup: " << std::boolalpha << is_dup
-                              << " qos: " << qos_value
-                              << " retain: " << std::boolalpha << is_retain << std::endl;
+                                  << " dup: "    << pubopts.get_dup()
+                                  << " qos: "    << pubopts.get_qos()
+                                  << " retain: " << pubopts.get_retain() << std::endl;
                     if (packet_id)
                         locked_cout() << "[server] packet_id: " << *packet_id << std::endl;
                     locked_cout() << "[server] topic_name: " << topic_name << std::endl;
@@ -316,8 +312,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
                             boost::asio::buffer(topic_name),
                             boost::asio::buffer(contents),
                             std::make_pair(topic_name, contents),
-                            std::min(r.first->qos_value, qos_value),
-                            is_retain
+                            std::min(r.first->qos_value, pubopts.get_qos()) | pubopts.get_retain()
                         );
                     }
                     return true;

--- a/example/v5_no_tls_client.cpp
+++ b/example/v5_no_tls_client.cpp
@@ -123,17 +123,15 @@ int main(int argc, char** argv) {
         });
     c->set_v5_publish_handler( // use v5 handler
         [&]
-        (bool is_dup,
-         MQTT_NS::qos qos_value,
-         bool is_retain,
-         MQTT_NS::optional<packet_id_t> packet_id,
+        (MQTT_NS::optional<packet_id_t> packet_id,
+         MQTT_NS::publish_options pubopts,
          MQTT_NS::buffer topic_name,
          MQTT_NS::buffer contents,
          MQTT_NS::v5::properties /*props*/){
             std::cout << "[client] publish received. "
-                      << "dup: " << std::boolalpha << is_dup
-                      << " qos: " << qos_value
-                      << " retain: " << std::boolalpha << is_retain << std::endl;
+                      << "dup: "     << pubopts.get_dup()
+                      << " qos: "    << pubopts.get_qos()
+                      << " retain: " << pubopts.get_retain() << std::endl;
             if (packet_id)
                 std::cout << "[client] packet_id: " << *packet_id << std::endl;
             std::cout << "[client] topic_name: " << topic_name << std::endl;

--- a/example/v5_no_tls_server.cpp
+++ b/example/v5_no_tls_server.cpp
@@ -175,17 +175,15 @@ int main(int argc, char** argv) {
                 });
             ep.set_v5_publish_handler( // use v5 handler
                 [&subs]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic_name,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/){
                     std::cout << "[server] publish received."
-                              << " dup: " << std::boolalpha << is_dup
-                              << " qos: " << qos_value
-                              << " retain: " << std::boolalpha << is_retain << std::endl;
+                              << " dup: "    << pubopts.get_dup()
+                              << " qos: "    << pubopts.get_qos()
+                              << " retain: " << pubopts.get_retain() << std::endl;
                     if (packet_id)
                         std::cout << "[server] packet_id: " << *packet_id << std::endl;
                     std::cout << "[server] topic_name: " << topic_name << std::endl;
@@ -197,8 +195,7 @@ int main(int argc, char** argv) {
                             boost::asio::buffer(topic_name),
                             boost::asio::buffer(contents),
                             std::make_pair(topic_name, contents),
-                            std::min(r.first->qos_value, qos_value),
-                            is_retain
+                            std::min(r.first->qos_value, pubopts.get_qos()) | pubopts.get_retain()
                         );
                     }
                     return true;

--- a/include/mqtt/async_client.hpp
+++ b/include/mqtt/async_client.hpp
@@ -227,14 +227,10 @@ public:
 
     void connect() = delete;
     void disconnect() = delete;
-    void publish_at_most_once() = delete;
-    void publish_at_least_once() = delete;
-    void publish_exactly_once() = delete;
 
     void publish() = delete;
     void subscribe() = delete;
     void unsubscribe() = delete;
-    void publish_dup() = delete;
     void pingresp() = delete;
     void connack() = delete;
     void puback() = delete;

--- a/include/mqtt/callable_overlay.hpp
+++ b/include/mqtt/callable_overlay.hpp
@@ -126,32 +126,28 @@ struct callable_overlay final : public Impl
 
     /**
      * @brief Publish handler
-     * @param fixed_header
-     *        See https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc398718038<BR>
-     *        3.3.1 Fixed header<BR>
-     *        You can check the fixed header using MQTT_NS::publish functions.
      * @param packet_id
      *        packet identifier<BR>
      *        If received publish's QoS is 0, packet_id is MQTT_NS::nullopt.<BR>
      *        See https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc398718039<BR>
      *        3.3.2  Variable header
+     * @param fixed_header
+     *        See https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc398718038<BR>
+     *        3.3.1 Fixed header<BR>
+     *        You can check the fixed header using MQTT_NS::publish functions.
      * @param topic_name
      *        Topic name
      * @param contents
      *        Published contents
      * @return if the handler returns true, then continue receiving, otherwise quit.
      */
-    MQTT_ALWAYS_INLINE bool on_publish(bool dup,
-                                           qos qos_value,
-                                           bool retain,
-                                           MQTT_NS::optional<packet_id_t> packet_id,
-                                           MQTT_NS::buffer topic_name,
-                                           MQTT_NS::buffer contents) override final {
+    MQTT_ALWAYS_INLINE bool on_publish(MQTT_NS::optional<packet_id_t> packet_id,
+                                       MQTT_NS::publish_options pubopts,
+                                       MQTT_NS::buffer topic_name,
+                                       MQTT_NS::buffer contents) override final {
         return    ! h_publish_
-               || h_publish_(dup,
-                             qos_value,
-                             retain,
-                             packet_id,
+               || h_publish_(packet_id,
+                             pubopts,
                              MQTT_NS::force_move(topic_name),
                              MQTT_NS::force_move(contents));
     }
@@ -366,15 +362,15 @@ struct callable_overlay final : public Impl
 
     /**
      * @brief Publish handler
-     * @param fixed_header
-     *        See https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901101<BR>
-     *        3.3.1 Fixed header<BR>
-     *        You can check the fixed header using MQTT_NS::publish functions.
      * @param packet_id
      *        packet identifier<BR>
      *        If received publish's QoS is 0, packet_id is MQTT_NS::nullopt.<BR>
      *        See https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901108<BR>
      *        3.3.2.2 Packet Identifier
+     * @param fixed_header
+     *        See https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901101<BR>
+     *        3.3.1 Fixed header<BR>
+     *        You can check the fixed header using MQTT_NS::publish functions.
      * @param topic_name
      *        Topic name<BR>
      *        See https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901107<BR>
@@ -389,18 +385,14 @@ struct callable_overlay final : public Impl
      *        3.3.2.3 PUBLISH Properties
      * @return if the handler returns true, then continue receiving, otherwise quit.
      */
-    MQTT_ALWAYS_INLINE bool on_v5_publish(bool dup,
-                                              qos qos_value,
-                                              bool retain,
-                                              MQTT_NS::optional<packet_id_t> packet_id,
-                                              MQTT_NS::buffer topic_name,
-                                              MQTT_NS::buffer contents,
-                                              v5::properties props) override final {
+    MQTT_ALWAYS_INLINE bool on_v5_publish(MQTT_NS::optional<packet_id_t> packet_id,
+                                          MQTT_NS::publish_options pubopts,
+                                          MQTT_NS::buffer topic_name,
+                                          MQTT_NS::buffer contents,
+                                          v5::properties props) override final {
         return    ! h_v5_publish_
-               || h_v5_publish_(dup,
-                                qos_value,
-                                retain,
-                                packet_id,
+               || h_v5_publish_(packet_id,
+                                pubopts,
                                 MQTT_NS::force_move(topic_name),
                                 MQTT_NS::force_move(contents),
                                 MQTT_NS::force_move(props));
@@ -843,10 +835,8 @@ struct callable_overlay final : public Impl
      *        Published contents
      * @return if the handler returns true, then continue receiving, otherwise quit.
      */
-    using publish_handler = std::function<bool(bool dup,
-                                               qos qos_value,
-                                               bool retain,
-                                               MQTT_NS::optional<packet_id_t> packet_id,
+    using publish_handler = std::function<bool(MQTT_NS::optional<packet_id_t> packet_id,
+                                               MQTT_NS::publish_options pubopts,
                                                MQTT_NS::buffer topic_name,
                                                MQTT_NS::buffer contents)>;
 
@@ -1025,15 +1015,15 @@ struct callable_overlay final : public Impl
 
     /**
      * @brief Publish handler
-     * @param fixed_header
-     *        See https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901101<BR>
-     *        3.3.1 Fixed header<BR>
-     *        You can check the fixed header using MQTT_NS::publish functions.
      * @param packet_id
      *        packet identifier<BR>
      *        If received publish's QoS is 0, packet_id is MQTT_NS::nullopt.<BR>
      *        See https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901108<BR>
      *        3.3.2.2 Packet Identifier
+     * @param fixed_header
+     *        See https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901101<BR>
+     *        3.3.1 Fixed header<BR>
+     *        You can check the fixed header using MQTT_NS::publish functions.
      * @param topic_name
      *        Topic name<BR>
      *        See https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901107<BR>
@@ -1049,10 +1039,8 @@ struct callable_overlay final : public Impl
      * @return if the handler returns true, then continue receiving, otherwise quit.
      */
     using v5_publish_handler = std::function<
-        bool(bool dup,
-             qos qos_value,
-             bool retain,
-             MQTT_NS::optional<packet_id_t> packet_id,
+        bool(MQTT_NS::optional<packet_id_t> packet_id,
+             MQTT_NS::publish_options pubopts,
              MQTT_NS::buffer topic_name,
              MQTT_NS::buffer contents,
              v5::properties props)

--- a/include/mqtt/connect_flags.hpp
+++ b/include/mqtt/connect_flags.hpp
@@ -9,7 +9,7 @@
 
 #include <cstdint>
 #include <mqtt/namespace.hpp>
-#include <mqtt/subscribe_options.hpp>
+#include <mqtt/publish.hpp>
 
 namespace MQTT_NS {
 
@@ -29,8 +29,10 @@ constexpr bool has_will_flag(char v) {
     return (v & will_flag) != 0;
 }
 
-constexpr bool has_will_retain(char v) {
-    return (v & will_retain) != 0;
+constexpr retain has_will_retain(char v) {
+    return   ((v & will_retain) != 0)
+           ? retain::yes
+           : retain::no;
 }
 
 constexpr bool has_password_flag(char v) {

--- a/include/mqtt/property.hpp
+++ b/include/mqtt/property.hpp
@@ -672,40 +672,28 @@ public:
 };
 
 template <typename Property>
-typename std::enable_if<
-    Property::of_ == detail::ostream_format::direct,
-    std::ostream&
->::type
+std::enable_if_t< Property::of_ == detail::ostream_format::direct, std::ostream& >
 operator<<(std::ostream& o, Property const& p) {
     o << p.val();
     return o;
 }
 
 template <typename Property>
-typename std::enable_if<
-    Property::of_ == detail::ostream_format::int_cast,
-    std::ostream&
->::type
+std::enable_if_t< Property::of_ == detail::ostream_format::int_cast, std::ostream& >
 operator<<(std::ostream& o, Property const& p) {
     o << static_cast<int>(p.val());
     return o;
 }
 
 template <typename Property>
-typename std::enable_if<
-    Property::of_ == detail::ostream_format::key_val,
-    std::ostream&
->::type
+std::enable_if_t< Property::of_ == detail::ostream_format::key_val, std::ostream& >
 operator<<(std::ostream& o, Property const& p) {
     o << p.key() << ':' << p.val();
     return o;
 }
 
 template <typename Property>
-typename std::enable_if<
-    Property::of_ == detail::ostream_format::binary_string,
-    std::ostream&
->::type
+std::enable_if_t< Property::of_ == detail::ostream_format::binary_string, std::ostream& >
 operator<<(std::ostream& o, Property const& p) {
     // Note this only compiles because both strings below are the same length.
     o << ((p.val() == payload_format_indicator::binary) ? "binary" : "string");

--- a/include/mqtt/publish.hpp
+++ b/include/mqtt/publish.hpp
@@ -35,17 +35,99 @@ constexpr void set_dup(std::uint8_t& fixed_header, bool dup) {
     else     fixed_header &= static_cast<std::uint8_t>(~0b00001000);
 }
 
-constexpr void set_qos(std::uint8_t& fixed_header, qos qos_value) {
-    BOOST_ASSERT(qos_value == qos::at_most_once || qos_value == qos::at_least_once || qos_value == qos::exactly_once);
-    fixed_header |= static_cast<std::uint8_t>(static_cast<std::uint8_t>(qos_value) << 1);
-}
-
-constexpr void set_retain(std::uint8_t& fixed_header, bool retain) {
-    if (retain) fixed_header |=  0b00000001;
-    else        fixed_header &= static_cast<std::uint8_t>(~0b00000001);
-}
-
 } // namespace publish
+
+enum class retain : std::uint8_t
+{
+    yes = 0b00000001,
+    no = 0b00000000,
+};
+
+enum class dup : std::uint8_t
+{
+    yes = 0b00001000,
+    no = 0b00000000,
+};
+
+struct publish_options final {
+    constexpr publish_options(void) = default;
+    ~publish_options(void) = default;
+    constexpr publish_options(publish_options &&) = default;
+    constexpr publish_options(publish_options const&) = default;
+    constexpr publish_options& operator=(publish_options &&) = default;
+    constexpr publish_options& operator=(publish_options const&) = default;
+
+    explicit constexpr publish_options(std::uint8_t value) : data_(value) { }
+
+    constexpr publish_options(retain value) : data_(static_cast<std::uint8_t>(value)) { }
+    constexpr publish_options(dup value)    : data_(static_cast<std::uint8_t>(value)) { }
+    constexpr publish_options(qos value)    : data_(static_cast<std::uint8_t>(static_cast<std::uint8_t>(value) << 1))
+    {
+        BOOST_ASSERT(value == qos::at_most_once || value == qos::at_least_once || value == qos::exactly_once);
+    }
+
+    constexpr publish_options operator|(publish_options rhs) const { return publish_options(data_ | rhs.data_); }
+    constexpr publish_options operator|(retain rhs) const          { return *this | publish_options(rhs); }
+    constexpr publish_options operator|(dup rhs) const             { return *this | publish_options(rhs); }
+    constexpr publish_options operator|(qos rhs) const             { return *this | publish_options(rhs); }
+
+    constexpr publish_options& operator|=(publish_options rhs) { return (*this = (*this | rhs)); }
+    constexpr publish_options& operator|=(retain rhs)          { return (*this = (*this | rhs)); }
+    constexpr publish_options& operator|=(dup rhs)             { return (*this = (*this | rhs)); }
+    constexpr publish_options& operator|=(qos rhs)             { return (*this = (*this | rhs)); }
+
+    constexpr retain get_retain() const
+    { return static_cast<retain>(data_ & 0b00000001); }
+    constexpr dup get_dup() const
+    { return static_cast<dup>(data_ & 0b00001000); }
+    constexpr qos get_qos() const
+    { return static_cast<qos>((data_ & 0b00000110) >> 1); }
+
+    explicit constexpr operator std::uint8_t() const { return data_; }
+
+private:
+    std::uint8_t data_ = 0; // defaults to retain::no, dup::no, qos::at_most_once
+};
+
+constexpr publish_options operator|(retain lhs, dup rhs) { return publish_options(lhs) | rhs; }
+constexpr publish_options operator|(retain lhs, qos rhs) { return publish_options(lhs) | rhs; }
+
+constexpr publish_options operator|(dup lhs, retain rhs) { return publish_options(lhs) | rhs; }
+constexpr publish_options operator|(dup lhs, qos rhs)    { return publish_options(lhs) | rhs; }
+
+constexpr publish_options operator|(qos lhs, retain rhs) { return publish_options(lhs) | rhs; }
+constexpr publish_options operator|(qos lhs, dup rhs)    { return publish_options(lhs) | rhs; }
+
+
+constexpr char const* publish_retain_to_str(retain v) {
+    switch(v) {
+        case retain::yes: return "yes";
+        case retain::no:  return "no";
+        default:                  return "invalid_publish_retain";
+    }
+}
+
+template<typename Stream>
+Stream & operator<<(Stream & os, retain val)
+{
+    os << publish_retain_to_str(val);
+    return os;
+}
+
+constexpr char const* dup_to_str(dup v) {
+    switch(v) {
+        case dup::yes: return "yes";
+        case dup::no:  return "no";
+        default:                  return "invalid_publish_retain";
+    }
+}
+
+template<typename Stream>
+Stream & operator<<(Stream & os, dup val)
+{
+    os << dup_to_str(val);
+    return os;
+}
 
 } // namespace MQTT_NS
 

--- a/include/mqtt/sync_client.hpp
+++ b/include/mqtt/sync_client.hpp
@@ -226,14 +226,10 @@ public:
 
     void async_connect() = delete;
     void async_disconnect() = delete;
-    void async_publish_at_most_once() = delete;
-    void async_publish_at_least_once() = delete;
-    void async_publish_exactly_once() = delete;
 
     void async_publish() = delete;
     void async_subscribe() = delete;
     void async_unsubscribe() = delete;
-    void async_publish_dup() = delete;
     void async_pingresp() = delete;
     void async_connack() = delete;
     void async_puback() = delete;

--- a/include/mqtt/v5_message.hpp
+++ b/include/mqtt/v5_message.hpp
@@ -200,7 +200,7 @@ public:
         }
         if (w) {
             connect_flags_ |= connect_flags::will_flag;
-            if (w.value().retain()) connect_flags_ |= connect_flags::will_retain;
+            if (w.value().get_retain() == retain::yes) connect_flags_ |= connect_flags::will_retain;
             connect_flags::set_will_qos(connect_flags_, w.value().get_qos());
 
             auto wpb = variable_bytes(will_property_length_);
@@ -544,15 +544,13 @@ template <std::size_t PacketIdBytes>
 class basic_publish_message {
 public:
     basic_publish_message(
-        as::const_buffer topic_name,
-        qos qos_value,
-        bool retain,
-        bool dup,
         typename packet_id_type<PacketIdBytes>::type packet_id,
-        properties props,
-        as::const_buffer payload
+        as::const_buffer topic_name,
+        as::const_buffer payload,
+        publish_options pubopts,
+        properties props
     )
-        : fixed_header_(make_fixed_header(control_packet_type::publish, 0b0000)),
+        : fixed_header_(make_fixed_header(control_packet_type::publish, 0b0000) | pubopts.operator std::uint8_t()),
           topic_name_(topic_name),
           topic_name_length_buf_ { num_to_2bytes(boost::numeric_cast<std::uint16_t>(topic_name_.size())) },
           property_length_(
@@ -571,7 +569,7 @@ public:
               2                      // topic name length
               + topic_name_.size()   // topic name
               + payload_.size()      // payload
-              + (  (qos_value == qos::at_least_once || qos_value == qos::exactly_once)
+              + (  (pubopts.get_qos() == qos::at_least_once || pubopts.get_qos() == qos::exactly_once)
                  ? PacketIdBytes // packet_id
                  : 0)
           ),
@@ -580,7 +578,7 @@ public:
               1 +                   // remaining length
               1 +                   // topic name length
               1 +                   // topic name
-              ((qos_value == qos::at_most_once) ? 0U : 1U) + // packet id
+              ((pubopts.get_qos() == qos::at_most_once) ? 0U : 1U) + // packet id
               1 +                   // property length
               std::accumulate(
                   props_.begin(),
@@ -594,9 +592,6 @@ public:
           )
     {
         utf8string_check(topic_name_);
-        publish::set_qos(fixed_header_, qos_value);
-        publish::set_retain(fixed_header_, retain);
-        publish::set_dup(fixed_header_, dup);
 
         auto pb = variable_bytes(property_length_);
         for (auto e : pb) {
@@ -609,8 +604,8 @@ public:
         for (auto e : rb) {
             remaining_length_buf_.push_back(e);
         }
-        if (qos_value == qos::at_least_once ||
-            qos_value == qos::exactly_once) {
+        if (pubopts.get_qos() == qos::at_least_once ||
+            pubopts.get_qos() == qos::exactly_once) {
             packet_id_.reserve(PacketIdBytes);
             add_packet_id_to_buf<PacketIdBytes>::apply(packet_id_, packet_id);
         }

--- a/include/mqtt/will.hpp
+++ b/include/mqtt/will.hpp
@@ -10,9 +10,10 @@
 #include <string>
 
 #include <mqtt/namespace.hpp>
-#include <mqtt/subscribe_options.hpp>
-#include <mqtt/property_variant.hpp>
+
 #include <mqtt/move.hpp>
+#include <mqtt/publish.hpp>
+#include <mqtt/property_variant.hpp>
 
 namespace MQTT_NS {
 
@@ -24,57 +25,19 @@ public:
      *        A topic name to publish as a will
      * @param message
      *        The contents to publish as a will
-     * @param retain
-     *        A retain flag. If set it to true, the contents is retained.<BR>
-     *        See http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718038<BR>
-     *        3.3.1.3 RETAIN
+     * @param pubopts
+     *        Qos and retain flag
      * @param qos
      *        qos
      */
     will(buffer topic,
          buffer message,
-         bool retain,
-         qos qos_value,
+         publish_options pubopts = {},
          v5::properties props = {})
         :topic_(force_move(topic)),
          message_(force_move(message)),
-         retain_(retain),
-         qos_(qos_value),
+         pubopts_(pubopts),
          props_(force_move(props))
-    {}
-
-    /**
-     * @brief constructor (QoS0)
-     * @param topic
-     *        A topic name to publish as a will
-     * @param message
-     *        The contents to publish as a will
-     * @param retain
-     *        A retain flag. If set it to true, the contents is retained.<BR>
-     *        See http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718038<BR>
-     *        3.3.1.3 RETAIN
-     */
-    will(buffer topic,
-         buffer message,
-         bool retain = false,
-         v5::properties props = {})
-        :will(force_move(topic), force_move(message), retain, qos::at_most_once, force_move(props))
-    {}
-
-    /**
-     * @brief constructor (retain = false)
-     * @param topic
-     *        A topic name to publish as a will
-     * @param message
-     *        The contents to publish as a will
-     * @param qos
-     *        qos
-     */
-    will(buffer topic,
-         buffer message,
-         qos qos_value,
-         v5::properties props = {})
-        :will(force_move(topic), force_move(message), false, qos_value, force_move(props))
     {}
 
     constexpr buffer const& topic() const {
@@ -89,11 +52,11 @@ public:
     constexpr buffer& message() {
         return message_;
     }
-    constexpr bool retain() const {
-        return retain_;
+    constexpr retain get_retain() const {
+        return pubopts_.get_retain();
     }
     constexpr qos get_qos() const {
-        return qos_;
+        return pubopts_.get_qos();
     }
     constexpr v5::properties const& props() const {
         return props_;
@@ -105,8 +68,7 @@ public:
 private:
     buffer topic_;
     buffer message_;
-    bool retain_ = false;
-    qos qos_ = qos::at_most_once;
+    publish_options pubopts_;
     v5::properties props_;
 };
 

--- a/test/as_buffer_async_pubsub_1.cpp
+++ b/test/as_buffer_async_pubsub_1.cpp
@@ -82,8 +82,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                         as::buffer("topic1", sizeof("topic1") - 1),
                         as::buffer("topic1_contents", sizeof("topic1_contents") - 1),
                         MQTT_NS::any(),
-                        MQTT_NS::qos::at_most_once,
-                        false
+                        MQTT_NS::qos::at_most_once | MQTT_NS::retain::no
                     );
                     return true;
                 });
@@ -97,16 +96,14 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                 });
             c->set_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -166,8 +163,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                         as::buffer("topic1", sizeof("topic1") - 1),
                         as::buffer("topic1_contents", sizeof("topic1_contents") - 1),
                         MQTT_NS::any(),
-                        MQTT_NS::qos::at_most_once,
-                        false
+                        MQTT_NS::qos::at_most_once | MQTT_NS::retain::no
                     );
                     return true;
                 });
@@ -183,17 +179,15 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -330,16 +324,14 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                 });
             c->set_publish_handler(
                 [&chk]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -420,17 +412,15 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -562,16 +552,14 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                 });
             c->set_publish_handler(
                 [&chk]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -653,17 +641,15 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -764,8 +750,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                         as::buffer("topic1", sizeof("topic1") - 1),
                         as::buffer("topic1_contents", sizeof("topic1_contents") - 1),
                         MQTT_NS::any(),
-                        MQTT_NS::qos::at_most_once,
-                        false
+                        MQTT_NS::qos::at_most_once  | MQTT_NS::retain::no
                     );
                     return true;
                 });
@@ -779,16 +764,14 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                 });
             c->set_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -848,8 +831,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                         as::buffer("topic1", sizeof("topic1") - 1),
                         as::buffer("topic1_contents", sizeof("topic1_contents") - 1),
                         MQTT_NS::any(),
-                        MQTT_NS::qos::at_most_once,
-                        false
+                        MQTT_NS::qos::at_most_once | MQTT_NS::retain::no
                     );
                     return true;
                 });
@@ -865,17 +847,15 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -1020,16 +1000,14 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                 });
             c->set_publish_handler(
                 [&chk, &recv_packet_id]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(*packet_id != 0);
                     recv_packet_id = packet_id;
                     BOOST_TEST(topic == "topic1");
@@ -1104,17 +1082,15 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &recv_packet_id]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(*packet_id != 0);
                     recv_packet_id = packet_id;
                     BOOST_TEST(topic == "topic1");
@@ -1250,16 +1226,14 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                 });
             c->set_publish_handler(
                 [&chk, &recv_packet_id]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(*packet_id != 0);
                     recv_packet_id = packet_id;
                     BOOST_TEST(topic == "topic1");
@@ -1342,18 +1316,15 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &recv_packet_id]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(is_retain == false);
-                    BOOST_TEST(*packet_id != 0);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     recv_packet_id = packet_id;
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");

--- a/test/as_buffer_async_pubsub_2.cpp
+++ b/test/as_buffer_async_pubsub_2.cpp
@@ -85,8 +85,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                         as::buffer(*topic1),
                         as::buffer(*contents),
                         std::make_pair(topic1, contents),
-                        MQTT_NS::qos::at_most_once,
-                        false
+                        MQTT_NS::qos::at_most_once | MQTT_NS::retain::no
                     );
                     return true;
                 });
@@ -100,16 +99,14 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                 });
             c->set_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -171,8 +168,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                         as::buffer(*topic1),
                         as::buffer(*contents),
                         std::make_pair(topic1, contents),
-                        MQTT_NS::qos::at_most_once,
-                        false
+                        MQTT_NS::qos::at_most_once | MQTT_NS::retain::no
                     );
                     return true;
                 });
@@ -188,17 +184,15 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -344,16 +338,14 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                 });
             c->set_publish_handler(
                 [&chk, &recv_packet_id]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(*packet_id != 0);
                     recv_packet_id = packet_id;
                     BOOST_TEST(topic == "topic1");
@@ -435,17 +427,15 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &recv_packet_id]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(*packet_id != 0);
                     recv_packet_id = packet_id;
                     BOOST_TEST(topic == "topic1");
@@ -583,16 +573,14 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                 });
             c->set_publish_handler(
                 [&chk, &recv_packet_id]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::exactly_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::exactly_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(*packet_id != 0);
                     recv_packet_id = packet_id;
                     BOOST_TEST(topic == "topic1");
@@ -675,17 +663,15 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &recv_packet_id]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::exactly_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::exactly_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(*packet_id != 0);
                     recv_packet_id = packet_id;
                     BOOST_TEST(topic == "topic1");
@@ -722,7 +708,6 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
 
         std::uint16_t pid_sub;
         std::uint16_t pid_unsub;
-
 
         checker chk = {
             // connect
@@ -799,16 +784,14 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
                 });
             c->set_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -886,17 +869,15 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -940,7 +921,6 @@ BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
         std::uint16_t pid_sub;
         std::uint16_t pid_unsub;
 
-
         checker chk = {
             // connect
             cont("h_connack"),
@@ -1015,16 +995,14 @@ BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
                 });
             c->set_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -1101,17 +1079,15 @@ BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -1154,7 +1130,6 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
 
         std::uint16_t pid_sub;
         std::uint16_t pid_unsub;
-
 
         checker chk = {
             // connect
@@ -1223,12 +1198,12 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                     auto topic1 = std::make_shared<std::string>("topic1");
                     auto contents = std::make_shared<std::string>("topic1_contents");
                     c->register_packet_id(1);
-                    c->async_publish_dup(
+                    c->async_publish(
                         1,
                         as::buffer(*topic1),
                         as::buffer(*contents),
                         std::make_pair(topic1, contents),
-                        MQTT_NS::qos::at_least_once
+                        MQTT_NS::qos::at_least_once | MQTT_NS::dup::yes
                     );
                     return true;
                 });
@@ -1242,16 +1217,14 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                 });
             c->set_publish_handler(
                 [&chk]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false); // not propagated
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no); // not propagated
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(packet_id.value() == 1);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -1311,12 +1284,12 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                     auto topic1 = std::make_shared<std::string>("topic1");
                     auto contents = std::make_shared<std::string>("topic1_contents");
                     c->register_packet_id(1);
-                    c->async_publish_dup(
+                    c->async_publish(
                         1,
                         as::buffer(*topic1),
                         as::buffer(*contents),
                         std::make_pair(topic1, contents),
-                        MQTT_NS::qos::at_least_once
+                        MQTT_NS::qos::at_least_once | MQTT_NS::dup::yes
                     );
                     return true;
                 });
@@ -1332,17 +1305,15 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                 });
             c->set_v5_publish_handler(
                 [&chk]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false); // not propagated
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no); // not propagated
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(packet_id.value() == 1);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");

--- a/test/as_buffer_pubsub.cpp
+++ b/test/as_buffer_pubsub.cpp
@@ -82,16 +82,14 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                 });
             c->set_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -149,17 +147,15 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                  bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -272,16 +268,14 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                 });
             c->set_publish_handler(
                 [&chk]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -342,17 +336,15 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -466,16 +458,14 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                 });
             c->set_publish_handler(
                 [&chk]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -536,17 +526,15 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -587,7 +575,6 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
 
         std::uint16_t pid_sub;
         std::uint16_t pid_unsub;
-
 
         checker chk = {
             // connect
@@ -650,16 +637,14 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                 });
             c->set_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -717,17 +702,15 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -849,16 +832,14 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                 });
             c->set_publish_handler(
                 [&chk, &recv_packet_id]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(*packet_id != 0);
                     recv_packet_id = packet_id;
                     BOOST_TEST(topic == "topic1");
@@ -919,17 +900,15 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &recv_packet_id]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(*packet_id != 0);
                     recv_packet_id = packet_id;
                     BOOST_TEST(topic == "topic1");
@@ -1048,16 +1027,14 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                 });
             c->set_publish_handler(
                 [&chk, &recv_packet_id]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(*packet_id != 0);
                     recv_packet_id = packet_id;
                     BOOST_TEST(topic == "topic1");
@@ -1119,17 +1096,15 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &recv_packet_id]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(*packet_id != 0);
                     recv_packet_id = packet_id;
                     BOOST_TEST(topic == "topic1");
@@ -1230,16 +1205,14 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                 });
             c->set_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -1297,17 +1270,15 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -1429,16 +1400,14 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                 });
             c->set_publish_handler(
                 [&chk, &recv_packet_id]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(*packet_id != 0);
                     recv_packet_id = packet_id;
                     BOOST_TEST(topic == "topic1");
@@ -1499,17 +1468,15 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &recv_packet_id]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(*packet_id != 0);
                     recv_packet_id = packet_id;
                     BOOST_TEST(topic == "topic1");
@@ -1628,16 +1595,14 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                 });
             c->set_publish_handler(
                 [&chk, &recv_packet_id]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::exactly_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::exactly_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(*packet_id != 0);
                     recv_packet_id = packet_id;
                     BOOST_TEST(topic == "topic1");
@@ -1699,17 +1664,15 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &recv_packet_id]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::exactly_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::exactly_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(*packet_id != 0);
                     recv_packet_id = packet_id;
                     BOOST_TEST(topic == "topic1");
@@ -1810,16 +1773,14 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
                 });
             c->set_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                  bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -1877,17 +1838,15 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -1979,7 +1938,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                     BOOST_TEST(results.size() == 1U);
                     BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
                     BOOST_TEST(c->register_packet_id(1) == true);
-                    c->publish_dup(1, "topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
+                    c->publish(1, "topic1", "topic1_contents", MQTT_NS::qos::at_least_once | MQTT_NS::dup::yes);
                     return true;
                 });
             c->set_unsuback_handler(
@@ -1992,16 +1951,14 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                 });
             c->set_publish_handler(
                 [&chk]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false); // not propagated
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(packet_id.value() == 1);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -2046,7 +2003,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                     BOOST_TEST(reasons.size() == 1U);
                     BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_1);
                     BOOST_TEST(c->register_packet_id(1) == true);
-                    c->publish_dup(1, "topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
+                    c->publish(1, "topic1", "topic1_contents", MQTT_NS::qos::at_least_once | MQTT_NS::dup::yes);
                     return true;
                 });
             c->set_v5_unsuback_handler(
@@ -2061,17 +2018,15 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                 });
             c->set_v5_publish_handler(
                 [&chk]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false); // not propagated
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(packet_id.value() == 1);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");

--- a/test/async_pubsub_1.cpp
+++ b/test/async_pubsub_1.cpp
@@ -68,16 +68,14 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                 });
             c->set_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -137,17 +135,15 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -284,16 +280,14 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                 });
             c->set_publish_handler(
                 [&chk]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -360,17 +354,15 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -484,16 +476,14 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                 });
             c->set_publish_handler(
                 [&chk]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -556,17 +546,15 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -672,16 +660,14 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                 });
             c->set_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -741,17 +727,15 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -874,16 +858,14 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                 });
             c->set_publish_handler(
                 [&chk, &recv_packet_id]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(*packet_id != 0);
                     recv_packet_id = packet_id;
                     BOOST_TEST(topic == "topic1");
@@ -944,17 +926,15 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &recv_packet_id]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(*packet_id != 0);
                     recv_packet_id = packet_id;
                     BOOST_TEST(topic == "topic1");
@@ -1073,16 +1053,14 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                 });
             c->set_publish_handler(
                 [&chk, &recv_packet_id]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(*packet_id != 0);
                     recv_packet_id = packet_id;
                     BOOST_TEST(topic == "topic1");
@@ -1146,17 +1124,15 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &recv_packet_id]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(*packet_id != 0);
                     recv_packet_id = packet_id;
                     BOOST_TEST(topic == "topic1");

--- a/test/async_pubsub_2.cpp
+++ b/test/async_pubsub_2.cpp
@@ -88,16 +88,14 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                 });
             c->set_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -157,17 +155,15 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -290,16 +286,14 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                 });
             c->set_publish_handler(
                 [&chk, &recv_packet_id]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(*packet_id != 0);
                     recv_packet_id = packet_id;
                     BOOST_TEST(topic == "topic1");
@@ -362,17 +356,15 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &recv_packet_id]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(*packet_id != 0);
                     recv_packet_id = packet_id;
                     BOOST_TEST(topic == "topic1");
@@ -492,16 +484,14 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                 });
             c->set_publish_handler(
                 [&chk, &recv_packet_id]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::exactly_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::exactly_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(*packet_id != 0);
                     recv_packet_id = packet_id;
                     BOOST_TEST(topic == "topic1");
@@ -565,17 +555,15 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &recv_packet_id]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::exactly_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::exactly_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(*packet_id != 0);
                     recv_packet_id = packet_id;
                     BOOST_TEST(topic == "topic1");
@@ -677,16 +665,14 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
                 });
             c->set_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -746,17 +732,15 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -851,7 +835,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                     BOOST_TEST(results.size() == 1U);
                     BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
                     c->register_packet_id(1);
-                    c->async_publish_dup(1, "topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
+                    c->async_publish(1, "topic1", "topic1_contents", MQTT_NS::qos::at_least_once | MQTT_NS::dup::yes);
                     return true;
                 });
             c->set_unsuback_handler(
@@ -864,16 +848,14 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                 });
             c->set_publish_handler(
                 [&chk]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false); // not propagated
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(packet_id.value() == 1);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -920,7 +902,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                     BOOST_TEST(reasons.size() == 1U);
                     BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_1);
                     c->register_packet_id(1);
-                    c->async_publish_dup(1, "topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
+                    c->async_publish(1, "topic1", "topic1_contents", MQTT_NS::qos::at_least_once | MQTT_NS::dup::yes);
                     return true;
                 });
             c->set_v5_unsuback_handler(
@@ -935,17 +917,15 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                 });
             c->set_v5_publish_handler(
                 [&chk]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false); // not propagated
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(packet_id.value() == 1);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -975,7 +955,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
     do_combi_test_async(test);
 }
 
-BOOST_AUTO_TEST_CASE( publish_dup_function_buffer ) {
+BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_clean_session(true);
@@ -1038,7 +1018,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function_buffer ) {
                     BOOST_TEST(results.size() == 1U);
                     BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
                     c->register_packet_id(1);
-                    c->async_publish_dup(1, "topic1"_mb, "topic1_contents"_mb, MQTT_NS::qos::at_least_once);
+                    c->async_publish(1, "topic1"_mb, "topic1_contents"_mb, MQTT_NS::qos::at_least_once | MQTT_NS::dup::yes);
                     return true;
                 });
             c->set_unsuback_handler(
@@ -1051,16 +1031,14 @@ BOOST_AUTO_TEST_CASE( publish_dup_function_buffer ) {
                 });
             c->set_publish_handler(
                 [&chk]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false); // not propagated
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(packet_id.value() == 1);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -1107,7 +1085,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function_buffer ) {
                     BOOST_TEST(reasons.size() == 1U);
                     BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_1);
                     c->register_packet_id(1);
-                    c->async_publish_dup(1, "topic1"_mb, "topic1_contents"_mb, MQTT_NS::qos::at_least_once);
+                    c->async_publish(1, "topic1"_mb, "topic1_contents"_mb, MQTT_NS::qos::at_least_once | MQTT_NS::dup::yes);
                     return true;
                 });
             c->set_v5_unsuback_handler(
@@ -1122,17 +1100,15 @@ BOOST_AUTO_TEST_CASE( publish_dup_function_buffer ) {
                 });
             c->set_v5_publish_handler(
                 [&chk]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false); // not propagated
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(packet_id.value() == 1);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -1219,7 +1195,7 @@ BOOST_AUTO_TEST_CASE( pub_sub_prop ) {
                 BOOST_TEST(packet_id == pid_sub);
                 BOOST_TEST(reasons.size() == 1U);
                 BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_0);
-                c->async_publish("topic1", "topic1_contents", MQTT_NS::qos::at_most_once, false, std::move(ps));
+                c->async_publish("topic1", "topic1_contents", MQTT_NS::qos::at_most_once | MQTT_NS::retain::no, std::move(ps));
                 return true;
             });
         c->set_v5_unsuback_handler(
@@ -1234,17 +1210,15 @@ BOOST_AUTO_TEST_CASE( pub_sub_prop ) {
             });
         c->set_v5_publish_handler(
             [&chk, &c, &pid_unsub, &user_prop_count, prop_size]
-            (bool is_dup,
-             MQTT_NS::qos qos_value,
-             bool is_retain,
-             MQTT_NS::optional<packet_id_t> packet_id,
+            (MQTT_NS::optional<packet_id_t> packet_id,
+             MQTT_NS::publish_options pubopts,
              MQTT_NS::buffer topic,
              MQTT_NS::buffer contents,
              MQTT_NS::v5::properties props) {
                 MQTT_CHK("h_publish");
-                BOOST_TEST(is_dup == false);
-                BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                BOOST_TEST(is_retain == false);
+                BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                 BOOST_CHECK(!packet_id);
                 BOOST_TEST(topic == "topic1");
                 BOOST_TEST(contents == "topic1_contents");
@@ -1473,17 +1447,15 @@ BOOST_AUTO_TEST_CASE( puback_props ) {
             });
         c->set_v5_publish_handler(
             [&chk, &c, &recv_packet_id, pubackps = std::move(pubackps)]
-            (bool is_dup,
-             MQTT_NS::qos qos_value,
-             bool is_retain,
-             MQTT_NS::optional<packet_id_t> packet_id,
+            (MQTT_NS::optional<packet_id_t> packet_id,
+             MQTT_NS::publish_options pubopts,
              MQTT_NS::buffer topic,
              MQTT_NS::buffer contents,
              MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_publish");
-                BOOST_TEST(is_dup == false);
-                BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                BOOST_TEST(is_retain == false);
+                BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                 BOOST_TEST(*packet_id != 0);
                 recv_packet_id = packet_id;
                 BOOST_TEST(topic == "topic1");
@@ -1741,17 +1713,15 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
             });
         c->set_v5_publish_handler(
             [&chk, &c, &recv_packet_id, pubrecps = std::move(pubrecps)]
-            (bool is_dup,
-             MQTT_NS::qos qos_value,
-             bool is_retain,
-             MQTT_NS::optional<packet_id_t> packet_id,
+            (MQTT_NS::optional<packet_id_t> packet_id,
+             MQTT_NS::publish_options pubopts,
              MQTT_NS::buffer topic,
              MQTT_NS::buffer contents,
              MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_publish");
-                BOOST_TEST(is_dup == false);
-                BOOST_TEST(qos_value == MQTT_NS::qos::exactly_once);
-                BOOST_TEST(is_retain == false);
+                BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::exactly_once);
+                BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                 BOOST_TEST(*packet_id != 0);
                 recv_packet_id = packet_id;
                 BOOST_TEST(topic == "topic1");

--- a/test/length_check.cpp
+++ b/test/length_check.cpp
@@ -65,10 +65,8 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
             });
         c->set_publish_handler(
             []
-            (bool /* is_dup */,
-             MQTT_NS::qos /* qos_value */,
-             bool /* is_retain */,
-             MQTT_NS::optional<packet_id_t> ,
+            (MQTT_NS::optional<packet_id_t> /*packet_id*/,
+             MQTT_NS::publish_options /*pubopts*/,
              MQTT_NS::buffer /*topic*/,
              MQTT_NS::buffer /*contents*/) {
                 BOOST_CHECK(false);

--- a/test/manual_publish.cpp
+++ b/test/manual_publish.cpp
@@ -91,15 +91,13 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                 });
             c->set_publish_handler(
                 [&chk]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -168,16 +166,14 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");

--- a/test/message.cpp
+++ b/test/message.cpp
@@ -18,7 +18,7 @@ using namespace MQTT_NS::literals;
 
 BOOST_AUTO_TEST_CASE( connect_cbuf ) {
     auto cid = "cid"_mb;
-    MQTT_NS::optional<MQTT_NS::will> w = MQTT_NS::will("wt"_mb, "wmsg"_mb, false, MQTT_NS::qos::at_most_once);
+    MQTT_NS::optional<MQTT_NS::will> w = MQTT_NS::will("wt"_mb, "wmsg"_mb, MQTT_NS::retain::no | MQTT_NS::qos::at_most_once);
     MQTT_NS::optional<MQTT_NS::buffer> user = "user"_mb;
     MQTT_NS::optional<MQTT_NS::buffer> password = "pw"_mb;
     auto m = MQTT_NS::connect_message(

--- a/test/multi_sub.cpp
+++ b/test/multi_sub.cpp
@@ -108,15 +108,13 @@ BOOST_AUTO_TEST_CASE( multi_channel ) {
             });
         c->set_publish_handler(
             [&chk, &c, &pid_unsub]
-            (bool is_dup,
-             MQTT_NS::qos qos_value,
-             bool is_retain,
-             MQTT_NS::optional<packet_id_t> packet_id,
+            (MQTT_NS::optional<packet_id_t> packet_id,
+             MQTT_NS::publish_options pubopts,
              MQTT_NS::buffer topic,
              MQTT_NS::buffer contents) {
-                BOOST_TEST(is_dup == false);
-                BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                BOOST_TEST(is_retain == false);
+            BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+            BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+            BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                 BOOST_CHECK(!packet_id);
                 auto ret = chk.match(
                     "h_suback",
@@ -272,16 +270,14 @@ BOOST_AUTO_TEST_CASE( multi_client_qos0 ) {
         });
     c1->set_publish_handler(
         [&chk, &c1, &pid_unsub1]
-        (bool is_dup,
-         MQTT_NS::qos qos_value,
-         bool is_retain,
-         MQTT_NS::optional<packet_id_t> packet_id,
+        (MQTT_NS::optional<packet_id_t> packet_id,
+         MQTT_NS::publish_options pubopts,
          MQTT_NS::buffer topic,
          MQTT_NS::buffer contents) {
             MQTT_CHK("h_publish_1");
-            BOOST_TEST(is_dup == false);
-            BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-            BOOST_TEST(is_retain == false);
+            BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+            BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+            BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
             BOOST_CHECK(!packet_id);
             BOOST_TEST(topic == "topic1");
             BOOST_TEST(contents == "topic1_contents");
@@ -355,16 +351,14 @@ BOOST_AUTO_TEST_CASE( multi_client_qos0 ) {
         });
     c2->set_publish_handler(
         [&chk, &c2, &pid_unsub2]
-        (bool is_dup,
-         MQTT_NS::qos qos_value,
-         bool is_retain,
-         MQTT_NS::optional<packet_id_t> packet_id,
+        (MQTT_NS::optional<packet_id_t> packet_id,
+         MQTT_NS::publish_options pubopts,
          MQTT_NS::buffer topic,
          MQTT_NS::buffer contents) {
             MQTT_CHK("h_publish_2");
-            BOOST_TEST(is_dup == false);
-            BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-            BOOST_TEST(is_retain == false);
+            BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+            BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+            BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
             BOOST_CHECK(!packet_id);
             BOOST_TEST(topic == "topic1");
             BOOST_TEST(contents == "topic1_contents");
@@ -503,16 +497,14 @@ BOOST_AUTO_TEST_CASE( multi_client_qos1 ) {
         });
     c1->set_publish_handler(
         [&chk, &c1, &pid_unsub1]
-        (bool is_dup,
-         MQTT_NS::qos qos_value,
-         bool is_retain,
-         MQTT_NS::optional<packet_id_t> packet_id,
+        (MQTT_NS::optional<packet_id_t> packet_id,
+         MQTT_NS::publish_options pubopts,
          MQTT_NS::buffer topic,
          MQTT_NS::buffer contents) {
             MQTT_CHK("h_publish_1");
-            BOOST_TEST(is_dup == false);
-            BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-            BOOST_TEST(is_retain == false);
+            BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+            BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+            BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
             BOOST_TEST(*packet_id != 0);
             BOOST_TEST(topic == "topic1");
             BOOST_TEST(contents == "topic1_contents");
@@ -567,16 +559,14 @@ BOOST_AUTO_TEST_CASE( multi_client_qos1 ) {
         });
     c2->set_publish_handler(
         [&chk, &c2, &pid_unsub2]
-        (bool is_dup,
-         MQTT_NS::qos qos_value,
-         bool is_retain,
-         MQTT_NS::optional<packet_id_t> packet_id,
+        (MQTT_NS::optional<packet_id_t> packet_id,
+         MQTT_NS::publish_options pubopts,
          MQTT_NS::buffer topic,
          MQTT_NS::buffer contents) {
             MQTT_CHK("h_publish_2");
-            BOOST_TEST(is_dup == false);
-            BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-            BOOST_TEST(is_retain == false);
+            BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+            BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+            BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
             BOOST_TEST(*packet_id != 0);
             BOOST_TEST(topic == "topic1");
             BOOST_TEST(contents == "topic1_contents");

--- a/test/offline.cpp
+++ b/test/offline.cpp
@@ -549,8 +549,7 @@ BOOST_AUTO_TEST_CASE( async_publish_qos1 ) {
                             pid_pub,
                             "topic1",
                             "topic1_contents",
-                            MQTT_NS::qos::at_least_once,
-                            false, // retain
+                            MQTT_NS::qos::at_least_once  | MQTT_NS::retain::no,
                             [&chk](MQTT_NS::error_code ec){
                                 BOOST_TEST( ! ec);
                                 MQTT_CHK("h_pub_finish");

--- a/test/pubsub.cpp
+++ b/test/pubsub.cpp
@@ -83,16 +83,14 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                 });
             c->set_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -150,17 +148,15 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -277,16 +273,14 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                 });
             c->set_publish_handler(
                 [&chk]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -351,17 +345,15 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -475,16 +467,14 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                 });
             c->set_publish_handler(
                 [&chk]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -545,17 +535,15 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -659,16 +647,14 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                 });
             c->set_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -726,17 +712,15 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -857,16 +841,14 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                 });
             c->set_publish_handler(
                 [&chk, &recv_packet_id]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(*packet_id != 0);
                     recv_packet_id = packet_id;
                     BOOST_TEST(topic == "topic1");
@@ -927,17 +909,15 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &recv_packet_id]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(*packet_id != 0);
                     recv_packet_id = packet_id;
                     BOOST_TEST(topic == "topic1");
@@ -1055,16 +1035,14 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                 });
             c->set_publish_handler(
                 [&chk, &recv_packet_id]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(*packet_id != 0);
                     recv_packet_id = packet_id;
                     BOOST_TEST(topic == "topic1");
@@ -1126,17 +1104,15 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &recv_packet_id]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(*packet_id != 0);
                     recv_packet_id = packet_id;
                     BOOST_TEST(topic == "topic1");
@@ -1243,16 +1219,14 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                 });
             c->set_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -1310,17 +1284,15 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -1437,16 +1409,14 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                 });
             c->set_publish_handler(
                 [&chk, &recv_packet_id]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(*packet_id != 0);
                     recv_packet_id = packet_id;
                     BOOST_TEST(topic == "topic1");
@@ -1507,17 +1477,15 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &recv_packet_id]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(*packet_id != 0);
                     recv_packet_id = packet_id;
                     BOOST_TEST(topic == "topic1");
@@ -1636,16 +1604,14 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                 });
             c->set_publish_handler(
                 [&chk, &recv_packet_id]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::exactly_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::exactly_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(*packet_id != 0);
                     recv_packet_id = packet_id;
                     BOOST_TEST(topic == "topic1");
@@ -1707,17 +1673,15 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &recv_packet_id]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::exactly_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::exactly_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_TEST(*packet_id != 0);
                     recv_packet_id = packet_id;
                     BOOST_TEST(topic == "topic1");
@@ -1818,16 +1782,14 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
                 });
             c->set_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -1885,17 +1847,15 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -1996,16 +1956,14 @@ BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
                 });
             c->set_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -2063,17 +2021,15 @@ BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -2165,7 +2121,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                     BOOST_TEST(results.size() == 1U);
                     BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
                     BOOST_TEST(c->register_packet_id(1) == true);
-                    c->publish_dup(1, "topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
+                    c->publish(1, "topic1", "topic1_contents", MQTT_NS::qos::at_least_once | MQTT_NS::dup::yes);
                     return true;
                 });
             c->set_unsuback_handler(
@@ -2178,16 +2134,14 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                 });
             c->set_publish_handler(
                 [&chk]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false); // not propagated
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(packet_id.value() == 1);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -2232,7 +2186,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                     BOOST_TEST(reasons.size() == 1U);
                     BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_1);
                     BOOST_TEST(c->register_packet_id(1) == true);
-                    c->publish_dup(1, "topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
+                    c->publish(1, "topic1", "topic1_contents", MQTT_NS::qos::at_least_once | MQTT_NS::dup::yes);
                     return true;
                 });
             c->set_v5_unsuback_handler(
@@ -2247,17 +2201,15 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
                 });
             c->set_v5_publish_handler(
                 [&chk]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false); // not propagated
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(packet_id.value() == 1);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -2348,7 +2300,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function_buffer ) {
                     BOOST_TEST(results.size() == 1U);
                     BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
                     BOOST_TEST(c->register_packet_id(1) == true);
-                    c->publish_dup(1, "topic1"_mb, "topic1_contents"_mb, MQTT_NS::qos::at_least_once);
+                    c->publish(1, "topic1"_mb, "topic1_contents"_mb, MQTT_NS::qos::at_least_once | MQTT_NS::dup::yes);
                     return true;
                 });
             c->set_unsuback_handler(
@@ -2361,16 +2313,14 @@ BOOST_AUTO_TEST_CASE( publish_dup_function_buffer ) {
                 });
             c->set_publish_handler(
                 [&chk]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false); // not propagated
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(packet_id.value() == 1);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -2415,7 +2365,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function_buffer ) {
                     BOOST_TEST(reasons.size() == 1U);
                     BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_1);
                     BOOST_TEST(c->register_packet_id(1) == true);
-                    c->publish_dup(1, "topic1"_mb, "topic1_contents"_mb, MQTT_NS::qos::at_least_once);
+                    c->publish(1, "topic1"_mb, "topic1_contents"_mb, MQTT_NS::qos::at_least_once | MQTT_NS::dup::yes);
                     return true;
                 });
             c->set_v5_unsuback_handler(
@@ -2430,17 +2380,15 @@ BOOST_AUTO_TEST_CASE( publish_dup_function_buffer ) {
                 });
             c->set_v5_publish_handler(
                 [&chk]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false); // not propagated
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                    BOOST_TEST(is_retain == false);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                     BOOST_CHECK(packet_id.value() == 1);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -2544,7 +2492,7 @@ BOOST_AUTO_TEST_CASE( pub_sub_prop ) {
                 BOOST_TEST(packet_id == pid_sub);
                 BOOST_TEST(reasons.size() == 1U);
                 BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_0);
-                c->publish("topic1", "topic1_contents", MQTT_NS::qos::at_most_once, false, std::move(ps));
+                c->publish("topic1", "topic1_contents", MQTT_NS::qos::at_most_once | MQTT_NS::retain::no, std::move(ps));
                 return true;
             });
         c->set_v5_unsuback_handler(
@@ -2559,17 +2507,15 @@ BOOST_AUTO_TEST_CASE( pub_sub_prop ) {
             });
         c->set_v5_publish_handler(
             [&chk, &c, &pid_unsub, &user_prop_count, prop_size]
-            (bool is_dup,
-             MQTT_NS::qos qos_value,
-             bool is_retain,
-             MQTT_NS::optional<packet_id_t> packet_id,
+            (MQTT_NS::optional<packet_id_t> packet_id,
+             MQTT_NS::publish_options pubopts,
              MQTT_NS::buffer topic,
              MQTT_NS::buffer contents,
              MQTT_NS::v5::properties props) {
                 MQTT_CHK("h_publish");
-                BOOST_TEST(is_dup == false);
-                BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                BOOST_TEST(is_retain == false);
+                BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                 BOOST_CHECK(!packet_id);
                 BOOST_TEST(topic == "topic1");
                 BOOST_TEST(contents == "topic1_contents");
@@ -2780,17 +2726,15 @@ BOOST_AUTO_TEST_CASE( puback_prop ) {
             });
         c->set_v5_publish_handler(
             [&chk, &recv_packet_id]
-            (bool is_dup,
-             MQTT_NS::qos qos_value,
-             bool is_retain,
-             MQTT_NS::optional<packet_id_t> packet_id,
+            (MQTT_NS::optional<packet_id_t> packet_id,
+             MQTT_NS::publish_options pubopts,
              MQTT_NS::buffer topic,
              MQTT_NS::buffer contents,
              MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_publish");
-                BOOST_TEST(is_dup == false);
-                BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-                BOOST_TEST(is_retain == false);
+                BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                 BOOST_TEST(*packet_id != 0);
                 recv_packet_id = packet_id;
                 BOOST_TEST(topic == "topic1");
@@ -3032,17 +2976,15 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
             });
         c->set_v5_publish_handler(
             [&chk, &c, &recv_packet_id]
-            (bool is_dup,
-             MQTT_NS::qos qos_value,
-             bool is_retain,
-             MQTT_NS::optional<packet_id_t> packet_id,
+            (MQTT_NS::optional<packet_id_t> packet_id,
+             MQTT_NS::publish_options pubopts,
              MQTT_NS::buffer topic,
              MQTT_NS::buffer contents,
              MQTT_NS::v5::properties /*props*/) {
                 MQTT_CHK("h_publish");
-                BOOST_TEST(is_dup == false);
-                BOOST_TEST(qos_value == MQTT_NS::qos::exactly_once);
-                BOOST_TEST(is_retain == false);
+                BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::exactly_once);
+                BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                 BOOST_TEST(*packet_id != 0);
                 recv_packet_id = packet_id;
                 BOOST_TEST(topic == "topic1");

--- a/test/pubsub_no_strand.cpp
+++ b/test/pubsub_no_strand.cpp
@@ -120,16 +120,14 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
         });
     c->set_publish_handler(
         [&chk, &c, &pid_unsub]
-        (bool is_dup,
-         MQTT_NS::qos qos_value,
-         bool is_retain,
-         MQTT_NS::optional<packet_id_t> packet_id,
+        (MQTT_NS::optional<packet_id_t> packet_id,
+         MQTT_NS::publish_options pubopts,
          MQTT_NS::buffer topic,
          MQTT_NS::buffer contents) {
             MQTT_CHK("h_publish");
-            BOOST_TEST(is_dup == false);
-            BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-            BOOST_TEST(is_retain == false);
+            BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+            BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+            BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
             BOOST_CHECK(!packet_id);
             BOOST_TEST(topic == "topic1");
             BOOST_TEST(contents == "topic1_contents");
@@ -249,16 +247,14 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
         });
     c->set_publish_handler(
         [&chk]
-        (bool is_dup,
-         MQTT_NS::qos qos_value,
-         bool is_retain,
-         MQTT_NS::optional<packet_id_t> packet_id,
+        (MQTT_NS::optional<packet_id_t> packet_id,
+         MQTT_NS::publish_options pubopts,
          MQTT_NS::buffer topic,
          MQTT_NS::buffer contents) {
             MQTT_CHK("h_publish");
-            BOOST_TEST(is_dup == false);
-            BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-            BOOST_TEST(is_retain == false);
+            BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+            BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+            BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
             BOOST_TEST(!packet_id);
             BOOST_TEST(topic == "topic1");
             BOOST_TEST(contents == "topic1_contents");
@@ -378,16 +374,14 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
         });
     c->set_publish_handler(
         [&chk]
-        (bool is_dup,
-         MQTT_NS::qos qos_value,
-         bool is_retain,
-         MQTT_NS::optional<packet_id_t> packet_id,
+        (MQTT_NS::optional<packet_id_t> packet_id,
+         MQTT_NS::publish_options pubopts,
          MQTT_NS::buffer topic,
          MQTT_NS::buffer contents) {
             MQTT_CHK("h_publish");
-            BOOST_TEST(is_dup == false);
-            BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-            BOOST_TEST(is_retain == false);
+            BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+            BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+            BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
             BOOST_CHECK(!packet_id);
             BOOST_TEST(topic == "topic1");
             BOOST_TEST(contents == "topic1_contents");
@@ -501,16 +495,14 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
         });
     c->set_publish_handler(
         [&chk, &c, &pid_unsub]
-        (bool is_dup,
-         MQTT_NS::qos qos_value,
-         bool is_retain,
-         MQTT_NS::optional<packet_id_t> packet_id,
+        (MQTT_NS::optional<packet_id_t> packet_id,
+         MQTT_NS::publish_options pubopts,
          MQTT_NS::buffer topic,
          MQTT_NS::buffer contents) {
             MQTT_CHK("h_publish");
-            BOOST_TEST(is_dup == false);
-            BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-            BOOST_TEST(is_retain == false);
+            BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+            BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+            BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
             BOOST_CHECK(!packet_id);
             BOOST_TEST(topic == "topic1");
             BOOST_TEST(contents == "topic1_contents");
@@ -637,16 +629,14 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
         });
     c->set_publish_handler(
         [&chk, &recv_packet_id]
-        (bool is_dup,
-         MQTT_NS::qos qos_value,
-         bool is_retain,
-         MQTT_NS::optional<packet_id_t> packet_id,
+        (MQTT_NS::optional<packet_id_t> packet_id,
+         MQTT_NS::publish_options pubopts,
          MQTT_NS::buffer topic,
          MQTT_NS::buffer contents) {
             MQTT_CHK("h_publish");
-            BOOST_TEST(is_dup == false);
-            BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-            BOOST_TEST(is_retain == false);
+            BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+            BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+            BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
             BOOST_TEST(*packet_id != 0);
             recv_packet_id = packet_id;
             BOOST_TEST(topic == "topic1");
@@ -775,16 +765,14 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
         });
     c->set_publish_handler(
         [&chk, &recv_packet_id]
-        (bool is_dup,
-         MQTT_NS::qos qos_value,
-         bool is_retain,
-         MQTT_NS::optional<packet_id_t> packet_id,
+        (MQTT_NS::optional<packet_id_t> packet_id,
+         MQTT_NS::publish_options pubopts,
          MQTT_NS::buffer topic,
          MQTT_NS::buffer contents) {
             MQTT_CHK("h_publish");
-            BOOST_TEST(is_dup == false);
-            BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-            BOOST_TEST(is_retain == false);
+            BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+            BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+            BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
             BOOST_TEST(*packet_id != 0);
             recv_packet_id = packet_id;
             BOOST_TEST(topic == "topic1");
@@ -900,16 +888,14 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
         });
     c->set_publish_handler(
         [&chk, &c, &pid_unsub]
-        (bool is_dup,
-         MQTT_NS::qos qos_value,
-         bool is_retain,
-         MQTT_NS::optional<packet_id_t> packet_id,
+        (MQTT_NS::optional<packet_id_t> packet_id,
+         MQTT_NS::publish_options pubopts,
          MQTT_NS::buffer topic,
          MQTT_NS::buffer contents) {
             MQTT_CHK("h_publish");
-            BOOST_TEST(is_dup == false);
-            BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-            BOOST_TEST(is_retain == false);
+            BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+            BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+            BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
             BOOST_CHECK(!packet_id);
             BOOST_TEST(topic == "topic1");
             BOOST_TEST(contents == "topic1_contents");
@@ -1037,16 +1023,14 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
         });
     c->set_publish_handler(
         [&chk, &recv_packet_id]
-        (bool is_dup,
-         MQTT_NS::qos qos_value,
-         bool is_retain,
-         MQTT_NS::optional<packet_id_t> packet_id,
+        (MQTT_NS::optional<packet_id_t> packet_id,
+         MQTT_NS::publish_options pubopts,
          MQTT_NS::buffer topic,
          MQTT_NS::buffer contents) {
             MQTT_CHK("h_publish");
-            BOOST_TEST(is_dup == false);
-            BOOST_TEST(qos_value == MQTT_NS::qos::at_least_once);
-            BOOST_TEST(is_retain == false);
+            BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+            BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+            BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
             BOOST_TEST(*packet_id != 0);
             recv_packet_id = packet_id;
             BOOST_TEST(topic == "topic1");
@@ -1176,16 +1160,14 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
         });
     c->set_publish_handler(
         [&chk, &recv_packet_id]
-        (bool is_dup,
-         MQTT_NS::qos qos_value,
-         bool is_retain,
-         MQTT_NS::optional<packet_id_t> packet_id,
+        (MQTT_NS::optional<packet_id_t> packet_id,
+         MQTT_NS::publish_options pubopts,
          MQTT_NS::buffer topic,
          MQTT_NS::buffer contents) {
             MQTT_CHK("h_publish");
-            BOOST_TEST(is_dup == false);
-            BOOST_TEST(qos_value == MQTT_NS::qos::exactly_once);
-            BOOST_TEST(is_retain == false);
+            BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+            BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::exactly_once);
+            BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
             BOOST_TEST(*packet_id != 0);
             recv_packet_id = packet_id;
             BOOST_TEST(topic == "topic1");
@@ -1301,16 +1283,14 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
         });
     c->set_publish_handler(
         [&chk, &c, &pid_unsub]
-        (bool is_dup,
-         MQTT_NS::qos qos_value,
-         bool is_retain,
-         MQTT_NS::optional<packet_id_t> packet_id,
+        (MQTT_NS::optional<packet_id_t> packet_id,
+         MQTT_NS::publish_options pubopts,
          MQTT_NS::buffer topic,
          MQTT_NS::buffer contents) {
             MQTT_CHK("h_publish");
-            BOOST_TEST(is_dup == false);
-            BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-            BOOST_TEST(is_retain == false);
+            BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+            BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+            BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
             BOOST_CHECK(!packet_id);
             BOOST_TEST(topic == "topic1");
             BOOST_TEST(contents == "topic1_contents");

--- a/test/remaining_length.cpp
+++ b/test/remaining_length.cpp
@@ -101,16 +101,14 @@ BOOST_AUTO_TEST_CASE( pub_sub_over_127 ) {
             });
         c->set_publish_handler(
             [&chk, &c, &pid_unsub, &test_contents]
-            (bool is_dup,
-             MQTT_NS::qos qos_value,
-             bool is_retain,
-             MQTT_NS::optional<packet_id_t> packet_id,
+            (MQTT_NS::optional<packet_id_t> packet_id,
+             MQTT_NS::publish_options pubopts,
              MQTT_NS::buffer topic,
              MQTT_NS::buffer contents) {
                 MQTT_CHK("h_publish");
-                BOOST_TEST(is_dup == false);
-                BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                BOOST_TEST(is_retain == false);
+                BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                 BOOST_CHECK(!packet_id);
                 BOOST_TEST(topic == "topic1");
                 BOOST_TEST(contents == test_contents);
@@ -213,16 +211,14 @@ BOOST_AUTO_TEST_CASE( pub_sub_over_16384 ) {
             });
         c->set_publish_handler(
             [&chk, &c, &pid_unsub, &test_contents]
-            (bool is_dup,
-             MQTT_NS::qos qos_value,
-             bool is_retain,
-             MQTT_NS::optional<packet_id_t> packet_id,
+            (MQTT_NS::optional<packet_id_t> packet_id,
+             MQTT_NS::publish_options pubopts,
              MQTT_NS::buffer topic,
              MQTT_NS::buffer contents) {
                 MQTT_CHK("h_publish");
-                BOOST_TEST(is_dup == false);
-                BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                BOOST_TEST(is_retain == false);
+                BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                 BOOST_CHECK(!packet_id);
                 BOOST_TEST(topic == "topic1");
                 BOOST_TEST(contents == test_contents);
@@ -327,16 +323,14 @@ BOOST_AUTO_TEST_CASE( pub_sub_over_2097152 ) {
             });
         c->set_publish_handler(
             [&chk, &c, &pid_unsub, &test_contents]
-            (bool is_dup,
-             MQTT_NS::qos qos_value,
-             bool is_retain,
-             MQTT_NS::optional<packet_id_t> packet_id,
+            (MQTT_NS::optional<packet_id_t> packet_id,
+             MQTT_NS::publish_options pubopts,
              MQTT_NS::buffer topic,
              MQTT_NS::buffer contents) {
                 MQTT_CHK("h_publish");
-                BOOST_TEST(is_dup == false);
-                BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                BOOST_TEST(is_retain == false);
+                BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                 BOOST_CHECK(!packet_id);
                 BOOST_TEST(topic == "topic1");
                 BOOST_TEST(contents == test_contents);

--- a/test/resend.cpp
+++ b/test/resend.cpp
@@ -167,7 +167,7 @@ BOOST_AUTO_TEST_CASE( publish_qos1 ) {
                             // The previous connection is not set Session Expiry Interval.
                             // That means session state is cleared on close.
                             BOOST_TEST(sp == false);
-                            pid_pub = c->publish("topic1", "topic1_contents", MQTT_NS::qos::at_least_once, false, std::move(ps));
+                            pid_pub = c->publish("topic1", "topic1_contents", MQTT_NS::qos::at_least_once | MQTT_NS::retain::no, std::move(ps));
                             c->force_disconnect();
                         },
                         "h_error",

--- a/test/resend_serialize.cpp
+++ b/test/resend_serialize.cpp
@@ -15,9 +15,7 @@ using namespace MQTT_NS::literals;
 
 template <typename Client, typename Packet>
 inline
-typename std::enable_if<
-    sizeof(typename Client::element_type::packet_id_t) == 2
->::type
+std::enable_if_t< sizeof(typename Client::element_type::packet_id_t) == 2 >
 restore_serialized_publish_message(Client const& c, Packet const& packet) {
     c->restore_serialized_message(
         MQTT_NS::publish_message(MQTT_NS::buffer(MQTT_NS::string_view(packet.data(), packet.size()))),
@@ -27,9 +25,7 @@ restore_serialized_publish_message(Client const& c, Packet const& packet) {
 
 template <typename Client, typename Packet>
 inline
-typename std::enable_if<
-    sizeof(typename Client::element_type::packet_id_t) == 4
->::type
+std::enable_if_t< sizeof(typename Client::element_type::packet_id_t) == 4 >
 restore_serialized_publish_message(Client const& c, Packet const& packet) {
     c->restore_serialized_message(
         MQTT_NS::publish_32_message(MQTT_NS::buffer(MQTT_NS::string_view(packet.data(), packet.size()))),
@@ -39,9 +35,7 @@ restore_serialized_publish_message(Client const& c, Packet const& packet) {
 
 template <typename Client, typename Packet>
 inline
-typename std::enable_if<
-    sizeof(typename Client::element_type::packet_id_t) == 2
->::type
+std::enable_if_t< sizeof(typename Client::element_type::packet_id_t) == 2 >
 restore_serialized_pubrel_message(Client const& c, Packet const& packet) {
     c->restore_serialized_message(
         MQTT_NS::pubrel_message(MQTT_NS::buffer(MQTT_NS::string_view(packet.data(), packet.size())))
@@ -50,9 +44,7 @@ restore_serialized_pubrel_message(Client const& c, Packet const& packet) {
 
 template <typename Client, typename Packet>
 inline
-typename std::enable_if<
-    sizeof(typename Client::element_type::packet_id_t) == 4
->::type
+std::enable_if_t< sizeof(typename Client::element_type::packet_id_t) == 4 >
 restore_serialized_pubrel_message(Client const& c, Packet const& packet) {
     c->restore_serialized_message(
         MQTT_NS::pubrel_32_message(MQTT_NS::buffer(MQTT_NS::string_view(packet.data(), packet.size())))
@@ -62,9 +54,7 @@ restore_serialized_pubrel_message(Client const& c, Packet const& packet) {
 
 template <typename Client, typename Serialized>
 inline
-typename std::enable_if<
-    sizeof(typename Client::element_type::packet_id_t) == 2
->::type
+std::enable_if_t< sizeof(typename Client::element_type::packet_id_t) == 2 >
 set_serialize_handlers(Client const& c, Serialized& serialized) {
     using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
     c->set_serialize_handlers(
@@ -84,9 +74,7 @@ set_serialize_handlers(Client const& c, Serialized& serialized) {
 
 template <typename Client, typename Serialized>
 inline
-typename std::enable_if<
-    sizeof(typename Client::element_type::packet_id_t) == 4
->::type
+std::enable_if_t< sizeof(typename Client::element_type::packet_id_t) == 4 >
 set_serialize_handlers(Client const& c, Serialized& serialized) {
     using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
     c->set_serialize_handlers(
@@ -767,9 +755,7 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1 ) {
 
 template <typename Client, typename Packet>
 inline
-typename std::enable_if<
-    sizeof(typename Client::element_type::packet_id_t) == 2
->::type
+std::enable_if_t< sizeof(typename Client::element_type::packet_id_t) == 2 >
 restore_v5_serialized_publish_message(Client const& c, Packet const& packet) {
     c->restore_v5_serialized_message(
         MQTT_NS::v5::publish_message(MQTT_NS::buffer(MQTT_NS::string_view(packet.data(), packet.size()))),
@@ -779,9 +765,7 @@ restore_v5_serialized_publish_message(Client const& c, Packet const& packet) {
 
 template <typename Client, typename Packet>
 inline
-typename std::enable_if<
-    sizeof(typename Client::element_type::packet_id_t) == 4
->::type
+std::enable_if_t< sizeof(typename Client::element_type::packet_id_t) == 4 >
 restore_v5_serialized_publish_message(Client const& c, Packet const& packet) {
     c->restore_v5_serialized_message(
         MQTT_NS::v5::publish_32_message(MQTT_NS::buffer(MQTT_NS::string_view(packet.data(), packet.size()))),
@@ -791,9 +775,7 @@ restore_v5_serialized_publish_message(Client const& c, Packet const& packet) {
 
 template <typename Client, typename Packet>
 inline
-typename std::enable_if<
-    sizeof(typename Client::element_type::packet_id_t) == 2
->::type
+std::enable_if_t< sizeof(typename Client::element_type::packet_id_t) == 2 >
 restore_v5_serialized_pubrel_message(Client const& c, Packet const& packet) {
     c->restore_v5_serialized_message(
         MQTT_NS::v5::pubrel_message(MQTT_NS::buffer(MQTT_NS::string_view(packet.data(), packet.size()))),
@@ -803,9 +785,7 @@ restore_v5_serialized_pubrel_message(Client const& c, Packet const& packet) {
 
 template <typename Client, typename Packet>
 inline
-typename std::enable_if<
-    sizeof(typename Client::element_type::packet_id_t) == 4
->::type
+std::enable_if_t< sizeof(typename Client::element_type::packet_id_t) == 4 >
 restore_v5_serialized_pubrel_message(Client const& c, Packet const& packet) {
     c->restore_v5_serialized_message(
         MQTT_NS::v5::pubrel_32_message(MQTT_NS::buffer(MQTT_NS::string_view(packet.data(), packet.size()))),
@@ -816,9 +796,7 @@ restore_v5_serialized_pubrel_message(Client const& c, Packet const& packet) {
 
 template <typename Client, typename Serialized>
 inline
-typename std::enable_if<
-    sizeof(typename Client::element_type::packet_id_t) == 2
->::type
+std::enable_if_t< sizeof(typename Client::element_type::packet_id_t) == 2 >
 set_v5_serialize_handlers(Client const& c, Serialized& serialized) {
     using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
     c->set_v5_serialize_handlers(
@@ -838,9 +816,7 @@ set_v5_serialize_handlers(Client const& c, Serialized& serialized) {
 
 template <typename Client, typename Serialized>
 inline
-typename std::enable_if<
-    sizeof(typename Client::element_type::packet_id_t) == 4
->::type
+std::enable_if_t< sizeof(typename Client::element_type::packet_id_t) == 4 >
 set_v5_serialize_handlers(Client const& c, Serialized& serialized) {
     using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
     c->set_v5_serialize_handlers(
@@ -1013,7 +989,7 @@ BOOST_AUTO_TEST_CASE( publish_qos1_v5 ) {
                     // The previous connection is not set Session Expiry Interval.
                     // That means session state is cleared on close.
                     BOOST_TEST(sp == false);
-                    pid_pub = c1->publish("topic1", "topic1_contents", MQTT_NS::qos::at_least_once, false, std::move(ps));
+                    pid_pub = c1->publish("topic1", "topic1_contents", MQTT_NS::retain::no | MQTT_NS::qos::at_least_once, std::move(ps));
                     c1->force_disconnect();
                 }
             );

--- a/test/resend_serialize_ptr_size.cpp
+++ b/test/resend_serialize_ptr_size.cpp
@@ -815,7 +815,7 @@ BOOST_AUTO_TEST_CASE( publish_qos1_v5 ) {
                     // The previous connection is not set Session Expiry Interval.
                     // That means session state is cleared on close.
                     BOOST_TEST(sp == false);
-                    pid_pub = c1->publish("topic1", "topic1_contents", MQTT_NS::qos::at_least_once, false, std::move(ps));
+                    pid_pub = c1->publish("topic1", "topic1_contents", MQTT_NS::retain::no | MQTT_NS::qos::at_least_once, std::move(ps));
                     c1->force_disconnect();
                 }
             );

--- a/test/retain.cpp
+++ b/test/retain.cpp
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE( simple ) {
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
 
-                    c->publish("topic1", "retained_contents", MQTT_NS::qos::at_most_once, true);
+                    c->publish("topic1", "retained_contents", MQTT_NS::qos::at_most_once | MQTT_NS::retain::yes);
 
                     pid_sub = c->subscribe("topic1", MQTT_NS::qos::at_most_once);
                     return true;
@@ -86,16 +86,14 @@ BOOST_AUTO_TEST_CASE( simple ) {
                 });
             c->set_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == true);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::yes);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "retained_contents");
@@ -111,7 +109,7 @@ BOOST_AUTO_TEST_CASE( simple ) {
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
 
-                    c->publish("topic1", "retained_contents", MQTT_NS::qos::at_most_once, true);
+                    c->publish("topic1", "retained_contents", MQTT_NS::qos::at_most_once | MQTT_NS::retain::yes);
 
                     pid_sub = c->subscribe("topic1", MQTT_NS::qos::at_most_once);
                     return true;
@@ -155,17 +153,15 @@ BOOST_AUTO_TEST_CASE( simple ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == true);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::yes);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "retained_contents");
@@ -228,9 +224,9 @@ BOOST_AUTO_TEST_CASE( overwrite ) {
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
 
-                    c->publish("topic1", "retained_contents1", MQTT_NS::qos::at_most_once, true);
-                    c->publish("topic1", "retained_contents2", MQTT_NS::qos::at_most_once, true);
-                    c->publish("topic1", "retained_contents3", MQTT_NS::qos::at_most_once, false);
+                    c->publish("topic1", "retained_contents1", MQTT_NS::qos::at_most_once | MQTT_NS::retain::yes);
+                    c->publish("topic1", "retained_contents2", MQTT_NS::qos::at_most_once | MQTT_NS::retain::yes);
+                    c->publish("topic1", "retained_contents3", MQTT_NS::qos::at_most_once | MQTT_NS::retain::no);
 
                     pid_sub = c->subscribe("topic1", MQTT_NS::qos::at_most_once);
                     return true;
@@ -272,16 +268,14 @@ BOOST_AUTO_TEST_CASE( overwrite ) {
                 });
             c->set_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == true);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::yes);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "retained_contents2");
@@ -297,9 +291,9 @@ BOOST_AUTO_TEST_CASE( overwrite ) {
                     BOOST_TEST(sp == false);
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
 
-                    c->publish("topic1", "retained_contents1", MQTT_NS::qos::at_most_once, true);
-                    c->publish("topic1", "retained_contents2", MQTT_NS::qos::at_most_once, true);
-                    c->publish("topic1", "retained_contents3", MQTT_NS::qos::at_most_once, false);
+                    c->publish("topic1", "retained_contents1", MQTT_NS::qos::at_most_once | MQTT_NS::retain::yes);
+                    c->publish("topic1", "retained_contents2", MQTT_NS::qos::at_most_once | MQTT_NS::retain::yes);
+                    c->publish("topic1", "retained_contents3", MQTT_NS::qos::at_most_once | MQTT_NS::retain::no);
 
                     pid_sub = c->subscribe("topic1", MQTT_NS::qos::at_most_once);
                     return true;
@@ -343,17 +337,15 @@ BOOST_AUTO_TEST_CASE( overwrite ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_publish");
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                    BOOST_TEST(is_retain == true);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::yes);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "retained_contents2");
@@ -450,7 +442,7 @@ BOOST_AUTO_TEST_CASE( retain_and_publish ) {
                         "h_connack",
                         [&] {
                             MQTT_CHK("h_suback1");
-                            c->publish("topic1", "topic1_contents", MQTT_NS::qos::at_most_once, true);
+                            c->publish("topic1", "topic1_contents", MQTT_NS::qos::at_most_once | MQTT_NS::retain::yes);
                         },
                         "h_unsuback1",
                         [&] {
@@ -481,14 +473,12 @@ BOOST_AUTO_TEST_CASE( retain_and_publish ) {
                 });
             c->set_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents) {
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -497,12 +487,12 @@ BOOST_AUTO_TEST_CASE( retain_and_publish ) {
                         "h_suback1",
                         [&] {
                             MQTT_CHK("h_publish1");
-                            BOOST_TEST(is_retain == false);
+                            BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                         },
                         "h_suback2",
                         [&] {
                             MQTT_CHK("h_publish2");
-                            BOOST_TEST(is_retain == true);
+                            BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::yes);
                         }
                     );
                     BOOST_TEST(ret);
@@ -547,7 +537,7 @@ BOOST_AUTO_TEST_CASE( retain_and_publish ) {
                         "h_connack",
                         [&] {
                             MQTT_CHK("h_suback1");
-                            c->publish("topic1", "topic1_contents", MQTT_NS::qos::at_most_once, true);
+                            c->publish("topic1", "topic1_contents", MQTT_NS::qos::at_most_once | MQTT_NS::retain::yes);
                         },
                         "h_unsuback1",
                         [&] {
@@ -580,15 +570,13 @@ BOOST_AUTO_TEST_CASE( retain_and_publish ) {
                 });
             c->set_v5_publish_handler(
                 [&chk, &c, &pid_unsub]
-                (bool is_dup,
-                 MQTT_NS::qos qos_value,
-                 bool is_retain,
-                 MQTT_NS::optional<packet_id_t> packet_id,
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
                  MQTT_NS::buffer topic,
                  MQTT_NS::buffer contents,
                  MQTT_NS::v5::properties /*props*/) {
-                    BOOST_TEST(is_dup == false);
-                    BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
+                BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
                     BOOST_CHECK(!packet_id);
                     BOOST_TEST(topic == "topic1");
                     BOOST_TEST(contents == "topic1_contents");
@@ -597,12 +585,12 @@ BOOST_AUTO_TEST_CASE( retain_and_publish ) {
                         "h_suback1",
                         [&] {
                             MQTT_CHK("h_publish1");
-                            BOOST_TEST(is_retain == false);
+                            BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
                         },
                         "h_suback2",
                         [&] {
                             MQTT_CHK("h_publish2");
-                            BOOST_TEST(is_retain == true);
+                            BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::yes);
                         }
                     );
                     BOOST_TEST(ret);
@@ -679,7 +667,7 @@ BOOST_AUTO_TEST_CASE( prop ) {
                 BOOST_TEST(sp == false);
                 BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
 
-                c->publish("topic1", "retained_contents", MQTT_NS::qos::at_most_once, true, std::move(ps));
+                c->publish("topic1", "retained_contents", MQTT_NS::qos::at_most_once | MQTT_NS::retain::yes, std::move(ps));
 
                 pid_sub = c->subscribe("topic1", MQTT_NS::qos::at_most_once);
                 return true;
@@ -723,17 +711,15 @@ BOOST_AUTO_TEST_CASE( prop ) {
             });
         c->set_v5_publish_handler(
             [&chk, &c, &pid_unsub, prop_size, &user_prop_count]
-            (bool is_dup,
-             MQTT_NS::qos qos_value,
-             bool is_retain,
-             MQTT_NS::optional<packet_id_t> packet_id,
+            (MQTT_NS::optional<packet_id_t> packet_id,
+             MQTT_NS::publish_options pubopts,
              MQTT_NS::buffer topic,
              MQTT_NS::buffer contents,
              MQTT_NS::v5::properties props) {
                 MQTT_CHK("h_publish");
-                BOOST_TEST(is_dup == false);
-                BOOST_TEST(qos_value == MQTT_NS::qos::at_most_once);
-                BOOST_TEST(is_retain == true);
+                BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::yes);
                 BOOST_CHECK(!packet_id);
                 BOOST_TEST(topic == "topic1");
                 BOOST_TEST(contents == "retained_contents");


### PR DESCRIPTION
I'd like some feedback on the names of the new items. I'm not happy with the names I picked for e..g `enum class dup` or `enum class publish_retain`