### PR TITLE
Added topic alias support.

### DIFF
--- a/include/mqtt/client.hpp
+++ b/include/mqtt/client.hpp
@@ -1389,20 +1389,18 @@ private:
     }
 
     static optional<session_expiry_interval_t> get_session_expiry_interval_by_props(v5::properties const& props) {
-        bool finish = false;
-        optional<session_expiry_interval_t > val;
+        optional<session_expiry_interval_t> val;
         for (auto const& prop : props) {
             MQTT_NS::visit(
                 make_lambda_visitor(
-                    [&finish, &val](v5::property::session_expiry_interval const& p) {
+                    [&val](v5::property::session_expiry_interval const& p) {
                         val = p.val();
-                        finish = true;
                     },
                     [](auto&&) {
                     }
                 ), prop
             );
-            if (finish) break;
+            if (val) break;
         }
         return val;
     }

--- a/include/mqtt/constant.hpp
+++ b/include/mqtt/constant.hpp
@@ -12,6 +12,7 @@
 namespace MQTT_NS {
 
 static constexpr session_expiry_interval_t const session_never_expire = 0xffffffffUL;
+static constexpr topic_alias_t const topic_alias_max = 0xffff;
 
 } // namespace MQTT_NS
 

--- a/include/mqtt/setup_log.hpp
+++ b/include/mqtt/setup_log.hpp
@@ -127,6 +127,7 @@ void setup_log(severity_level threshold = severity_level::warning) {
         {
             { "mqtt_api", threshold },
             { "mqtt_cb", threshold },
+            { "mqtt_impl", threshold },
         }
     );
 }

--- a/include/mqtt/topic_alias_recv.hpp
+++ b/include/mqtt/topic_alias_recv.hpp
@@ -1,0 +1,70 @@
+// Copyright Takatoshi Kondo 2020
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(MQTT_TOPIC_ALIAS_RECV_HPP)
+#define MQTT_TOPIC_ALIAS_RECV_HPP
+
+#include <string>
+#include <map>
+#include <array>
+
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/member.hpp>
+
+#include <mqtt/string_view.hpp>
+#include <mqtt/constant.hpp>
+#include <mqtt/type.hpp>
+#include <mqtt/log.hpp>
+
+namespace MQTT_NS {
+
+using topic_alias_recv_map_t = std::map<topic_alias_t, std::string>;
+
+inline void register_topic_alias(topic_alias_recv_map_t& m,  string_view topic, topic_alias_t alias) {
+    BOOST_ASSERT(alias > 0 && alias <= topic_alias_max);
+
+    MQTT_LOG("mqtt_impl", info)
+        << MQTT_ADD_VALUE(address, &m)
+        << "register_topic_alias"
+        << " topic:" << topic
+        << " alias:" << alias;
+
+    if (topic.empty()) {
+        m.erase(alias);
+    }
+    else {
+        m[alias] = std::string(topic); // overwrite
+    }
+}
+
+inline std::string find_topic_by_alias(topic_alias_recv_map_t const& m,  topic_alias_t alias) {
+    BOOST_ASSERT(alias > 0 && alias <= topic_alias_max);
+
+    std::string topic;
+    auto it = m.find(alias);
+    if (it != m.end()) topic = it->second;
+
+    MQTT_LOG("mqtt_impl", info)
+        << MQTT_ADD_VALUE(address, &m)
+        << "find_topic_by_alias"
+        << " alias:" << alias
+        << " topic:" << topic;
+
+    return topic;
+}
+
+inline void clear_topic_alias(topic_alias_recv_map_t& m) {
+    MQTT_LOG("mqtt_impl", info)
+        << MQTT_ADD_VALUE(address, &m)
+        << "clear_topic_alias";
+
+    m.clear();
+}
+
+} // namespace MQTT_NS
+
+#endif // MQTT_TOPIC_ALIAS_RECV_HPP

--- a/include/mqtt/type.hpp
+++ b/include/mqtt/type.hpp
@@ -12,6 +12,7 @@
 namespace MQTT_NS {
 
 using session_expiry_interval_t = std::uint32_t;
+using topic_alias_t = std::uint16_t;
 
 } // namespace MQTT_NS
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,6 +22,7 @@ IF (MQTT_TEST_1)
     LIST (APPEND check_PROGRAMS
         connect.cpp
         underlying_timeout.cpp
+        topic_alias_recv.cpp
     )
 ENDIF ()
 

--- a/test/as_buffer_async_pubsub_1.cpp
+++ b/test/as_buffer_async_pubsub_1.cpp
@@ -19,6 +19,7 @@ BOOST_AUTO_TEST_SUITE(test_as_buffer_async_pubsub_1)
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         packet_id_t pid_sub;
@@ -233,6 +234,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
 BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         packet_id_t pid_pub;
@@ -459,6 +461,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
 BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         packet_id_t pid_pub;
@@ -687,6 +690,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         packet_id_t pid_sub;
@@ -900,6 +904,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
 BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         packet_id_t pid_pub;
@@ -1124,6 +1129,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
 BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         packet_id_t pid_pub;

--- a/test/as_buffer_async_pubsub_2.cpp
+++ b/test/as_buffer_async_pubsub_2.cpp
@@ -19,6 +19,7 @@ BOOST_AUTO_TEST_SUITE(test_as_buffer_async_pubsub_2)
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         std::uint16_t pid_sub;
@@ -237,6 +238,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
 BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         std::uint16_t pid_pub;
