### PR TITLE
fix for failure to send > 1 ping request

### DIFF
--- a/include/mqtt/callable_overlay.hpp
+++ b/include/mqtt/callable_overlay.hpp
@@ -709,6 +709,7 @@ struct callable_overlay final : public Impl
      */
     MQTT_ALWAYS_INLINE void on_pre_send() noexcept override final {
         if(h_pre_send_) h_pre_send_();
+        else base::on_pre_send();
     }
 
     /**

--- a/include/mqtt/client.hpp
+++ b/include/mqtt/client.hpp
@@ -1295,14 +1295,14 @@ private:
                 async_handshake_socket(socket, force_move(props), force_move(session_life_keeper), force_move(func));
             });
     }
-
+protected:
     void on_pre_send() noexcept override
     {
         if (ping_duration_ms_ != 0) {
             reset_timer();
         }
     }
-
+private:
     void handle_timer(error_code ec) {
         if (!ec) {
             if (async_pingreq_) {


### PR DESCRIPTION
Testing with a modified version of the tls_client example, I was seeing only a single ping request, i.e. only a single call to the ping request callback.

Credit for fix here goes to jonesmz.

See https://github.com/redboltz/mqtt_cpp/issues/573