### PR TITLE
Removed boost::static_visitor inheritance.

### DIFF
--- a/example/redirect.cpp
+++ b/example/redirect.cpp
@@ -52,7 +52,7 @@ void set_client_handlers(
                 MQTT_NS::buffer server_reference;
                 for (auto const& p : props) {
                     MQTT_NS::visit(
-                        MQTT_NS::make_lambda_visitor<void>(
+                        MQTT_NS::make_lambda_visitor(
                             [&](MQTT_NS::v5::property::server_reference const& t) {
                                 locked_cout() << "[client] prop: server_reference: " << t.val() << std::endl;
                                 server_reference = t.val();

--- a/example/v5_no_tls_prop.cpp
+++ b/example/v5_no_tls_prop.cpp
@@ -35,7 +35,7 @@ void client_proc(Client& c) {
 
             for (auto const& p : props) {
                 MQTT_NS::visit(
-                    MQTT_NS::make_lambda_visitor<void>(
+                    MQTT_NS::make_lambda_visitor(
                         [&](MQTT_NS::v5::property::session_expiry_interval const& t) {
                             locked_cout() << "[client] prop: session_expiry_interval: " << t.val() << std::endl;
                         },
@@ -204,7 +204,7 @@ void server_proc(Server& s, std::set<con_sp_t>& connections) {
                     // check properties
                     for (auto const& p : props) {
                         MQTT_NS::visit(
-                            MQTT_NS::make_lambda_visitor<void>(
+                            MQTT_NS::make_lambda_visitor(
                                 [&](MQTT_NS::v5::property::session_expiry_interval const& t) {
                                     locked_cout() << "[server] prop: session_expiry_interval: " << t.val() << std::endl;
                                 },

--- a/include/mqtt/endpoint.hpp
+++ b/include/mqtt/endpoint.hpp
@@ -3828,23 +3828,19 @@ public:
     }
 
 private:
-    struct restore_basic_message_variant_visitor
-#if !defined(MQTT_STD_VARIANT)
-        : boost::static_visitor<void>
-#endif // !defined(MQTT_STD_VARIANT)
-    {
+    struct restore_basic_message_variant_visitor {
         restore_basic_message_variant_visitor(this_type& ep, any life_keeper):ep_(ep), life_keeper_(force_move(life_keeper)) {}
 
-        void operator()(basic_publish_message<PacketIdBytes>&& msg) const {
+        void operator()(basic_publish_message<PacketIdBytes>&& msg) {
             ep_.restore_serialized_message(force_move(msg), force_move(life_keeper_));
         }
-        void operator()(basic_pubrel_message<PacketIdBytes>&& msg) const {
+        void operator()(basic_pubrel_message<PacketIdBytes>&& msg) {
             ep_.restore_serialized_message(force_move(msg), force_move(life_keeper_));
         }
-        void operator()(v5::basic_publish_message<PacketIdBytes>&& msg) const {
+        void operator()(v5::basic_publish_message<PacketIdBytes>&& msg) {
             ep_.restore_v5_serialized_message(force_move(msg), force_move(life_keeper_));
         }
-        void operator()(v5::basic_pubrel_message<PacketIdBytes>&& msg) const {
+        void operator()(v5::basic_pubrel_message<PacketIdBytes>&& msg) {
             ep_.restore_v5_serialized_message(force_move(msg), force_move(life_keeper_));
         }
         template <typename T>
@@ -3853,7 +3849,7 @@ private:
         }
     private:
         this_type& ep_;
-        mutable any life_keeper_;
+        any life_keeper_;
     };
 
 public:

--- a/include/mqtt/message_variant.hpp
+++ b/include/mqtt/message_variant.hpp
@@ -53,52 +53,28 @@ using message_variant = basic_message_variant<2>;
 
 namespace detail {
 
-struct const_buffer_sequence_visitor
-
-#if !defined(MQTT_STD_VARIANT)
-    : boost::static_visitor<std::vector<as::const_buffer>>
-#endif // !defined(MQTT_STD_VARIANT)
-
-{
+struct const_buffer_sequence_visitor {
     template <typename T>
     std::vector<as::const_buffer> operator()(T&& t) const {
         return t.const_buffer_sequence();
     }
 };
 
-struct size_visitor
-
-#if !defined(MQTT_STD_VARIANT)
-    : boost::static_visitor<std::size_t>
-#endif // !defined(MQTT_STD_VARIANT)
-
-{
+struct size_visitor {
     template <typename T>
     std::size_t operator()(T&& t) const {
         return t.size();
     }
 };
 
-struct num_of_const_buffer_sequence_visitor
-
-#if !defined(MQTT_STD_VARIANT)
-    : boost::static_visitor<std::size_t>
-#endif // !defined(MQTT_STD_VARIANT)
-
-{
+struct num_of_const_buffer_sequence_visitor {
     template <typename T>
     std::size_t operator()(T&& t) const {
         return t.num_of_const_buffer_sequence();
     }
 };
 
-struct continuous_buffer_visitor
-
-#if !defined(MQTT_STD_VARIANT)
-    : boost::static_visitor<std::string>
-#endif // !defined(MQTT_STD_VARIANT)
-
-{
+struct continuous_buffer_visitor {
     template <typename T>
     std::string operator()(T&& t) const {
         return std::forward<T>(t).continuous_buffer();
@@ -145,13 +121,7 @@ using store_message_variant = basic_store_message_variant<2>;
 namespace detail {
 
 template <std::size_t PacketIdBytes>
-struct basic_message_variant_visitor
-
-#if !defined(MQTT_STD_VARIANT)
-    : boost::static_visitor<basic_message_variant<PacketIdBytes>>
-#endif // !defined(MQTT_STD_VARIANT)
-
-{
+struct basic_message_variant_visitor {
     template <typename T>
     basic_message_variant<PacketIdBytes> operator()(T&& t) const {
         return t;

--- a/include/mqtt/property_variant.hpp
+++ b/include/mqtt/property_variant.hpp
@@ -54,13 +54,7 @@ namespace property {
 
 namespace detail {
 
-struct add_const_buffer_sequence_visitor
-
-#if !defined(MQTT_STD_VARIANT)
-    : boost::static_visitor<void>
-#endif // !defined(MQTT_STD_VARIANT)
-
-{
+struct add_const_buffer_sequence_visitor {
     add_const_buffer_sequence_visitor(std::vector<as::const_buffer>& v):v(v) {}
     template <typename T>
     void operator()(T&& t) const {
@@ -69,26 +63,14 @@ struct add_const_buffer_sequence_visitor
     std::vector<as::const_buffer>& v;
 };
 
-struct size_visitor
-
-#if !defined(MQTT_STD_VARIANT)
-    : boost::static_visitor<std::size_t>
-#endif // !defined(MQTT_STD_VARIANT)
-
-{
+struct size_visitor {
     template <typename T>
     std::size_t operator()(T&& t) const {
         return t.size();
     }
 };
 
-struct num_of_const_buffer_sequence_visitor
-
-#if !defined(MQTT_STD_VARIANT)
-    : boost::static_visitor<std::size_t>
-#endif // !defined(MQTT_STD_VARIANT)
-
-{
+struct num_of_const_buffer_sequence_visitor {
     template <typename T>
     std::size_t operator()(T&& t) const {
         return t.num_of_const_buffer_sequence();
@@ -96,13 +78,7 @@ struct num_of_const_buffer_sequence_visitor
 };
 
 template <typename Iterator>
-struct fill_visitor
-
-#if !defined(MQTT_STD_VARIANT)
-    : boost::static_visitor<void>
-#endif // !defined(MQTT_STD_VARIANT)
-
-{
+struct fill_visitor {
     fill_visitor(Iterator b, Iterator e):b(b), e(e) {}
 
     template <typename T>

--- a/include/mqtt/visitor_util.hpp
+++ b/include/mqtt/visitor_util.hpp
@@ -12,47 +12,29 @@
 
 namespace MQTT_NS {
 
-template <typename ReturnType, typename... Lambdas>
+template <typename... Lambdas>
 struct lambda_visitor;
 
-template <typename ReturnType, typename Lambda1, typename... Lambdas>
-struct lambda_visitor<ReturnType, Lambda1, Lambdas...>
-    : Lambda1, lambda_visitor<ReturnType, Lambdas...> {
+template <typename Lambda1, typename... Lambdas>
+struct lambda_visitor<Lambda1, Lambdas...>
+    : Lambda1, lambda_visitor<Lambdas...> {
     using Lambda1::operator();
-    using lambda_visitor<ReturnType, Lambdas...>::operator();
+    using lambda_visitor<Lambdas...>::operator();
     lambda_visitor(Lambda1 lambda1, Lambdas... lambdas)
-        : Lambda1(lambda1), lambda_visitor<ReturnType, Lambdas...>(lambdas...) {}
+        : Lambda1(lambda1), lambda_visitor<Lambdas...>(lambdas...) {}
 };
 
 
-template <typename ReturnType, typename Lambda1>
-struct lambda_visitor<ReturnType, Lambda1>
-    :
-#if !defined(MQTT_STD_VARIANT)
-    boost::static_visitor<ReturnType>,
-#endif // !defined(MQTT_STD_VARIANT)
-    Lambda1 {
+template <typename Lambda1>
+struct lambda_visitor<Lambda1> : Lambda1 {
     using Lambda1::operator();
     lambda_visitor(Lambda1 lambda1)
-        :
-#if !defined(MQTT_STD_VARIANT)
-        boost::static_visitor<ReturnType>(),
-#endif // !defined(MQTT_STD_VARIANT)
-        Lambda1(lambda1) {}
+        : Lambda1(lambda1) {}
 };
 
 
-template <typename ReturnType>
-struct lambda_visitor<ReturnType>
-#if !defined(MQTT_STD_VARIANT)
-    : public boost::static_visitor<ReturnType>
-#endif // !defined(MQTT_STD_VARIANT)
-{
-    lambda_visitor() {}
-};
-
-template <typename ReturnType, typename... Lambdas>
-inline lambda_visitor<ReturnType, Lambdas...> make_lambda_visitor(Lambdas&&... lambdas) {
+template <typename... Lambdas>
+inline lambda_visitor<Lambdas...> make_lambda_visitor(Lambdas&&... lambdas) {
     return { std::forward<Lambdas>(lambdas)... };
 }
 

--- a/test/async_pubsub_2.cpp
+++ b/test/async_pubsub_2.cpp
@@ -1227,7 +1227,7 @@ BOOST_AUTO_TEST_CASE( pub_sub_prop ) {
 
                 for (auto const& p : props) {
                     MQTT_NS::visit(
-                        MQTT_NS::make_lambda_visitor<void>(
+                        MQTT_NS::make_lambda_visitor(
                             [&](MQTT_NS::v5::property::payload_format_indicator const& t) {
                                 BOOST_TEST(t.val() == MQTT_NS::v5::property::payload_format_indicator::string);
                             },
@@ -1356,7 +1356,7 @@ BOOST_AUTO_TEST_CASE( puback_props ) {
                 BOOST_TEST(props.size() == size);
                 for (auto const& p : props) {
                     MQTT_NS::visit(
-                        MQTT_NS::make_lambda_visitor<void>(
+                        MQTT_NS::make_lambda_visitor(
                             [&](MQTT_NS::v5::property::reason_string const& t) {
                                 BOOST_TEST(t.val() == "test success");
                             },
@@ -1552,7 +1552,7 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
                 BOOST_TEST(props.size() == size);
                 for (auto const& p : props) {
                     MQTT_NS::visit(
-                        MQTT_NS::make_lambda_visitor<void>(
+                        MQTT_NS::make_lambda_visitor(
                             [&](MQTT_NS::v5::property::reason_string const& t) {
                                 BOOST_TEST(t.val() == "test success");
                             },
@@ -1586,7 +1586,7 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
                 BOOST_TEST(props.size() == size);
                 for (auto const& p : props) {
                     MQTT_NS::visit(
-                        MQTT_NS::make_lambda_visitor<void>(
+                        MQTT_NS::make_lambda_visitor(
                             [&](MQTT_NS::v5::property::reason_string const& t) {
                                 BOOST_TEST(t.val() == "test success");
                             },
@@ -1620,7 +1620,7 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
                 BOOST_TEST(props.size() == size);
                 for (auto const& p : props) {
                     MQTT_NS::visit(
-                        MQTT_NS::make_lambda_visitor<void>(
+                        MQTT_NS::make_lambda_visitor(
                             [&](MQTT_NS::v5::property::reason_string const& t) {
                                 BOOST_TEST(t.val() == "test success");
                             },

--- a/test/connect.cpp
+++ b/test/connect.cpp
@@ -954,7 +954,7 @@ BOOST_AUTO_TEST_CASE( connect_disconnect_prop ) {
                 BOOST_TEST(size == props.size());
                 for (auto const& p : props) {
                     MQTT_NS::visit(
-                        MQTT_NS::make_lambda_visitor<void>(
+                        MQTT_NS::make_lambda_visitor(
                             [&](MQTT_NS::v5::property::session_expiry_interval const& t) {
                                 BOOST_TEST(t.val() == 0x12345678UL);
                             },
@@ -1009,7 +1009,7 @@ BOOST_AUTO_TEST_CASE( connect_disconnect_prop ) {
                 BOOST_TEST(size == props.size());
                 for (auto const& p : props) {
                     MQTT_NS::visit(
-                        MQTT_NS::make_lambda_visitor<void>(
+                        MQTT_NS::make_lambda_visitor(
                             [&](MQTT_NS::v5::property::session_expiry_interval const& t) {
                                 BOOST_TEST(t.val() == 0x12345678UL);
                             },
@@ -1132,7 +1132,7 @@ BOOST_AUTO_TEST_CASE( connack_prop ) {
 
                 for (auto const& p : props) {
                     MQTT_NS::visit(
-                        MQTT_NS::make_lambda_visitor<void>(
+                        MQTT_NS::make_lambda_visitor(
                             [&](MQTT_NS::v5::property::session_expiry_interval const& t) {
                                 BOOST_TEST(t.val() == 0);
                             },

--- a/test/pubsub.cpp
+++ b/test/pubsub.cpp
@@ -2524,7 +2524,7 @@ BOOST_AUTO_TEST_CASE( pub_sub_prop ) {
 
                 for (auto const& p : props) {
                     MQTT_NS::visit(
-                        MQTT_NS::make_lambda_visitor<void>(
+                        MQTT_NS::make_lambda_visitor(
                             [&](MQTT_NS::v5::property::payload_format_indicator const& t) {
                                 BOOST_TEST(t.val() == MQTT_NS::v5::property::payload_format_indicator::string);
                             },
@@ -2662,7 +2662,7 @@ BOOST_AUTO_TEST_CASE( puback_prop ) {
                 BOOST_TEST(props.size() == puback_prop_size);
                 for (auto const& p : props) {
                     MQTT_NS::visit(
-                        MQTT_NS::make_lambda_visitor<void>(
+                        MQTT_NS::make_lambda_visitor(
                             [&](MQTT_NS::v5::property::reason_string const& t) {
                                 BOOST_TEST(t.val() == "test success");
                             },
@@ -2822,7 +2822,7 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
                 BOOST_TEST(props.size() == size);
                 for (auto const& p : props) {
                     MQTT_NS::visit(
-                        MQTT_NS::make_lambda_visitor<void>(
+                        MQTT_NS::make_lambda_visitor(
                             [&](MQTT_NS::v5::property::reason_string const& t) {
                                 BOOST_TEST(t.val() == "test success");
                             },
@@ -2883,7 +2883,7 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
                 BOOST_TEST(props.size() == pubrec_prop_size);
                 for (auto const& p : props) {
                     MQTT_NS::visit(
-                        MQTT_NS::make_lambda_visitor<void>(
+                        MQTT_NS::make_lambda_visitor(
                             [&](MQTT_NS::v5::property::reason_string const& t) {
                                 BOOST_TEST(t.val() == "test success");
                             },
@@ -2923,7 +2923,7 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
                 BOOST_TEST(props.size() == pubcomp_prop_size);
                 for (auto const& p : props) {
                     MQTT_NS::visit(
-                        MQTT_NS::make_lambda_visitor<void>(
+                        MQTT_NS::make_lambda_visitor(
                             [&](MQTT_NS::v5::property::reason_string const& t) {
                                 BOOST_TEST(t.val() == "test success");
                             },

--- a/test/resend.cpp
+++ b/test/resend.cpp
@@ -59,7 +59,7 @@ BOOST_AUTO_TEST_CASE( publish_qos1 ) {
 
                 for (auto const& p : props) {
                     MQTT_NS::visit(
-                        MQTT_NS::make_lambda_visitor<void>(
+                        MQTT_NS::make_lambda_visitor(
                             [&](MQTT_NS::v5::property::payload_format_indicator const& t) {
                                 BOOST_TEST(t.val() == MQTT_NS::v5::property::payload_format_indicator::string);
                             },
@@ -447,7 +447,7 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2 ) {
                 BOOST_TEST(props.size() == size);
                 for (auto const& p : props) {
                     MQTT_NS::visit(
-                        MQTT_NS::make_lambda_visitor<void>(
+                        MQTT_NS::make_lambda_visitor(
                             [&](MQTT_NS::v5::property::reason_string const& t) {
                                 BOOST_TEST(t.val() == "test success");
                             },

--- a/test/resend_new_client.cpp
+++ b/test/resend_new_client.cpp
@@ -676,7 +676,7 @@ BOOST_AUTO_TEST_CASE( publish_qos1_v5 ) {
 
             for (auto const& p : props) {
                 MQTT_NS::visit(
-                    MQTT_NS::make_lambda_visitor<void>(
+                    MQTT_NS::make_lambda_visitor(
                         [&](MQTT_NS::v5::property::payload_format_indicator const& t) {
                             BOOST_TEST(t.val() == MQTT_NS::v5::property::payload_format_indicator::string);
                         },
@@ -1033,7 +1033,7 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2_v5 ) {
             BOOST_TEST(props.size() == size);
             for (auto const& p : props) {
                 MQTT_NS::visit(
-                    MQTT_NS::make_lambda_visitor<void>(
+                    MQTT_NS::make_lambda_visitor(
                         [&](MQTT_NS::v5::property::reason_string const& t) {
                             BOOST_TEST(t.val() == "test success");
                         },

--- a/test/resend_serialize.cpp
+++ b/test/resend_serialize.cpp
@@ -920,7 +920,7 @@ BOOST_AUTO_TEST_CASE( publish_qos1_v5 ) {
 
             for (auto const& p : props) {
                 MQTT_NS::visit(
-                    MQTT_NS::make_lambda_visitor<void>(
+                    MQTT_NS::make_lambda_visitor(
                         [&](MQTT_NS::v5::property::payload_format_indicator const& t) {
                             BOOST_TEST(t.val() == MQTT_NS::v5::property::payload_format_indicator::string);
                         },
@@ -1313,7 +1313,7 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2_v5 ) {
             BOOST_TEST(props.size() == size);
             for (auto const& p : props) {
                 MQTT_NS::visit(
-                    MQTT_NS::make_lambda_visitor<void>(
+                    MQTT_NS::make_lambda_visitor(
                         [&](MQTT_NS::v5::property::reason_string const& t) {
                             BOOST_TEST(t.val() == "test success");
                         },

--- a/test/resend_serialize_ptr_size.cpp
+++ b/test/resend_serialize_ptr_size.cpp
@@ -746,7 +746,7 @@ BOOST_AUTO_TEST_CASE( publish_qos1_v5 ) {
 
             for (auto const& p : props) {
                 MQTT_NS::visit(
-                    MQTT_NS::make_lambda_visitor<void>(
+                    MQTT_NS::make_lambda_visitor(
                         [&](MQTT_NS::v5::property::payload_format_indicator const& t) {
                             BOOST_TEST(t.val() == MQTT_NS::v5::property::payload_format_indicator::string);
                         },
@@ -1111,7 +1111,7 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2_v5 ) {
             BOOST_TEST(props.size() == size);
             for (auto const& p : props) {
                 MQTT_NS::visit(
-                    MQTT_NS::make_lambda_visitor<void>(
+                    MQTT_NS::make_lambda_visitor(
                         [&](MQTT_NS::v5::property::reason_string const& t) {
                             BOOST_TEST(t.val() == "test success");
                         },

--- a/test/retain.cpp
+++ b/test/retain.cpp
@@ -728,7 +728,7 @@ BOOST_AUTO_TEST_CASE( prop ) {
 
                 for (auto const& p : props) {
                     MQTT_NS::visit(
-                        MQTT_NS::make_lambda_visitor<void>(
+                        MQTT_NS::make_lambda_visitor(
                             [&](MQTT_NS::v5::property::payload_format_indicator const& t) {
                                 BOOST_TEST(t.val() == MQTT_NS::v5::property::payload_format_indicator::string);
                             },

--- a/test/sub.cpp
+++ b/test/sub.cpp
@@ -779,7 +779,7 @@ BOOST_AUTO_TEST_CASE( sub_unsub_prop ) {
                 BOOST_TEST(props.size() == size);
                 for (auto const& p : props) {
                     MQTT_NS::visit(
-                        MQTT_NS::make_lambda_visitor<void>(
+                        MQTT_NS::make_lambda_visitor(
                             [&](MQTT_NS::v5::property::subscription_identifier const& t) {
                                 BOOST_TEST(t.val() == 268435455UL);
                             },
@@ -813,7 +813,7 @@ BOOST_AUTO_TEST_CASE( sub_unsub_prop ) {
                 BOOST_TEST(props.size() == size);
                 for (auto const& p : props) {
                     MQTT_NS::visit(
-                        MQTT_NS::make_lambda_visitor<void>(
+                        MQTT_NS::make_lambda_visitor(
                             [&](MQTT_NS::v5::property::user_property const& t) {
                                 switch (unsub_user_prop_count++) {
                                 case 0:
@@ -937,7 +937,7 @@ BOOST_AUTO_TEST_CASE( suback_unsuback_prop ) {
                 BOOST_TEST(props.size() == suback_prop_size);
                 for (auto const& p : props) {
                     MQTT_NS::visit(
-                        MQTT_NS::make_lambda_visitor<void>(
+                        MQTT_NS::make_lambda_visitor(
                             [&](MQTT_NS::v5::property::reason_string const& t) {
                                 BOOST_TEST(t.val() == "test success");
                             },
@@ -974,7 +974,7 @@ BOOST_AUTO_TEST_CASE( suback_unsuback_prop ) {
                 BOOST_TEST(props.size() == unsuback_prop_size);
                 for (auto const& p : props) {
                     MQTT_NS::visit(
-                        MQTT_NS::make_lambda_visitor<void>(
+                        MQTT_NS::make_lambda_visitor(
                             [&](MQTT_NS::v5::property::reason_string const& t) {
                                 BOOST_TEST(t.val() == "test success");
                             },

--- a/test/test_broker.hpp
+++ b/test/test_broker.hpp
@@ -439,7 +439,7 @@ private:
         if (ep.get_protocol_version() == MQTT_NS::protocol_version::v5) {
             for (auto const& p : props) {
                 MQTT_NS::visit(
-                    MQTT_NS::make_lambda_visitor<void>(
+                    MQTT_NS::make_lambda_visitor(
                         [&session_expiry_interval](MQTT_NS::v5::property::session_expiry_interval const& t) {
                             if (t.val() != 0) {
                                 session_expiry_interval.emplace(boost::posix_time::seconds(t.val()));

--- a/test/will.cpp
+++ b/test/will.cpp
@@ -868,7 +868,7 @@ BOOST_AUTO_TEST_CASE( will_prop ) {
 
             for (auto const& p : props) {
                 MQTT_NS::visit(
-                    MQTT_NS::make_lambda_visitor<void>(
+                    MQTT_NS::make_lambda_visitor(
                         [&](MQTT_NS::v5::property::payload_format_indicator const& t) {
                             BOOST_TEST(t.val() == MQTT_NS::v5::property::payload_format_indicator::string);
                         },


### PR DESCRIPTION
It works well with non const operator()().
It requires boost 1.67 or later.