### PR TITLE
Use multiindex in retained_map to use both hash map as well as ordered index

### DIFF
--- a/include/mqtt/string_view.hpp
+++ b/include/mqtt/string_view.hpp
@@ -41,14 +41,6 @@ using string_view = boost::string_view;
 template<class CharT, class Traits = std::char_traits<CharT> >
 using basic_string_view = boost::basic_string_view<CharT, Traits>;
 
-#if BOOST_VERSION < 106900
-
-template <class charT, class traits>
-std::size_t hash_value(basic_string_view<charT, traits> s) {
-    return boost::hash_range(s.begin(), s.end());
-}
-#endif // BOOST_VERSION < 106900
-
 } // namespace MQTT_NS
 
 #else  // BOOST_VERSION >= 106100
@@ -67,6 +59,16 @@ using basic_string_view = boost::basic_string_ref<CharT, Traits>;
 } // namespace MQTT_NS
 
 #endif // BOOST_VERSION >= 106100
+
+#if BOOST_VERSION < 106900
+namespace boost {
+template <class charT, class traits>
+std::size_t hash_value(basic_string_view<charT, traits> s) {
+    return boost::hash_range(s.begin(), s.end());
+}
+}
+
+#endif // BOOST_VERSION < 106900
 
 #endif // !defined(MQTT_NO_BOOST_STRING_VIEW)
 

--- a/test/retained_topic_map.cpp
+++ b/test/retained_topic_map.cpp
@@ -10,6 +10,8 @@
 
 #include "retained_topic_map.hpp"
 
+#include <boost/format.hpp>
+
 BOOST_AUTO_TEST_SUITE(test_retained_map)
 
 BOOST_AUTO_TEST_CASE(general) {
@@ -17,6 +19,7 @@ BOOST_AUTO_TEST_CASE(general) {
     map.insert_or_update("a/b/c", "123");
     BOOST_TEST(map.size() == 1);
     BOOST_TEST(map.internal_size() == 4);
+
 
     BOOST_TEST(map.insert_or_update("a/b", "123") == 1);
     BOOST_TEST(map.size() == 2);
@@ -40,7 +43,7 @@ BOOST_AUTO_TEST_CASE(general) {
         "example/test/A", "example/test/B", "example/A/test", "example/B/test"
     };
 
-    for (auto const& i: values) {
+    for (auto const& i : values) {
         map.insert_or_update(i, i);
     }
     BOOST_TEST(map.size() == 4);
@@ -195,5 +198,30 @@ BOOST_AUTO_TEST_CASE(erase_upper_first) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(large_number_of_topics) {
+    retained_topic_map<size_t> map;
+
+    constexpr size_t num_topics = 10000;
+    for (size_t i = 0; i < num_topics; ++i) {
+        map.insert_or_update((boost::format("topic/%d") % i).str(), i);
+    }
+
+    BOOST_TEST(map.size() == num_topics);
+    for (size_t i = 0; i < num_topics; ++i) {
+        map.find(
+            (boost::format("topic/%d") % i).str(),
+            [&](size_t value) {
+                BOOST_TEST(value == i);
+            }
+        );
+   }
+
+    for (size_t i = 0; i < num_topics; ++i) {
+        map.erase((boost::format("topic/%d") % i).str());
+    }
+
+    BOOST_TEST(map.size() == 0);
+    BOOST_TEST(map.internal_size() == 1);
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/subscription_map.hpp
+++ b/test/subscription_map.hpp
@@ -1,4 +1,4 @@
-// Copyright wkl04 2019
+// Copyright Wouter van Kleunen 2019
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at


### PR DESCRIPTION
The following PR allows for optimization in retained_map by using two indices: hash map for direct key acccess, ordered index for wildcard access. 