### PR TITLE
Add workaround for a bug in clang when compiling certain parts of the standard template library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ OPTION(MQTT_STD_OPTIONAL "Use std::optional from C++17 instead of boost::optiona
 OPTION(MQTT_STD_STRING_VIEW "Use std::string_view from C++17 instead of boost::string_view" OFF)
 OPTION(MQTT_STD_ANY "Use std::any from C++17 instead of boost::any" OFF)
 OPTION(MQTT_STD_SHARED_PTR_ARRAY "Use std::shared_ptr<char[]> from C++17 instead of boost::shared_ptr<char[]>" OFF)
+OPTION(MQTT_CLANG_STL_WORKAROUND "Work around bug in clang involving std::make_tuple" OFF)
 
 IF (POLICY CMP0074)
   CMAKE_POLICY(SET CMP0074 NEW)

--- a/example/no_tls_both.cpp
+++ b/example/no_tls_both.cpp
@@ -185,7 +185,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
             // Pass spep to keep lifetime.
             // It makes sure wp.lock() never return nullptr in the handlers below
             // including close_handler and error_handler.
-            ep.start_session(std::make_tuple(std::move(spep), std::move(g)));
+            ep.start_session(MQTT_NS::make_collection(std::move(spep), std::move(g)));
 
             // set connection (lower than MQTT) level handlers
             ep.set_close_handler(

--- a/example/no_tls_ws_both.cpp
+++ b/example/no_tls_ws_both.cpp
@@ -184,7 +184,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
             // Pass spep to keep lifetime.
             // It makes sure wp.lock() never return nullptr in the handlers below
             // including close_handler and error_handler.
-            ep.start_session(std::make_tuple(std::move(spep), std::move(g)));
+            ep.start_session(MQTT_NS::make_collection(std::move(spep), std::move(g)));
 
             // set connection (lower than MQTT) level handlers
             ep.set_close_handler(

--- a/example/tls_both.cpp
+++ b/example/tls_both.cpp
@@ -186,7 +186,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
             // Pass spep to keep lifetime.
             // It makes sure wp.lock() never return nullptr in the handlers below
             // including close_handler and error_handler.
-            ep.start_session(std::make_tuple(std::move(spep), std::move(g)));
+            ep.start_session(MQTT_NS::make_collection(std::move(spep), std::move(g)));
 
             // set connection (lower than MQTT) level handlers
             ep.set_close_handler(

--- a/example/tls_ws_both.cpp
+++ b/example/tls_ws_both.cpp
@@ -185,7 +185,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
             // Pass spep to keep lifetime.
             // It makes sure wp.lock() never return nullptr in the handlers below
             // including close_handler and error_handler.
-            ep.start_session(std::make_tuple(std::move(spep), std::move(g)));
+            ep.start_session(MQTT_NS::make_collection(std::move(spep), std::move(g)));
 
             // set connection (lower than MQTT) level handlers
             ep.set_close_handler(

--- a/example/v5_no_tls_both.cpp
+++ b/example/v5_no_tls_both.cpp
@@ -205,7 +205,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections, mi_sub_con& subs) {
             // Pass spep to keep lifetime.
             // It makes sure wp.lock() never return nullptr in the handlers below
             // including close_handler and error_handler.
-            ep.start_session(std::make_tuple(std::move(spep), std::move(g)));
+            ep.start_session(MQTT_NS::make_collection(std::move(spep), std::move(g)));
 
             // set connection (lower than MQTT) level handlers
             ep.set_close_handler(

--- a/example/v5_no_tls_prop.cpp
+++ b/example/v5_no_tls_prop.cpp
@@ -165,7 +165,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections) {
             // Pass spep to keep lifetime.
             // It makes sure wp.lock() never return nullptr in the handlers below
             // including close_handler and error_handler.
-            ep.start_session(std::make_tuple(std::move(spep), std::move(g)));
+            ep.start_session(MQTT_NS::make_collection(std::move(spep), std::move(g)));
 
             // set connection (lower than MQTT) level handlers
             ep.set_close_handler( // this handler doesn't depend on MQTT protocol version

--- a/include/mqtt/endpoint.hpp
+++ b/include/mqtt/endpoint.hpp
@@ -62,6 +62,7 @@
 #include <mqtt/deprecated.hpp>
 #include <mqtt/deprecated_msg.hpp>
 #include <mqtt/error_code.hpp>
+#include <mqtt/make_collection.hpp>
 
 #if defined(MQTT_USE_WS)
 #include <mqtt/ws_endpoint.hpp>
@@ -951,7 +952,7 @@ public:
                 contents_buf,
                 pubopts,
                 force_move(props),
-                std::make_tuple(
+                make_collection(
                     force_move(life_keeper),
                     force_move(sp_topic_name),
                     force_move(sp_contents)
@@ -1048,7 +1049,7 @@ public:
             contents_buf,
             pubopts,
             force_move(props),
-            std::make_tuple(
+            make_collection(
                 force_move(life_keeper),
                 force_move(topic_name),
                 force_move(contents)
@@ -1855,7 +1856,7 @@ public:
             contents_buf,
             pubopts,
             force_move(props),
-            std::make_tuple(
+            make_collection(
                 force_move(life_keeper),
                 force_move(sp_topic_name),
                 force_move(sp_contents)
@@ -1991,7 +1992,7 @@ public:
             contents_buf,
             pubopts,
             v5::properties{},
-            std::make_tuple(
+            make_collection(
                 force_move(life_keeper),
                 force_move(topic_name),
                 force_move(contents)
@@ -2047,7 +2048,7 @@ public:
             contents_buf,
             pubopts,
             force_move(props),
-            std::make_tuple(
+            make_collection(
                 force_move(life_keeper),
                 force_move(topic_name),
                 force_move(contents)
@@ -6446,7 +6447,7 @@ private:
             {
                 LockGuard<Mutex> lck (store_mtx_);
                 auto& idx = store_.template get<tag_packet_id_type>();
-                auto r = idx.equal_range(std::make_tuple(info.packet_id, control_packet_type::puback));
+                auto r = idx.equal_range(make_collection(info.packet_id, control_packet_type::puback));
                 idx.erase(std::get<0>(r), std::get<1>(r));
                 packet_id_.erase(info.packet_id);
             }
@@ -6591,7 +6592,7 @@ private:
             {
                 LockGuard<Mutex> lck (store_mtx_);
                 auto& idx = store_.template get<tag_packet_id_type>();
-                auto r = idx.equal_range(std::make_tuple(info.packet_id, control_packet_type::pubrec));
+                auto r = idx.equal_range(make_collection(info.packet_id, control_packet_type::pubrec));
                 idx.erase(std::get<0>(r), std::get<1>(r));
                 // packet_id shouldn't be erased here.
                 // It is reused for pubrel/pubcomp.
@@ -6936,7 +6937,7 @@ private:
             {
                 LockGuard<Mutex> lck (store_mtx_);
                 auto& idx = store_.template get<tag_packet_id_type>();
-                auto r = idx.equal_range(std::make_tuple(info.packet_id, control_packet_type::pubcomp));
+                auto r = idx.equal_range(make_collection(info.packet_id, control_packet_type::pubcomp));
                 idx.erase(std::get<0>(r), std::get<1>(r));
                 packet_id_.erase(info.packet_id);
             }

--- a/include/mqtt/make_collection.hpp
+++ b/include/mqtt/make_collection.hpp
@@ -1,0 +1,38 @@
+#if !defined(MQTT_MAKE_COLLECTION_HPP)
+#define MQTT_MAKE_COLLECTION_HPP
+
+#include <functional>
+#include <mqtt/namespace.hpp>
+#include <utility>
+
+namespace MQTT_NS {
+#if defined(MQTT_CLANG_STL_WORKAROUND)
+
+template <typename FIRST_T, typename SECOND_T, typename... ARGS_T>
+decltype(auto) make_collection(FIRST_T &&first, SECOND_T && second,
+                               ARGS_T &&...args) {
+    return std::make_pair(std::forward<FIRST_T>(first),  make_collection(std::forward<SECOND_T>(second),
+                                                                         std::forward<ARGS_T>(args)...));
+}
+
+template <typename FIRST_T, typename SECOND_T>
+decltype(auto) make_collection(FIRST_T &&first, SECOND_T && second) {
+    return std::make_pair(std::forward<FIRST_T>(first), std::forward<SECOND_T>(second));
+}
+
+template <typename FIRST_T>
+decltype(auto) make_collection(FIRST_T &&first) {
+    return first;
+}
+
+#else // MQTT_CLANG_STL_WORKAROUND
+
+template <typename... ARGS_T>
+decltype(auto) make_collection(ARGS_T &&... args) {
+    return std::make_tuple(std::forward<ARGS_T>(args)...);
+}
+
+#endif //MQTT_CLANG_STL_WORKAROUND
+
+}
+#endif // MQTT_MAKE_COLLECTION

--- a/include/mqtt_client_cpp.hpp
+++ b/include/mqtt_client_cpp.hpp
@@ -22,3 +22,4 @@
 #include <mqtt/utf8encoded_strings.hpp>
 #include <mqtt/visitor_util.hpp>
 #include <mqtt/will.hpp>
+#include <mqtt/make_collection.hpp>

--- a/test/async_pubsub_1.cpp
+++ b/test/async_pubsub_1.cpp
@@ -9,6 +9,7 @@
 #include "checker.hpp"
 
 #include <mqtt/optional.hpp>
+#include <mqtt/make_collection.hpp>
 
 #include <vector>
 #include <string>
@@ -233,7 +234,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                     c->async_subscribe(
                         pid_sub,
                         std::vector<std::tuple<std::string, MQTT_NS::subscribe_options>> {
-                            std::make_tuple("topic1", MQTT_NS::qos::at_most_once)
+                            MQTT_NS::make_collection("topic1", MQTT_NS::qos::at_most_once)
                         }
                     );
                     return true;
@@ -305,7 +306,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                     c->async_subscribe(
                         pid_sub,
                         std::vector<std::tuple<std::string, MQTT_NS::subscribe_options>> {
-                            std::make_tuple("topic1", MQTT_NS::qos::at_most_once)
+                            MQTT_NS::make_collection("topic1", MQTT_NS::qos::at_most_once)
                         }
                     );
                     return true;

--- a/test/pubsub.cpp
+++ b/test/pubsub.cpp
@@ -9,6 +9,8 @@
 #include "checker.hpp"
 
 #include <mqtt/optional.hpp>
+#include <mqtt/make_collection.hpp>
+
 
 BOOST_AUTO_TEST_SUITE(test_pubsub)
 
@@ -226,7 +228,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
                     pid_sub = c->subscribe(
                         std::vector<std::tuple<MQTT_NS::string_view, MQTT_NS::subscribe_options>> {
-                            std::make_tuple("topic1", MQTT_NS::qos::at_most_once)
+                            MQTT_NS::make_collection("topic1", MQTT_NS::qos::at_most_once)
                         }
                     );
                     return true;
@@ -296,7 +298,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
                     pid_sub = c->subscribe(
                         std::vector<std::tuple<MQTT_NS::string_view, MQTT_NS::subscribe_options>> {
-                            std::make_tuple("topic1", MQTT_NS::qos::at_most_once)
+                            MQTT_NS::make_collection("topic1", MQTT_NS::qos::at_most_once)
                         }
                     );
                     return true;

--- a/test/resend_serialize.cpp
+++ b/test/resend_serialize.cpp
@@ -9,6 +9,8 @@
 #include "checker.hpp"
 #include "test_util.hpp"
 
+#include <mqtt/make_collection.hpp>
+
 BOOST_AUTO_TEST_SUITE(test_resend_serialize)
 
 using namespace MQTT_NS::literals;
@@ -59,11 +61,11 @@ set_serialize_handlers(Client const& c, Serialized& serialized) {
     using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
     c->set_serialize_handlers(
         [&serialized](MQTT_NS::publish_message msg) {
-            serialized.emplace(msg.packet_id(), std::make_tuple(true, msg.continuous_buffer()));
+            serialized.emplace(msg.packet_id(), MQTT_NS::make_collection(true, msg.continuous_buffer()));
         },
         [&serialized](MQTT_NS::pubrel_message msg) {
             BOOST_CHECK(serialized.find(msg.packet_id()) != serialized.end());
-            serialized[msg.packet_id()] = std::make_tuple(false, msg.continuous_buffer());
+            serialized[msg.packet_id()] = MQTT_NS::make_collection(false, msg.continuous_buffer());
         },
         [&serialized](packet_id_t packet_id) {
             BOOST_CHECK(serialized.find(packet_id) != serialized.end());
@@ -79,11 +81,11 @@ set_serialize_handlers(Client const& c, Serialized& serialized) {
     using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
     c->set_serialize_handlers(
         [&serialized](MQTT_NS::publish_32_message msg) {
-            serialized.emplace(msg.packet_id(), std::make_tuple(true, msg.continuous_buffer()));
+            serialized.emplace(msg.packet_id(), MQTT_NS::make_collection(true, msg.continuous_buffer()));
         },
         [&serialized](MQTT_NS::pubrel_32_message msg) {
             BOOST_CHECK(serialized.find(msg.packet_id()) != serialized.end());
-            serialized[msg.packet_id()] = std::make_tuple(false, msg.continuous_buffer());
+            serialized[msg.packet_id()] = MQTT_NS::make_collection(false, msg.continuous_buffer());
         },
         [&serialized](packet_id_t packet_id) {
             BOOST_CHECK(serialized.find(packet_id) != serialized.end());
@@ -801,11 +803,11 @@ set_v5_serialize_handlers(Client const& c, Serialized& serialized) {
     using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
     c->set_v5_serialize_handlers(
         [&serialized](MQTT_NS::v5::publish_message msg) {
-            serialized.emplace(msg.packet_id(), std::make_tuple(true, msg.continuous_buffer()));
+            serialized.emplace(msg.packet_id(), MQTT_NS::make_collection(true, msg.continuous_buffer()));
         },
         [&serialized](MQTT_NS::v5::pubrel_message msg) {
             BOOST_CHECK(serialized.find(msg.packet_id()) != serialized.end());
-            serialized[msg.packet_id()] = std::make_tuple(false, msg.continuous_buffer());
+            serialized[msg.packet_id()] = MQTT_NS::make_collection(false, msg.continuous_buffer());
         },
         [&serialized](packet_id_t packet_id) {
             BOOST_CHECK(serialized.find(packet_id) != serialized.end());
@@ -821,11 +823,11 @@ set_v5_serialize_handlers(Client const& c, Serialized& serialized) {
     using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
     c->set_v5_serialize_handlers(
         [&serialized](MQTT_NS::v5::publish_32_message msg) {
-            serialized.emplace(msg.packet_id(), std::make_tuple(true, msg.continuous_buffer()));
+            serialized.emplace(msg.packet_id(), MQTT_NS::make_collection(true, msg.continuous_buffer()));
         },
         [&serialized](MQTT_NS::v5::pubrel_32_message msg) {
             BOOST_CHECK(serialized.find(msg.packet_id()) != serialized.end());
-            serialized[msg.packet_id()] = std::make_tuple(false, msg.continuous_buffer());
+            serialized[msg.packet_id()] = MQTT_NS::make_collection(false, msg.continuous_buffer());
         },
         [&serialized](packet_id_t packet_id) {
             BOOST_CHECK(serialized.find(packet_id) != serialized.end());

--- a/test/test_broker.hpp
+++ b/test/test_broker.hpp
@@ -20,6 +20,7 @@
 #include <mqtt_server_cpp.hpp>
 #include <mqtt/optional.hpp>
 #include <mqtt/visitor_util.hpp>
+#include <mqtt/make_collection.hpp>
 
 #include "test_settings.hpp"
 
@@ -603,7 +604,7 @@ private:
                         // TODO: why is this 'retain'?
                         std::min(item.qos_value, d.qos_value) | MQTT_NS::retain::yes,
                         *(d.props),
-                        std::make_tuple(item.topic, d.contents, *(d.props))
+                        MQTT_NS::make_collection(item.topic, d.contents, *(d.props))
                         );
                 }
                 subs_.emplace(item.topic, spep, item.qos_value);


### PR DESCRIPTION
When compiling an mqtt_cpp project with clang on linux, I have been getting build failures (varying depending on usage) surrounding usage of the STL std::make_tuple function. This PR adds a build flag allowing building mqtt_cpp with clang by replacing it with calls to std::make_pair.