### PR TITLE
Using subscription map to allow for wildcard processing in mqtt test broker

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -78,6 +78,7 @@ IF (MQTT_TEST_7)
         as_buffer_pubsub.cpp
         as_buffer_async_pubsub_1.cpp
         as_buffer_async_pubsub_2.cpp
+        subscription_map.cpp
         subscription_map_broker.cpp
         async_pubsub_2.cpp
     )

--- a/test/subscription_map.cpp
+++ b/test/subscription_map.cpp
@@ -1,0 +1,41 @@
+// Copyright Takatoshi Kondo 2020
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+#include "test_main.hpp"
+#include "combi_test.hpp"
+#include "checker.hpp"
+#include "global_fixture.hpp"
+
+#include "subscription_map.hpp"
+
+#include <iostream>
+
+BOOST_AUTO_TEST_SUITE(test_subscription_map)
+
+BOOST_AUTO_TEST_CASE( failed_erase ) {
+    using func_t = std::function<void()>;
+    using value_t = std::shared_ptr<func_t>; // shared_ptr for '<' and hash
+    using sm_t = multiple_subscription_map<value_t>;
+
+    sm_t m;
+    auto v1 = std::make_shared<func_t>([] { std::cout << "v1" << std::endl; });
+    auto v2 = std::make_shared<func_t>([] { std::cout << "v2" << std::endl; });
+
+    auto it_success1 = m.insert("a/b/c", v1);
+    assert(it_success1.second);
+    m.dump(std::cout);
+    auto it_success2 = m.insert("a/b", v2);
+    assert(it_success2.second);
+    m.dump(std::cout);
+
+    auto e1 = m.erase(it_success1.first, v1);
+    std::cout << e1 << std::endl;
+    m.dump(std::cout);
+    auto e2 = m.erase(it_success2.first, v2); //  Invalid handle was specified is thrown here
+    std::cout << e2 << std::endl;
+    m.dump(std::cout);
+}	
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/subscription_map.hpp
+++ b/test/subscription_map.hpp
@@ -373,16 +373,9 @@ public:
 
     // Insert a value at the specified subscription path
     std::pair<handle, bool> insert(MQTT_NS::string_view subscription, Value value) {
-        auto path = this->find_subscription(subscription);
-        if (path.empty()) {
-            auto new_subscription_path = this->create_subscription(subscription);
-            new_subscription_path.back()->second.value.insert(std::move(value));
-            return std::make_pair(this->path_to_handle(new_subscription_path), true);
-        }
-
-        auto &subscription_set = path.back()->second.value;
-        bool insert_result = subscription_set.insert(std::move(value)).second;
-        return std::make_pair(this->path_to_handle(path), insert_result);
+        auto new_subscription_path = this->create_subscription(subscription);
+        new_subscription_path.back()->second.value.insert(std::move(value));
+        return std::make_pair(this->path_to_handle(new_subscription_path), true);
     }
 
     // Insert a value with a handle to the subscription


### PR DESCRIPTION
Using the subscription map it is possible to find connections which match a topic using wildcards. 