### PR TITLE
Removed packet_id from restoring functions.

### DIFF
--- a/include/mqtt/endpoint.hpp
+++ b/include/mqtt/endpoint.hpp
@@ -3603,13 +3603,12 @@ public:
     /**
      * @brief Restore serialized publish and pubrel messages.
      *        This function should be called before connect.
-     * @param packet_id packet id of the message
      * @param b         iterator begin of the message
      * @param e         iterator end of the message
      */
     template <typename Iterator>
     std::enable_if_t< std::is_convertible<typename Iterator::value_type, char>::value >
-    restore_serialized_message(packet_id_t /*packet_id*/, Iterator b, Iterator e) {
+    restore_serialized_message(Iterator b, Iterator e) {
         static_assert(
             std::is_same<
                 typename std::iterator_traits<Iterator>::iterator_category,
@@ -3724,13 +3723,12 @@ public:
     /**
      * @brief Restore serialized publish and pubrel messages.
      *        This function shouold be called before connect.
-     * @param packet_id packet id of the message
      * @param b         iterator begin of the message
      * @param e         iterator end of the message
      */
     template <typename Iterator>
     std::enable_if_t< std::is_convertible<typename Iterator::value_type, char>::value >
-    restore_v5_serialized_message(packet_id_t /*packet_id*/, Iterator b, Iterator e) {
+    restore_v5_serialized_message(Iterator b, Iterator e) {
         if (b == e) return;
 
         auto fixed_header = static_cast<std::uint8_t>(*b);

--- a/test/resend_serialize_ptr_size.cpp
+++ b/test/resend_serialize_ptr_size.cpp
@@ -16,7 +16,7 @@ using namespace MQTT_NS::literals;
 template <typename Client, typename Elem>
 inline
 void restore_serialized_message(Client const& c, Elem const& e) {
-    c->restore_serialized_message(e.first, e.second.begin(), e.second.end());
+    c->restore_serialized_message(e.second.begin(), e.second.end());
 }
 
 template <typename Client, typename Serialized>
@@ -644,7 +644,7 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1 ) {
 template <typename Client, typename Elem>
 inline
 void restore_v5_serialized_message(Client const& c, Elem const& e) {
-    c->restore_v5_serialized_message(e.first, e.second.begin(), e.second.end());
+    c->restore_v5_serialized_message(e.second.begin(), e.second.end());
 }
 
 template <typename Client, typename Serialized>


### PR DESCRIPTION
The message body has packet_id. It is used to use but currently not used.