### PR TITLE
Performance optimization in multiple_subscription_map: switch between flat_map and unordered_map

### DIFF
--- a/test/subscription_map.cpp
+++ b/test/subscription_map.cpp
@@ -257,10 +257,27 @@ BOOST_AUTO_TEST_CASE( test_multiple_subscription_modify ) {
     map.insert_or_update("a/b/c", "123", my());
     map.insert_or_update("a/b/c", "456", my());
 
-    map.modify("a/b/c", [](std::string const& /*key*/, my &value) {
+    map.modify("a/b/c", [](std::string const& /*key*/, my& value) {
         value.const_mem_fun();
         value.non_const_mem_fun();
     });
+}
+
+BOOST_AUTO_TEST_CASE( test_multiple_subscription_large ) {
+    multiple_subscription_map<int, int> map;
+
+    size_t total_entries = 10000;
+    for(size_t i = 0; i < total_entries; ++i)
+        map.insert_or_update("a/b/c", i, i);
+
+    BOOST_TEST(map.size() == total_entries);
+    BOOST_TEST(map.internal_size() > 1u);
+
+    for(size_t i = 0; i < total_entries; ++i)
+        map.erase("a/b/c", i);
+
+    BOOST_TEST(map.size() == 0);
+    BOOST_TEST(map.internal_size() == 1);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/subscription_map_broker.cpp
+++ b/test/subscription_map_broker.cpp
@@ -124,6 +124,10 @@ bool sub_con_offline_cref_equal_to::operator()(sub_con_offline_cref const& lhs, 
     return lhs.get().client_id == rhs.get().client_id && lhs.get().topic_filter == rhs.get().topic_filter;
 }
 
+inline bool operator<(sub_con_online_cref lhs, sub_con_online_cref rhs) {
+    return &lhs.get() < &rhs.get();
+}
+
 struct tag_con {};
 struct tag_topic_filter {};
 struct tag_con_topic_filter {};


### PR DESCRIPTION
I allowed the multiple_subscription_map to use both a flat_map and an unordered_map. The flat_map is used initially, it has much lower memory usage and allows for fast iteration. Iteration is used to visit all the connections subscribed to a topic. 

The unordered_map is used if number of subscribers to a single topic is >1500. It has much better insert/delete performance when subscribing and unsubscribing topics, but iteration is slower. 