### PR TITLE
Added protocol error processing if control packets are received before

### DIFF
--- a/include/mqtt/endpoint.hpp
+++ b/include/mqtt/endpoint.hpp
@@ -4223,55 +4223,88 @@ private:
             if (mqtt_connected_) {
                 process_publish(force_move(session_life_keeper), remaining_length_ < packet_bulk_read_limit_, force_move(self));
             }
+            else {
+                call_protocol_error_handlers();
+            }
             break;
         case control_packet_type::puback:
             if (mqtt_connected_) {
                 process_puback(force_move(session_life_keeper), remaining_length_ < packet_bulk_read_limit_, force_move(self));
+            }
+            else {
+                call_protocol_error_handlers();
             }
             break;
         case control_packet_type::pubrec:
             if (mqtt_connected_) {
                 process_pubrec(force_move(session_life_keeper), remaining_length_ < packet_bulk_read_limit_, force_move(self));
             }
+            else {
+                call_protocol_error_handlers();
+            }
             break;
         case control_packet_type::pubrel:
             if (mqtt_connected_) {
                 process_pubrel(force_move(session_life_keeper), remaining_length_ < packet_bulk_read_limit_, force_move(self));
+            }
+            else {
+                call_protocol_error_handlers();
             }
             break;
         case control_packet_type::pubcomp:
             if (mqtt_connected_) {
                 process_pubcomp(force_move(session_life_keeper), remaining_length_ < packet_bulk_read_limit_, force_move(self));
             }
+            else {
+                call_protocol_error_handlers();
+            }
             break;
         case control_packet_type::subscribe:
             if (mqtt_connected_) {
                 process_subscribe(force_move(session_life_keeper), remaining_length_ < packet_bulk_read_limit_, force_move(self));
+            }
+            else {
+                call_protocol_error_handlers();
             }
             break;
         case control_packet_type::suback:
             if (mqtt_connected_) {
                 process_suback(force_move(session_life_keeper), remaining_length_ < packet_bulk_read_limit_, force_move(self));
             }
+            else {
+                call_protocol_error_handlers();
+            }
             break;
         case control_packet_type::unsubscribe:
             if (mqtt_connected_) {
                 process_unsubscribe(force_move(session_life_keeper), remaining_length_ < packet_bulk_read_limit_, force_move(self));
+            }
+            else {
+                call_protocol_error_handlers();
             }
             break;
         case control_packet_type::unsuback:
             if (mqtt_connected_) {
                 process_unsuback(force_move(session_life_keeper), remaining_length_ < packet_bulk_read_limit_, force_move(self));
             }
+            else {
+                call_protocol_error_handlers();
+            }
             break;
         case control_packet_type::pingreq:
             if (mqtt_connected_) {
                 process_pingreq(force_move(session_life_keeper));
             }
+            else {
+                call_protocol_error_handlers();
+            }
             break;
         case control_packet_type::pingresp:
             if (mqtt_connected_) {
                 process_pingresp(force_move(session_life_keeper));
+            }
+            else {
+                call_protocol_error_handlers();
             }
             break;
         case control_packet_type::disconnect:


### PR DESCRIPTION
connect/connack is received.

The error handler is also called force_disconnect() is called just
before process_payload() is called. It is expected behavior.
If error handler is not called, then the client has no way to get
trigger to reconnect. The session is silently stopped. It is not good.