### PR TITLE
Fixed #669.

### DIFF
--- a/include/mqtt/type_erased_socket.hpp
+++ b/include/mqtt/type_erased_socket.hpp
@@ -56,7 +56,11 @@ using socket = shared_any<
         has_lowest_layer<as::ip::tcp::socket::lowest_layer_type&()>,
         has_native_handle<any()>,
         has_close<void(boost::system::error_code&)>,
+#if BOOST_VERSION < 107400 || defined(BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT)
         has_get_executor<as::executor()>
+#else  // BOOST_VERSION < 107400 || defined(BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT)
+        has_get_executor<as::any_io_executor()>
+#endif // BOOST_VERSION < 107400 || defined(BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT)
     >
 >;
 


### PR DESCRIPTION
Fixed compile error on boost 1.74.0 or later.
If boost version is lower than 1.74.0 or
BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT is defined, then use
boost::asio::executor, otherwise use boost::asio::any_io_executor on
type erased socket.