### PR TITLE
add getter for client_id_

### DIFF
--- a/include/mqtt/client.hpp
+++ b/include/mqtt/client.hpp
@@ -255,6 +255,14 @@ public:
     }
 
     /**
+     * @brief Get the client id.
+     * @return The client id of this client.
+     */
+    std::string const& get_client_id() const {
+        return client_id_;
+    }
+
+    /**
      * @brief Set clean session.
      * @param cs clean session
      *


### PR DESCRIPTION
Some applications might want to access the client id on an mqtt_client after it is set. This PR exposes the client id.