### PR TITLE
Fixed type mismatch warning.

### DIFF
--- a/include/mqtt/endpoint.hpp
+++ b/include/mqtt/endpoint.hpp
@@ -3985,7 +3985,7 @@ protected:
         connected_ = true;
     }
 
-    void set_protocol_version(std::size_t version) {
+    void set_protocol_version(protocol_version version) {
         version_ = version;
     }
 


### PR DESCRIPTION
Thanks to clang 10.0.0, the mismatch is detected.