### PR TITLE
Replaced template Stream with std::ostream.

### DIFF
--- a/include/mqtt/connect_return_code.hpp
+++ b/include/mqtt/connect_return_code.hpp
@@ -8,6 +8,8 @@
 #define MQTT_CONNECT_RETURN_CODE_HPP
 
 #include <cstdint>
+#include <ostream>
+
 #include <mqtt/namespace.hpp>
 
 namespace MQTT_NS {
@@ -37,8 +39,8 @@ char const* connect_return_code_to_str(connect_return_code v) {
     return "unknown_connect_return_code";
 }
 
-template<typename Stream>
-Stream & operator<<(Stream & os, connect_return_code val)
+inline
+std::ostream& operator<<(std::ostream& os, connect_return_code val)
 {
     os << connect_return_code_to_str(val);
     return os;

--- a/include/mqtt/control_packet_type.hpp
+++ b/include/mqtt/control_packet_type.hpp
@@ -8,6 +8,8 @@
 #define MQTT_CONTROL_PACKET_TYPE_HPP
 
 #include <cstdint>
+#include <ostream>
+
 #include <mqtt/namespace.hpp>
 
 namespace MQTT_NS {
@@ -59,8 +61,8 @@ char const* control_packet_type_to_str(control_packet_type v) {
     }
 }
 
-template<typename Stream>
-Stream & operator<<(Stream & os, control_packet_type val)
+inline
+std::ostream& operator<<(std::ostream& os, control_packet_type val)
 {
     os << control_packet_type_to_str(val);
     return os;

--- a/include/mqtt/publish.hpp
+++ b/include/mqtt/publish.hpp
@@ -8,6 +8,7 @@
 #define MQTT_PUBLISH_HPP
 
 #include <cstdint>
+#include <ostream>
 
 #include <boost/assert.hpp>
 
@@ -107,8 +108,9 @@ constexpr char const* retain_to_str(retain v) {
     }
 }
 
-template<typename Stream>
-Stream & operator<<(Stream & os, retain val)
+
+inline
+std::ostream& operator<<(std::ostream& os, retain val)
 {
     os << retain_to_str(val);
     return os;
@@ -122,8 +124,9 @@ constexpr char const* dup_to_str(dup v) {
     }
 }
 
-template<typename Stream>
-Stream & operator<<(Stream & os, dup val)
+
+inline
+std::ostream& operator<<(std::ostream& os, dup val)
 {
     os << dup_to_str(val);
     return os;

--- a/include/mqtt/reason_code.hpp
+++ b/include/mqtt/reason_code.hpp
@@ -8,6 +8,7 @@
 #define MQTT_REASON_CODE_HPP
 
 #include <cstdint>
+#include <ostream>
 #include <mqtt/namespace.hpp>
 #include <mqtt/subscribe_options.hpp>
 
@@ -32,8 +33,8 @@ char const* suback_return_code_to_str(suback_return_code v) {
     }
 }
 
-template<typename Stream>
-Stream & operator<<(Stream & os, suback_return_code val)
+inline
+std::ostream& operator<<(std::ostream& os, suback_return_code val)
 {
     os << suback_return_code_to_str(val);
     return os;
@@ -102,8 +103,8 @@ char const* connect_reason_code_to_str(connect_reason_code v) {
     }
 }
 
-template<typename Stream>
-Stream & operator<<(Stream & os, connect_reason_code val)
+inline
+std::ostream& operator<<(std::ostream& os, connect_reason_code val)
 {
     os << connect_reason_code_to_str(val);
     return os;
@@ -178,8 +179,8 @@ char const* disconnect_reason_code_to_str(disconnect_reason_code v) {
     }
 }
 
-template<typename Stream>
-Stream & operator<<(Stream & os, disconnect_reason_code val)
+inline
+std::ostream& operator<<(std::ostream& os, disconnect_reason_code val)
 {
     os << disconnect_reason_code_to_str(val);
     return os;
@@ -221,8 +222,8 @@ char const* suback_reason_code_to_str(suback_reason_code v) {
     }
 }
 
-template<typename Stream>
-Stream & operator<<(Stream & os, suback_reason_code val)
+inline
+std::ostream& operator<<(std::ostream& os, suback_reason_code val)
 {
     os << suback_reason_code_to_str(val);
     return os;
@@ -257,8 +258,8 @@ char const* unsuback_reason_code_to_str(unsuback_reason_code v) {
     }
 }
 
-template<typename Stream>
-Stream & operator<<(Stream & os, unsuback_reason_code val)
+inline
+std::ostream& operator<<(std::ostream& os, unsuback_reason_code val)
 {
     os << unsuback_reason_code_to_str(val);
     return os;
@@ -293,8 +294,8 @@ char const* puback_reason_code_to_str(puback_reason_code v) {
     }
 }
 
-template<typename Stream>
-Stream & operator<<(Stream & os, puback_reason_code val)
+inline
+std::ostream& operator<<(std::ostream& os, puback_reason_code val)
 {
     os << puback_reason_code_to_str(val);
     return os;
@@ -329,8 +330,8 @@ char const* pubrec_reason_code_to_str(pubrec_reason_code v) {
     }
 }
 
-template<typename Stream>
-Stream & operator<<(Stream & os, pubrec_reason_code val)
+inline
+std::ostream& operator<<(std::ostream& os, pubrec_reason_code val)
 {
     os << pubrec_reason_code_to_str(val);
     return os;
@@ -351,8 +352,8 @@ char const* pubrel_reason_code_to_str(pubrel_reason_code v) {
     }
 }
 
-template<typename Stream>
-Stream & operator<<(Stream & os, pubrel_reason_code val)
+inline
+std::ostream& operator<<(std::ostream& os, pubrel_reason_code val)
 {
     os << pubrel_reason_code_to_str(val);
     return os;
@@ -373,8 +374,8 @@ char const* pubcomp_reason_code_to_str(pubcomp_reason_code v) {
     }
 }
 
-template<typename Stream>
-Stream & operator<<(Stream & os, pubcomp_reason_code val)
+inline
+std::ostream& operator<<(std::ostream& os, pubcomp_reason_code val)
 {
     os << pubcomp_reason_code_to_str(val);
     return os;
@@ -397,8 +398,8 @@ char const* auth_reason_code_to_str(auth_reason_code v) {
     }
 }
 
-template<typename Stream>
-Stream & operator<<(Stream & os, auth_reason_code val)
+inline
+std::ostream& operator<<(std::ostream& os, auth_reason_code val)
 {
     os << auth_reason_code_to_str(val);
     return os;

--- a/include/mqtt/subscribe_options.hpp
+++ b/include/mqtt/subscribe_options.hpp
@@ -8,6 +8,7 @@
 #define MQTT_SUBSCRIBE_OPTIONS_HPP
 
 #include <cstdint>
+#include <ostream>
 #include <mqtt/namespace.hpp>
 
 namespace MQTT_NS {
@@ -101,8 +102,8 @@ constexpr char const* retain_handling_to_str(retain_handling v) {
     }
 }
 
-template<typename Stream>
-Stream & operator<<(Stream & os, retain_handling val)
+inline
+std::ostream& operator<<(std::ostream& os, retain_handling val)
 {
     os << retain_handling_to_str(val);
     return os;
@@ -116,8 +117,8 @@ constexpr char const* rap_to_str(rap v) {
     }
 }
 
-template<typename Stream>
-Stream & operator<<(Stream & os, rap val)
+inline
+std::ostream& operator<<(std::ostream& os, rap val)
 {
     os << rap_to_str(val);
     return os;
@@ -131,8 +132,8 @@ constexpr char const* nl_to_str(nl v) {
     }
 }
 
-template<typename Stream>
-Stream & operator<<(Stream & os, nl val)
+inline
+std::ostream& operator<<(std::ostream& os, nl val)
 {
     os << nl_to_str(val);
     return os;
@@ -147,8 +148,8 @@ constexpr char const* qos_to_str(qos v) {
     }
 }
 
-template<typename Stream>
-Stream & operator<<(Stream & os, qos val)
+inline
+std::ostream& operator<<(std::ostream& os, qos val)
 {
     os << qos_to_str(val);
     return os;


### PR DESCRIPTION
It avoids ambiguous matching.