### PR TITLE
Fixed #573.

### DIFF
--- a/include/mqtt/client.hpp
+++ b/include/mqtt/client.hpp
@@ -1296,6 +1296,7 @@ private:
             });
     }
 
+protected:
     void on_pre_send() noexcept override
     {
         if (ping_duration_ms_ != 0) {
@@ -1303,6 +1304,7 @@ private:
         }
     }
 
+private:
     void handle_timer(error_code ec) {
         if (!ec) {
             if (async_pingreq_) {
@@ -1331,6 +1333,7 @@ private:
         set_timer();
     }
 
+protected:
     void on_close() noexcept override {
         if (ping_duration_ms_ != 0) tim_ping_.cancel();
     }
@@ -1340,7 +1343,6 @@ private:
         if (ping_duration_ms_ != 0) tim_ping_.cancel();
     }
 
-protected:
     // Ensure that only code that knows the *exact* type of an object
     // inheriting from this abstract base class can destruct it.
     // This avoids issues of the destructor not triggering destruction

--- a/include/mqtt/endpoint.hpp
+++ b/include/mqtt/endpoint.hpp
@@ -182,6 +182,7 @@ public:
 
     // MQTT Common handlers
 
+private:
     /**
      * @brief Pingreq handler
      *        See http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718086<BR>
@@ -669,13 +670,14 @@ public:
 
     // Original handlers
 
+protected:
     /**
      * @brief Close handler
      *
      * This handler is called if the client called `disconnect()` and the server closed the socket cleanly.
      * If the socket is closed by other reasons, error_handler is called.
      */
-    virtual void on_close() noexcept = 0;
+    virtual void on_close() noexcept {}
 
     /**
      * @brief Error handler
@@ -684,8 +686,9 @@ public:
      *
      * @param ec error code
      */
-    virtual void on_error(error_code ec) noexcept = 0;
+    virtual void on_error(error_code /*ec*/) noexcept {}
 
+private:
     /**
      * @brief Publish response sent handler
      *        This function is called just after puback sent on QoS1, or pubcomp sent on QoS2.
@@ -738,11 +741,14 @@ public:
      */
     virtual void on_serialize_remove(packet_id_t packet_id) noexcept = 0;
 
+protected:
     /**
      * @brief Pre-send handler
      *        This handler is called when any mqtt control packet is decided to send.
      */
-    virtual void on_pre_send() noexcept = 0;
+    virtual void on_pre_send() noexcept {}
+
+private:
 
     /**
      * @brief is valid length handler
@@ -753,6 +759,7 @@ public:
      */
     virtual bool check_is_valid_length(control_packet_type packet_type, std::size_t remaining_length) noexcept = 0;
 
+protected:
     /**
      * @brief next read handler
      *        This handler is called when the current mqtt message has been processed.
@@ -760,12 +767,12 @@ public:
      */
     MQTT_ALWAYS_INLINE virtual void on_mqtt_message_processed(MQTT_NS::any session_life_keeper) noexcept
     {
-        if(async_read_on_message_processed_)
-        {
+        if (async_read_on_message_processed_) {
             async_read_control_packet_type(force_move(session_life_keeper));
         }
     }
 
+public:
     endpoint(this_type const&) = delete;
     endpoint(this_type&&) = delete;
     endpoint& operator=(this_type const&) = delete;

--- a/include/mqtt/endpoint.hpp
+++ b/include/mqtt/endpoint.hpp
@@ -677,7 +677,7 @@ protected:
      * This handler is called if the client called `disconnect()` and the server closed the socket cleanly.
      * If the socket is closed by other reasons, error_handler is called.
      */
-    virtual void on_close() noexcept {}
+    virtual void on_close() noexcept = 0;
 
     /**
      * @brief Error handler
@@ -686,7 +686,7 @@ protected:
      *
      * @param ec error code
      */
-    virtual void on_error(error_code /*ec*/) noexcept {}
+    virtual void on_error(error_code ec) noexcept = 0;
 
 private:
     /**
@@ -746,7 +746,7 @@ protected:
      * @brief Pre-send handler
      *        This handler is called when any mqtt control packet is decided to send.
      */
-    virtual void on_pre_send() noexcept {}
+    virtual void on_pre_send() noexcept = 0;
 
 private:
 

--- a/include/mqtt/server.hpp
+++ b/include/mqtt/server.hpp
@@ -33,6 +33,16 @@ namespace MQTT_NS {
 
 namespace as = boost::asio;
 
+template <typename Mutex, template<typename...> class LockGuard, std::size_t PacketIdBytes>
+class server_endpoint : public endpoint<Mutex, LockGuard, PacketIdBytes> {
+public:
+    using endpoint<Mutex, LockGuard, PacketIdBytes>::endpoint;
+protected:
+    void on_pre_send() noexcept override {}
+    void on_close() noexcept override {}
+    void on_error(error_code /*ec*/) noexcept override {}
+};
+
 template <
     typename Strand = as::io_context::strand,
     typename Mutex = std::mutex,
@@ -42,7 +52,7 @@ template <
 class server {
 public:
     using socket_t = tcp_endpoint<as::ip::tcp::socket, Strand>;
-    using endpoint_t = callable_overlay<endpoint<Mutex, LockGuard, PacketIdBytes>>;
+    using endpoint_t = callable_overlay<server_endpoint<Mutex, LockGuard, PacketIdBytes>>;
 
     /**
      * @brief Accept handler
@@ -184,7 +194,7 @@ template <
 class server_tls {
 public:
     using socket_t = tcp_endpoint<as::ssl::stream<as::ip::tcp::socket>, Strand>;
-    using endpoint_t = callable_overlay<endpoint<Mutex, LockGuard, PacketIdBytes>>;
+    using endpoint_t = callable_overlay<server_endpoint<Mutex, LockGuard, PacketIdBytes>>;
 
     /**
      * @brief Accept handler
@@ -388,7 +398,7 @@ template <
 class server_ws {
 public:
     using socket_t = ws_endpoint<as::ip::tcp::socket, Strand>;
-    using endpoint_t = callable_overlay<endpoint<Mutex, LockGuard, PacketIdBytes>>;
+    using endpoint_t = callable_overlay<server_endpoint<Mutex, LockGuard, PacketIdBytes>>;
 
     /**
      * @brief Accept handler
@@ -633,7 +643,7 @@ template <
 class server_tls_ws {
 public:
     using socket_t = ws_endpoint<as::ssl::stream<as::ip::tcp::socket>, Strand>;
-    using endpoint_t = callable_overlay<endpoint<Mutex, LockGuard, PacketIdBytes>>;
+    using endpoint_t = callable_overlay<server_endpoint<Mutex, LockGuard, PacketIdBytes>>;
 
     /**
      * @brief Accept handler


### PR DESCRIPTION
`callable_overlay` always calls the base of `on_pre_send()`,
`on_close()`, and `on_error()`.
It makes sure `client` process is correctly done.

NOTE:
`callable_overlay` is not only used from `client` but also
`endpoint`. That means `endpoint::on_pre_send()` (and other
functions) are called. So I update them from pure virtual function to
non-pure virtual function that has empty definition.

NOTE:
`callable_overlay` calles `base::on_mqtt_processed()` only if
mqtt_processed handler is not set. It is inconsitent behavior to
`on_pre_send()` (and other functions). But it is correct behavior. So
I add documentation about that.
I personally believe this inconsitency doesn't cause a big
problem. Because this handler is for very advanced users. (I use it)