@@ -470,6 +472,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
 BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         std::uint16_t pid_pub;
@@ -705,6 +708,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
 BOOST_AUTO_TEST_CASE( publish_function ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         std::uint16_t pid_sub;
@@ -917,6 +921,7 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
 BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         std::uint16_t pid_sub;
@@ -1123,6 +1128,7 @@ BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
 BOOST_AUTO_TEST_CASE( publish_dup_function ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         std::uint16_t pid_sub;

--- a/test/as_buffer_pubsub.cpp
+++ b/test/as_buffer_pubsub.cpp
@@ -16,6 +16,7 @@ BOOST_AUTO_TEST_SUITE(test_as_buffer_pubsub)
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         std::uint16_t pid_sub;
@@ -195,6 +196,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
 BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
         bool pub_seq_finished = false;
 
@@ -383,6 +385,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
 BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         std::uint16_t pid_pub;
@@ -572,6 +575,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         std::uint16_t pid_sub;
@@ -750,6 +754,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
 BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         std::uint16_t pid_pub;
@@ -943,6 +948,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
 BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         std::uint16_t pid_pub;
@@ -1139,6 +1145,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         std::uint16_t pid_sub;
@@ -1318,6 +1325,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
 BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         std::uint16_t pid_pub;
@@ -1511,6 +1519,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
 BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         std::uint16_t pid_pub;
@@ -1707,6 +1716,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
 BOOST_AUTO_TEST_CASE( publish_function ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         std::uint16_t pid_sub;
@@ -1881,6 +1891,7 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
 BOOST_AUTO_TEST_CASE( publish_dup_function ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         std::uint16_t pid_sub;

--- a/test/as_buffer_sub.cpp
+++ b/test/as_buffer_sub.cpp
@@ -18,6 +18,7 @@ using namespace std::literals::string_literals;
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_single ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
 
@@ -109,6 +110,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_single ) {
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
 
@@ -212,6 +214,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg ) {
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
 
@@ -313,6 +316,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec ) {
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_single_async ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         checker chk = {
@@ -417,6 +421,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_single_async ) {
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg_async ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
 
@@ -536,6 +541,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg_async ) {
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec_async ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
 

--- a/test/async_pubsub_1.cpp
+++ b/test/async_pubsub_1.cpp
@@ -19,6 +19,7 @@ BOOST_AUTO_TEST_SUITE(test_async_pubsub_1)
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         std::uint16_t pid_sub;
@@ -202,6 +203,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
 BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         std::uint16_t pid_pub;
@@ -401,6 +403,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
 BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         std::uint16_t pid_pub;
@@ -593,6 +596,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         std::uint16_t pid_sub;
@@ -776,6 +780,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
 BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         std::uint16_t pid_pub;
@@ -969,6 +974,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
 BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         std::uint16_t pid_pub;

--- a/test/async_pubsub_2.cpp
+++ b/test/async_pubsub_2.cpp
@@ -21,6 +21,7 @@ using namespace MQTT_NS::literals;
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         std::uint16_t pid_sub;
@@ -204,6 +205,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
 BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         std::uint16_t pid_pub;
@@ -400,6 +402,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
 BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         std::uint16_t pid_pub;
@@ -598,6 +601,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
 BOOST_AUTO_TEST_CASE( publish_function ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         std::uint16_t pid_sub;
@@ -776,6 +780,7 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
 BOOST_AUTO_TEST_CASE( publish_dup_function ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         std::uint16_t pid_sub;
@@ -959,6 +964,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
 BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         std::uint16_t pid_sub;
@@ -1147,6 +1153,7 @@ BOOST_AUTO_TEST_CASE( pub_sub_prop ) {
         }
 
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         std::uint16_t pid_sub;
@@ -1224,7 +1231,12 @@ BOOST_AUTO_TEST_CASE( pub_sub_prop ) {
                 BOOST_TEST(topic == "topic1");
                 BOOST_TEST(contents == "topic1_contents");
 
-                BOOST_TEST(props.size() == prop_size);
+                // -1 means TopicAlias
+                // TopicAlias is not forwarded
+                // https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901113
+                // A receiver MUST NOT carry forward any Topic Alias mappings from
+                // one Network Connection to another [MQTT-3.3.2-7].
+                BOOST_TEST(props.size() == prop_size - 1);
 
                 for (auto const& p : props) {
                     MQTT_NS::visit(
@@ -1234,9 +1246,6 @@ BOOST_AUTO_TEST_CASE( pub_sub_prop ) {
                             },
                             [&](MQTT_NS::v5::property::message_expiry_interval const& t) {
                                 BOOST_TEST(t.val() == 0x12345678UL);
-                            },
-                            [&](MQTT_NS::v5::property::topic_alias const& t) {
-                                BOOST_TEST(t.val() == 0x1234U);
                             },
                             [&](MQTT_NS::v5::property::response_topic const& t) {
                                 BOOST_TEST(t.val() == "response topic");
@@ -1323,6 +1332,7 @@ BOOST_AUTO_TEST_CASE( puback_props ) {
         }
 
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
         c->set_auto_pub_response(false);
 
@@ -1504,6 +1514,7 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
         //    * test target
 
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
         c->set_auto_pub_response(false);
 

--- a/test/connect.cpp
+++ b/test/connect.cpp
@@ -1198,10 +1198,11 @@ BOOST_AUTO_TEST_CASE( async_pingresp_timeout ) {
 
 BOOST_AUTO_TEST_CASE( connect_prop ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& b) {
-    if (c->get_protocol_version() != MQTT_NS::protocol_version::v5) {
-        finish();
-        return;
-    }
+        if (c->get_protocol_version() != MQTT_NS::protocol_version::v5) {
+            finish();
+            return;
+        }
+
         c->set_client_id("cid1");
         c->set_clean_session(true);
         BOOST_TEST(c->connected() == false);
@@ -1319,10 +1320,11 @@ BOOST_AUTO_TEST_CASE( connect_prop ) {
 
 BOOST_AUTO_TEST_CASE( disconnect_prop ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& b) {
-    if (c->get_protocol_version() != MQTT_NS::protocol_version::v5) {
-        finish();
-        return;
-    }
+        if (c->get_protocol_version() != MQTT_NS::protocol_version::v5) {
+            finish();
+            return;
+        }
+
         c->set_client_id("cid1");
         c->set_clean_session(true);
         BOOST_TEST(c->connected() == false);

--- a/test/length_check.cpp
+++ b/test/length_check.cpp
@@ -21,6 +21,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
         }
 
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
 

--- a/test/manual_publish.cpp
+++ b/test/manual_publish.cpp
@@ -16,6 +16,7 @@ BOOST_AUTO_TEST_SUITE(test_manual_publish)
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
 

--- a/test/multi_sub.cpp
+++ b/test/multi_sub.cpp
@@ -23,6 +23,7 @@ BOOST_AUTO_TEST_CASE( multi_channel ) {
         }
 
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         std::uint16_t pid_sub;

--- a/test/pubsub.cpp
+++ b/test/pubsub.cpp
@@ -18,6 +18,7 @@ using namespace MQTT_NS::literals;
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         packet_id_t pid_sub;
@@ -196,6 +197,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
 BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
         bool pub_seq_finished = false;
 
@@ -392,6 +394,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
 BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         packet_id_t pid_pub;
@@ -581,6 +584,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         packet_id_t pid_sub;
@@ -759,6 +763,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
 BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         packet_id_t pid_pub;
@@ -951,6 +956,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
 BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         packet_id_t pid_pub;
@@ -1147,6 +1153,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         packet_id_t pid_sub;
@@ -1327,6 +1334,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
 BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         packet_id_t pid_pub;
@@ -1520,6 +1528,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
 BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         packet_id_t pid_pub;
@@ -1716,6 +1725,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
 BOOST_AUTO_TEST_CASE( publish_function ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         packet_id_t pid_sub;
@@ -1890,6 +1900,7 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
 BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         packet_id_t pid_sub;
@@ -2064,6 +2075,7 @@ BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
 BOOST_AUTO_TEST_CASE( publish_dup_function ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         packet_id_t pid_sub;
@@ -2243,6 +2255,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
 BOOST_AUTO_TEST_CASE( publish_dup_function_buffer ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         packet_id_t pid_sub;
@@ -2427,6 +2440,7 @@ BOOST_AUTO_TEST_CASE( pub_sub_prop ) {
         }
 
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         packet_id_t pid_sub;
@@ -2521,7 +2535,12 @@ BOOST_AUTO_TEST_CASE( pub_sub_prop ) {
                 BOOST_TEST(topic == "topic1");
                 BOOST_TEST(contents == "topic1_contents");
 
-                BOOST_TEST(props.size() == prop_size);
+                // -1 means TopicAlias
+                // TopicAlias is not forwarded
+                // https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901113
+                // A receiver MUST NOT carry forward any Topic Alias mappings from
+                // one Network Connection to another [MQTT-3.3.2-7].
+                BOOST_TEST(props.size() == prop_size - 1);
 
                 for (auto const& p : props) {
                     MQTT_NS::visit(
@@ -2534,9 +2553,6 @@ BOOST_AUTO_TEST_CASE( pub_sub_prop ) {
                             },
                             [&](MQTT_NS::v5::property::message_expiry_interval const& t) {
                                 BOOST_TEST(t.val() == 0x12345678UL);
-                            },
-                            [&](MQTT_NS::v5::property::topic_alias const& t) {
-                                BOOST_TEST(t.val() == 0x1234U);
                             },
                             [&](MQTT_NS::v5::property::response_topic const& t) {
                                 BOOST_TEST(t.val() == "response topic");
@@ -2604,6 +2620,7 @@ BOOST_AUTO_TEST_CASE( puback_prop ) {
         }
 
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         packet_id_t pid_pub;
@@ -2768,6 +2785,7 @@ BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
         }
 
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
         c->set_auto_pub_response(false);
 

--- a/test/pubsub_no_strand.cpp
+++ b/test/pubsub_no_strand.cpp
@@ -43,6 +43,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
     boost::asio::io_context ioc;
     auto c = MQTT_NS::make_client_no_strand(ioc, broker_url, broker_notls_port);
     using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+    c->set_client_id("cid1");
     c->set_clean_session(true);
 
     std::uint16_t pid_sub;
@@ -168,6 +169,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
     boost::asio::io_context ioc;
     auto c = MQTT_NS::make_client_no_strand(ioc, broker_url, broker_notls_port);
     using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+    c->set_client_id("cid1");
     c->set_clean_session(true);
 
     std::uint16_t pid_pub;
@@ -293,6 +295,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
     boost::asio::io_context ioc;
     auto c = MQTT_NS::make_client_no_strand(ioc, broker_url, broker_notls_port);
     using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+    c->set_client_id("cid1");
     c->set_clean_session(true);
 
     std::uint16_t pid_pub;
@@ -420,6 +423,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
     boost::asio::io_context ioc;
     auto c = MQTT_NS::make_client_no_strand(ioc, broker_url, broker_notls_port);
     using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+    c->set_client_id("cid1");
     c->set_clean_session(true);
 
     std::uint16_t pid_sub;
@@ -542,6 +546,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
     boost::asio::io_context ioc;
     auto c = MQTT_NS::make_client_no_strand(ioc, broker_url, broker_notls_port);
     using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+    c->set_client_id("cid1");
     c->set_clean_session(true);
 
     std::uint16_t pid_pub;
@@ -676,6 +681,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
     boost::asio::io_context ioc;
     auto c = MQTT_NS::make_client_no_strand(ioc, broker_url, broker_notls_port);
     using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+    c->set_client_id("cid1");
     c->set_clean_session(true);
 
     std::uint16_t pid_pub;
@@ -813,6 +819,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
     boost::asio::io_context ioc;
     auto c = MQTT_NS::make_client_no_strand(ioc, broker_url, broker_notls_port);
     using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+    c->set_client_id("cid1");
     c->set_clean_session(true);
 
     std::uint16_t pid_sub;
@@ -936,6 +943,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
     boost::asio::io_context ioc;
     auto c = MQTT_NS::make_client_no_strand(ioc, broker_url, broker_notls_port);
     using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+    c->set_client_id("cid1");
     c->set_clean_session(true);
 
     std::uint16_t pid_pub;
@@ -1071,6 +1079,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
     boost::asio::io_context ioc;
     auto c = MQTT_NS::make_client_no_strand(ioc, broker_url, broker_notls_port);
     using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+    c->set_client_id("cid1");
     c->set_clean_session(true);
 
     std::uint16_t pid_pub;
@@ -1208,6 +1217,7 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
     boost::asio::io_context ioc;
     auto c = MQTT_NS::make_client_no_strand(ioc, broker_url, broker_notls_port);
     using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+    c->set_client_id("cid1");
     c->set_clean_session(true);
 
     std::uint16_t pid_sub;

--- a/test/remaining_length.cpp
+++ b/test/remaining_length.cpp
@@ -26,6 +26,7 @@ BOOST_AUTO_TEST_CASE( pub_sub_over_127 ) {
             test_contents.push_back(static_cast<char>(i));
         }
 
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         std::uint16_t pid_sub;
@@ -136,6 +137,7 @@ BOOST_AUTO_TEST_CASE( pub_sub_over_16384 ) {
             test_contents.push_back(static_cast<char>(i & 0xff));
         }
 
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         std::uint16_t pid_sub;
@@ -248,6 +250,7 @@ BOOST_AUTO_TEST_CASE( pub_sub_over_2097152 ) {
             test_contents.push_back(static_cast<char>(i % 0xff));
         }
 
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         std::uint16_t pid_sub;

--- a/test/resend.cpp
+++ b/test/resend.cpp
@@ -20,7 +20,7 @@ BOOST_AUTO_TEST_CASE( publish_qos1 ) {
         c->set_client_id("cid1");
         c->set_clean_session(true);
 
-        std::uint16_t pid_pub;
+        packet_id_t pid_pub;
 
         boost::asio::steady_timer tim(ioc);
 
@@ -244,7 +244,7 @@ BOOST_AUTO_TEST_CASE( publish_qos2 ) {
         c->set_client_id("cid1");
         c->set_clean_session(true);
 
-        std::uint16_t pid_pub;
+        packet_id_t pid_pub;
 
         boost::asio::steady_timer tim(ioc);
 
@@ -413,7 +413,7 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2 ) {
         c->set_client_id("cid1");
         c->set_clean_session(true);
 
-        std::uint16_t pid_pub;
+        packet_id_t pid_pub;
 
         boost::asio::steady_timer tim(ioc);
 
@@ -633,7 +633,7 @@ BOOST_AUTO_TEST_CASE( publish_pubrel_qos2 ) {
         c->set_client_id("cid1");
         c->set_clean_session(true);
 
-        std::uint16_t pid_pub;
+        packet_id_t pid_pub;
 
         boost::asio::steady_timer tim(ioc);
 
@@ -842,8 +842,8 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1 ) {
         c->set_client_id("cid1");
         c->set_clean_session(true);
 
-        std::uint16_t pid_pub1;
-        std::uint16_t pid_pub2;
+        packet_id_t pid_pub1;
+        packet_id_t pid_pub2;
 
         boost::asio::steady_timer tim(ioc);
 
@@ -1028,7 +1028,7 @@ BOOST_AUTO_TEST_CASE( publish_session_before_expire ) {
         c->set_client_id("cid1");
         c->set_clean_session(true);
 
-        std::uint16_t pid_pub;
+        packet_id_t pid_pub;
 
         boost::asio::steady_timer tim(ioc);
 
@@ -1162,7 +1162,7 @@ BOOST_AUTO_TEST_CASE( publish_session_after_expire ) {
         c->set_client_id("cid1");
         c->set_clean_session(true);
 
-        std::uint16_t pid_pub;
+        packet_id_t pid_pub;
 
         boost::asio::steady_timer tim(ioc);
 

--- a/test/retain_1.cpp
+++ b/test/retain_1.cpp
@@ -18,6 +18,7 @@ using namespace MQTT_NS::literals;
 BOOST_AUTO_TEST_CASE( simple ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         std::uint16_t pid_sub;
@@ -196,6 +197,7 @@ BOOST_AUTO_TEST_CASE( simple ) {
 BOOST_AUTO_TEST_CASE( overwrite ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
         std::uint16_t pid_sub;

--- a/test/sub.cpp
+++ b/test/sub.cpp
@@ -20,6 +20,7 @@ using namespace std::literals::string_literals;
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_single ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
 
@@ -111,6 +112,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_single ) {
 BOOST_AUTO_TEST_CASE( sub_v5_options ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
 
@@ -205,6 +207,7 @@ BOOST_AUTO_TEST_CASE( sub_v5_options ) {
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
 
@@ -308,6 +311,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg ) {
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
 
@@ -415,6 +419,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec ) {
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_single_async ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
 
@@ -506,6 +511,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_single_async ) {
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg_async ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
 
@@ -623,6 +629,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg_async ) {
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec_async ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
 
@@ -747,6 +754,7 @@ BOOST_AUTO_TEST_CASE( sub_unsub_prop ) {
         }
 
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
 
@@ -889,6 +897,7 @@ BOOST_AUTO_TEST_CASE( suback_unsuback_prop ) {
         }
 
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
         c->set_clean_session(true);
 
 

--- a/test/topic_alias_recv.cpp
+++ b/test/topic_alias_recv.cpp
@@ -1,0 +1,684 @@
+// Copyright Takatoshi Kondo 2020
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include "test_main.hpp"
+#include "combi_test.hpp"
+#include "checker.hpp"
+#include "test_util.hpp"
+#include "global_fixture.hpp"
+
+#include <mqtt/optional.hpp>
+
+BOOST_AUTO_TEST_SUITE(test_topic_alias_recv)
+
+using namespace MQTT_NS::literals;
+
+BOOST_AUTO_TEST_CASE( pubsub ) {
+    auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+
+        if (c->get_protocol_version() != MQTT_NS::protocol_version::v5) {
+            finish();
+            return;
+        }
+
+        using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
+        c->set_clean_session(true);
+
+        checker chk = {
+            // connect
+            cont("h_connack"),
+            // subscribe topic1 QoS0
+            cont("h_suback"),
+            // publish topic1 alias1 QoS0
+            // publish alias1 QoS0
+            cont("h_publsh1"),
+            cont("h_publish2"),
+            cont("h_unsuback"),
+            // disconnect
+            cont("h_close"),
+        };
+
+        switch (c->get_protocol_version()) {
+        case MQTT_NS::protocol_version::v5:
+            c->set_v5_connack_handler(
+                [&chk, &c]
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
+                    MQTT_CHK("h_connack");
+                    BOOST_TEST(sp == false);
+                    BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
+                    c->subscribe("topic1", MQTT_NS::qos::at_most_once);
+                    return true;
+                });
+            c->set_v5_puback_handler(
+                []
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
+                    BOOST_CHECK(false);
+                    return true;
+                });
+            c->set_v5_pubrec_handler(
+                []
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
+                    BOOST_CHECK(false);
+                    return true;
+                });
+            c->set_v5_pubcomp_handler(
+                []
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
+                    BOOST_CHECK(false);
+                    return true;
+                });
+            c->set_v5_suback_handler(
+                [&chk, &c]
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
+                    MQTT_CHK("h_suback");
+                    BOOST_TEST(reasons.size() == 1U);
+                    BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_0);
+                    // register topic alias
+                    c->publish(
+                        "topic1",
+                        "topic1_contents_1",
+                        MQTT_NS::qos::at_most_once,
+                        MQTT_NS::v5::properties {
+                            MQTT_NS::v5::property::topic_alias(0x1U)
+                        }
+                    );
+                    // use topic alias
+                    c->publish(
+                        "",
+                        "topic1_contents_2",
+                        MQTT_NS::qos::at_most_once,
+                        MQTT_NS::v5::properties {
+                            MQTT_NS::v5::property::topic_alias(0x1U)
+                        }
+                    );
+                    return true;
+                });
+            c->set_v5_unsuback_handler(
+                [&chk, &c]
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
+                    MQTT_CHK("h_unsuback");
+                    BOOST_TEST(reasons.size() == 1U);
+                    BOOST_TEST(reasons[0] == MQTT_NS::v5::unsuback_reason_code::success);
+                    c->disconnect();
+                    return true;
+                });
+            c->set_v5_publish_handler(
+                [&chk, &c]
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
+                 MQTT_NS::buffer topic,
+                 MQTT_NS::buffer contents,
+                 MQTT_NS::v5::properties /*props*/) {
+                    auto ret = chk.match(
+                        "h_suback",
+                        [&] {
+                            MQTT_CHK("h_publsh1");
+                            BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                            BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                            BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
+                            BOOST_CHECK(!packet_id);
+                            BOOST_TEST(topic == "topic1");
+                            BOOST_TEST(contents == "topic1_contents_1");
+                        },
+                        "h_publsh1",
+                        [&] {
+                            MQTT_CHK("h_publish2");
+                            BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                            BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                            BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
+                            BOOST_CHECK(!packet_id);
+                            BOOST_TEST(topic == "topic1");
+                            BOOST_TEST(contents == "topic1_contents_2");
+                            c->unsubscribe("topic1");
+                        }
+                    );
+                    BOOST_TEST(ret);
+                    return true;
+                });
+            break;
+        default:
+            BOOST_CHECK(false);
+            break;
+        }
+
+        c->set_close_handler(
+            [&chk, &finish]
+            () {
+                MQTT_CHK("h_close");
+                finish();
+            });
+        c->set_error_handler(
+            []
+            (MQTT_NS::error_code) {
+                BOOST_CHECK(false);
+            });
+        c->set_pub_res_sent_handler(
+            []
+            (packet_id_t) {
+                BOOST_CHECK(false);
+            });
+        c->connect();
+        ioc.run();
+        BOOST_TEST(chk.all());
+    };
+    do_combi_test_sync(test);
+}
+
+BOOST_AUTO_TEST_CASE( overwrite ) {
+    auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+
+        if (c->get_protocol_version() != MQTT_NS::protocol_version::v5) {
+            finish();
+            return;
+        }
+
+        using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
+        c->set_clean_session(true);
+
+        checker chk = {
+            // connect
+            cont("h_connack"),
+            // subscribe topic1 QoS0
+            cont("h_suback1"),
+            cont("h_suback2"),
+            // publish topic1 alias1 QoS0
+            // publish topic2 alias1 QoS0
+            // publish alias1 QoS0
+            cont("h_publish1"),
+            cont("h_publish2"),
+            cont("h_publish3"),
+            cont("h_unsuback1"),
+            cont("h_unsuback2"),
+            // disconnect
+            cont("h_close"),
+        };
+
+        switch (c->get_protocol_version()) {
+        case MQTT_NS::protocol_version::v5:
+            c->set_v5_connack_handler(
+                [&chk, &c]
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
+                    MQTT_CHK("h_connack");
+                    BOOST_TEST(sp == false);
+                    BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
+                    c->subscribe("topic1", MQTT_NS::qos::at_most_once);
+                    c->subscribe("topic2", MQTT_NS::qos::at_most_once);
+                    return true;
+                });
+            c->set_v5_puback_handler(
+                []
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
+                    BOOST_CHECK(false);
+                    return true;
+                });
+            c->set_v5_pubrec_handler(
+                []
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
+                    BOOST_CHECK(false);
+                    return true;
+                });
+            c->set_v5_pubcomp_handler(
+                []
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
+                    BOOST_CHECK(false);
+                    return true;
+                });
+            c->set_v5_suback_handler(
+                [&chk, &c]
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
+                    auto ret = chk.match(
+                        "h_connack",
+                        [&] {
+                            MQTT_CHK("h_suback1");
+                        },
+                        "h_suback1",
+                        [&] {
+                            MQTT_CHK("h_suback2");
+                            BOOST_TEST(reasons.size() == 1U);
+                            BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_0);
+                            // register topic alias
+                            c->publish(
+                                "topic1",
+                                "topic1_contents_1",
+                                MQTT_NS::qos::at_most_once,
+                                MQTT_NS::v5::properties {
+                                    MQTT_NS::v5::property::topic_alias(0x1U)
+                                }
+                            );
+                            // overwrite topic alias
+                            c->publish(
+                                "topic2",
+                                "topic1_contents_2",
+                                MQTT_NS::qos::at_most_once,
+                                MQTT_NS::v5::properties {
+                                    MQTT_NS::v5::property::topic_alias(0x1U)
+                                        }
+                            );
+                            // use topic alias
+                            c->publish(
+                                "",
+                                "topic1_contents_3",
+                                MQTT_NS::qos::at_most_once,
+                                MQTT_NS::v5::properties {
+                                    MQTT_NS::v5::property::topic_alias(0x1U)
+                                }
+                            );
+                        }
+                    );
+                    BOOST_TEST(ret);
+                    return true;
+                });
+            c->set_v5_unsuback_handler(
+                [&chk, &c]
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
+                    auto ret = chk.match(
+                        "h_publish3",
+                        [&] {
+                            MQTT_CHK("h_unsuback1");
+                            BOOST_TEST(reasons.size() == 1U);
+                            BOOST_TEST(reasons[0] == MQTT_NS::v5::unsuback_reason_code::success);
+                        },
+                        "h_unsuback1",
+                        [&] {
+                            MQTT_CHK("h_unsuback2");
+                            BOOST_TEST(reasons.size() == 1U);
+                            BOOST_TEST(reasons[0] == MQTT_NS::v5::unsuback_reason_code::success);
+                            c->disconnect();
+                        }
+                    );
+                    BOOST_TEST(ret);
+                    return true;
+                });
+            c->set_v5_publish_handler(
+                [&chk, &c]
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
+                 MQTT_NS::buffer topic,
+                 MQTT_NS::buffer contents,
+                 MQTT_NS::v5::properties /*props*/) {
+                    auto ret = chk.match(
+                        "h_suback1",
+                        [&] {
+                            MQTT_CHK("h_publish1");
+                            BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                            BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                            BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
+                            BOOST_CHECK(!packet_id);
+                            BOOST_TEST(topic == "topic1");
+                            BOOST_TEST(contents == "topic1_contents_1");
+                        },
+                        "h_publish1",
+                        [&] {
+                            MQTT_CHK("h_publish2");
+                            BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                            BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                            BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
+                            BOOST_CHECK(!packet_id);
+                            BOOST_TEST(topic == "topic2");
+                            BOOST_TEST(contents == "topic1_contents_2");
+                        },
+                        "h_publish2",
+                        [&] {
+                            MQTT_CHK("h_publish3");
+                            BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                            BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                            BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
+                            BOOST_CHECK(!packet_id);
+                            BOOST_TEST(topic == "topic2");
+                            BOOST_TEST(contents == "topic1_contents_3");
+                            c->unsubscribe("topic1");
+                            c->unsubscribe("topic2");
+                        }
+                    );
+                    BOOST_TEST(ret);
+                    return true;
+                });
+            break;
+        default:
+            BOOST_CHECK(false);
+            break;
+        }
+
+        c->set_close_handler(
+            [&chk, &finish]
+            () {
+                MQTT_CHK("h_close");
+                finish();
+            });
+        c->set_error_handler(
+            []
+            (MQTT_NS::error_code) {
+                BOOST_CHECK(false);
+            });
+        c->set_pub_res_sent_handler(
+            []
+            (packet_id_t) {
+                BOOST_CHECK(false);
+            });
+        c->connect();
+        ioc.run();
+        BOOST_TEST(chk.all());
+    };
+    do_combi_test_sync(test);
+}
+
+BOOST_AUTO_TEST_CASE( no_entry ) {
+    auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+
+        if (c->get_protocol_version() != MQTT_NS::protocol_version::v5) {
+            finish();
+            return;
+        }
+
+        using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
+        c->set_clean_session(true);
+
+        checker chk = {
+            // connect
+            cont("h_connack"),
+            // publish topic_alias1 QoS0
+            cont("h_suback"),
+            // publish  QoS0
+            cont("h_disconnect"),
+            // disconnect
+            cont("h_error"),
+        };
+
+        switch (c->get_protocol_version()) {
+        case MQTT_NS::protocol_version::v5:
+            c->set_v5_connack_handler(
+                [&chk, &c]
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
+                    MQTT_CHK("h_connack");
+                    BOOST_TEST(sp == false);
+                    BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
+                    c->subscribe("topic1", MQTT_NS::qos::at_most_once);
+                    return true;
+                });
+            c->set_v5_puback_handler(
+                []
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
+                    BOOST_CHECK(false);
+                    return true;
+                });
+            c->set_v5_pubrec_handler(
+                []
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
+                    BOOST_CHECK(false);
+                    return true;
+                });
+            c->set_v5_pubcomp_handler(
+                []
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
+                    BOOST_CHECK(false);
+                    return true;
+                });
+            c->set_v5_suback_handler(
+                [&chk, &c]
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
+                    MQTT_CHK("h_suback");
+                    BOOST_TEST(reasons.size() == 1U);
+                    BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_0);
+                    // use no existing topic alias
+                    c->publish(
+                        "",
+                        "topic1_contents",
+                        MQTT_NS::qos::at_most_once,
+                        MQTT_NS::v5::properties {
+                            MQTT_NS::v5::property::topic_alias(0x1U)
+                        }
+                    );
+                    return true;
+                });
+            c->set_v5_unsuback_handler(
+                [&chk]
+                (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::unsuback_reason_code> /*reasons*/, MQTT_NS::v5::properties /*props*/) {
+                    BOOST_CHECK(false);
+                    return true;
+                });
+            c->set_v5_publish_handler(
+                [&chk]
+                (MQTT_NS::optional<packet_id_t> /*packet_id*/,
+                 MQTT_NS::publish_options /*pubopts*/,
+                 MQTT_NS::buffer /*topic*/,
+                 MQTT_NS::buffer /*contents*/,
+                 MQTT_NS::v5::properties /*props*/) {
+                    BOOST_CHECK(false);
+                    return true;
+                });
+            c->set_v5_disconnect_handler(
+                [&chk]
+                (MQTT_NS::v5::disconnect_reason_code reason_code, MQTT_NS::v5::properties /*props*/) {
+                    MQTT_CHK("h_disconnect");
+                    BOOST_TEST(reason_code == MQTT_NS::v5::disconnect_reason_code::protocol_error);
+                }
+            );
+            break;
+        default:
+            BOOST_CHECK(false);
+            break;
+        }
+
+        c->set_close_handler(
+            []
+            () {
+                BOOST_CHECK(false);
+            });
+        c->set_error_handler(
+            [&chk, &finish]
+            (MQTT_NS::error_code) {
+                MQTT_CHK("h_error");
+                finish();
+            });
+        c->set_pub_res_sent_handler(
+            []
+            (packet_id_t) {
+                BOOST_CHECK(false);
+            });
+        c->connect();
+        ioc.run();
+        BOOST_TEST(chk.all());
+    };
+    do_combi_test_sync(test);
+}
+
+BOOST_AUTO_TEST_CASE( resend_publish ) {
+    auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+
+        if (c->get_protocol_version() != MQTT_NS::protocol_version::v5) {
+            finish();
+            return;
+        }
+
+        using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
+        c->set_clean_session(true);
+
+        boost::asio::steady_timer tim(ioc);
+
+        checker chk = {
+            cont("start"),
+            // connect
+            cont("h_connack1"),
+            // disconnect
+            cont("h_close1"),
+            // connect
+            cont("h_connack2"),
+            // subscribe topic1 QoS0
+            cont("h_suback"),
+            // publish topic1 alias1 QoS0
+            // publish alias1 QoS1
+            deps("h_error", "h_suback"),
+            cont("h_connack3"),
+            cont("h_puback"),
+            deps("h_publish", "h_connack3"),
+            cont("h_unsuback"),
+            // disconnect
+            cont("h_close2"),
+        };
+
+        switch (c->get_protocol_version()) {
+        case MQTT_NS::protocol_version::v5:
+            c->set_v5_connack_handler(
+                [&chk, &c]
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
+                    auto ret = chk.match(
+                        "start",
+                        [&] {
+                            MQTT_CHK("h_connack1");
+                            BOOST_TEST(sp == false);
+                            c->disconnect();
+                        },
+                        "h_close1",
+                        [&] {
+                            MQTT_CHK("h_connack2");
+                            BOOST_TEST(sp == false);
+                            BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
+                            c->subscribe("topic1", MQTT_NS::qos::at_least_once);
+                        },
+                        "h_error",
+                        [&] {
+                            MQTT_CHK("h_connack3");
+                            BOOST_TEST(sp == true);
+                            BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
+                        }
+                    );
+                    return true;
+                });
+            c->set_v5_puback_handler(
+                [&chk, &c]
+                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
+                    MQTT_CHK("h_puback");
+                    c->disconnect();
+                    return true;
+                });
+            c->set_v5_pubrec_handler(
+                []
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
+                    BOOST_CHECK(false);
+                    return true;
+                });
+            c->set_v5_pubcomp_handler(
+                []
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
+                    BOOST_CHECK(false);
+                    return true;
+                });
+            c->set_v5_suback_handler(
+                [&chk, &c]
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
+                    MQTT_CHK("h_suback");
+                    BOOST_TEST(reasons.size() == 1U);
+                    BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_1);
+                    // register topic alias
+                    c->publish(
+                        "topic1",
+                        "topic1_contents_1",
+                        MQTT_NS::qos::at_most_once,
+                        MQTT_NS::v5::properties {
+                            MQTT_NS::v5::property::topic_alias(0x1U)
+                        }
+                    );
+                    // use topic alias
+                    c->publish(
+                        "",
+                        "topic1_contents_2",
+                        MQTT_NS::qos::at_least_once,
+                        MQTT_NS::v5::properties {
+                            MQTT_NS::v5::property::topic_alias(0x1U)
+                        }
+                    );
+
+                    // 1st publish is lost because QoS0 but topic_alias is registered
+                    // 2nd publish will be resent in the future.
+                    // However, it contains empty topic and topic_alias.
+                    // mqtt_cpp keeps topic_alias map's life time as the same as session lifetime
+                    // so resend would be successfully finished.
+                    // See https://lists.oasis-open.org/archives/mqtt-comment/202009/msg00000.html
+                    c->force_disconnect();
+
+                    return true;
+                });
+            c->set_v5_unsuback_handler(
+                [&chk, &c]
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
+                    MQTT_CHK("h_unsuback");
+                    BOOST_TEST(reasons.size() == 1U);
+                    BOOST_TEST(reasons[0] == MQTT_NS::v5::unsuback_reason_code::success);
+                    c->disconnect();
+                    return true;
+                });
+            c->set_v5_publish_handler(
+                [&chk, &c]
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
+                 MQTT_NS::buffer topic,
+                 MQTT_NS::buffer contents,
+                 MQTT_NS::v5::properties /*props*/) {
+                    MQTT_CHK("h_publish");
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
+                    BOOST_TEST(topic == "topic1");
+                    BOOST_TEST(contents == "topic1_contents_2");
+                    c->unsubscribe("topic1");
+                    return true;
+                });
+            break;
+        default:
+            BOOST_CHECK(false);
+            break;
+        }
+
+        c->set_close_handler(
+            [&chk, &c, &finish]
+            () {
+                auto ret = chk.match(
+                    "h_connack1",
+                    [&] {
+                        MQTT_CHK("h_close1");
+                        connect_no_clean(c);
+                    },
+                    "h_puback",
+                    [&] {
+                        MQTT_CHK("h_close2");
+                        finish();
+                    }
+                );
+                BOOST_TEST(ret);
+            });
+        c->set_error_handler(
+            [&chk, &c, &tim]
+            (MQTT_NS::error_code) {
+                MQTT_CHK("h_error");
+                // TCP level disconnection detecting timing is unpredictable.
+                // Sometimes broker first, sometimes the client (this test) first.
+                // This test assume that the broker detects first, so I set timer.
+                // If client detect the disconnection first, then reconnect with
+                // existing client id. And it is overwritten at broker.
+                // Then error handler in the broker called, assertion failed due to
+                // no corresponding connection exists
+                tim.expires_after(std::chrono::milliseconds(100));
+                tim.async_wait(
+                    [&c] (MQTT_NS::error_code ec) {
+                        BOOST_ASSERT( ! ec);
+                        connect_no_clean(c);
+                    }
+                );
+            });
+        MQTT_CHK("start");
+        c->connect();
+        ioc.run();
+        BOOST_TEST(chk.all());
+    };
+    do_combi_test_sync(test);
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
TopicAlias lifetime is the same as Session lifetime
It is different from MQTT v5 spec but practical choice.
See
https://lists.oasis-open.org/archives/mqtt-comment/202009/msg00000.html

Related fix:

When topic is empty and no topic alias entry is found, then
protocol_error.
The broker send DISCONNECT packet with protocol_error reason code.

process_disconnect implementation was simply doesn't call
`on_mqtt_message_processed()` but it was bad.
It caused exit from ioc.run() loop because the next async_read was not
called.
The correct behavior is calling `on_mqtt_message_processed()` and close
socket. The endpoint can detect the socket close by on_error().