### PR TITLE
Subscription map and retained map allow storing move-only classes

### DIFF
--- a/test/retained_topic_map.cpp
+++ b/test/retained_topic_map.cpp
@@ -16,16 +16,16 @@ BOOST_AUTO_TEST_SUITE(test_retained_map)
 
 BOOST_AUTO_TEST_CASE(general) {
     retained_topic_map<std::string> map;
-    map.insert_or_update("a/b/c", "123");
+    map.insert_or_assign("a/b/c", "123");
     BOOST_TEST(map.size() == 1);
     BOOST_TEST(map.internal_size() == 4);
 
 
-    BOOST_TEST(map.insert_or_update("a/b", "123") == 1);
+    BOOST_TEST(map.insert_or_assign("a/b", "123") == 1);
     BOOST_TEST(map.size() == 2);
     BOOST_TEST(map.internal_size() == 4);
 
-    BOOST_TEST(map.insert_or_update("a/b", "123") == 0);
+    BOOST_TEST(map.insert_or_assign("a/b", "123") == 0);
     BOOST_TEST(map.size() == 2);
     BOOST_TEST(map.internal_size() == 4);
 
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE(general) {
     };
 
     for (auto const& i : values) {
-        map.insert_or_update(i, i);
+        map.insert_or_assign(i, i);
     }
     BOOST_TEST(map.size() == 4);
 
@@ -111,8 +111,8 @@ BOOST_AUTO_TEST_CASE(general) {
 
 BOOST_AUTO_TEST_CASE(erase_lower_first) {
     retained_topic_map<std::string> map;
-    map.insert_or_update("a/b/c", "1");
-    map.insert_or_update("a/b", "2");
+    map.insert_or_assign("a/b/c", "1");
+    map.insert_or_assign("a/b", "2");
 
     auto e1 = map.erase("a/b/c"); // erase lower first
     BOOST_TEST(e1 == 1);
@@ -159,8 +159,8 @@ BOOST_AUTO_TEST_CASE(erase_lower_first) {
 
 BOOST_AUTO_TEST_CASE(erase_upper_first) {
     retained_topic_map<std::string> map;
-    map.insert_or_update("a/b/c", "1");
-    map.insert_or_update("a/b", "2");
+    map.insert_or_assign("a/b/c", "1");
+    map.insert_or_assign("a/b", "2");
 
     auto e1 = map.erase("a/b"); // erase upper first
 
@@ -211,7 +211,7 @@ BOOST_AUTO_TEST_CASE(large_number_of_topics) {
 
     constexpr size_t num_topics = 10000;
     for (size_t i = 0; i < num_topics; ++i) {
-        map.insert_or_update((boost::format("topic/%d") % i).str(), i);
+        map.insert_or_assign((boost::format("topic/%d") % i).str(), i);
     }
 
     BOOST_TEST(map.size() == num_topics);

--- a/test/retained_topic_map_broker.cpp
+++ b/test/retained_topic_map_broker.cpp
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE( multi_non_wc_crud ) {
             MQTT_NS::v5::properties {},
             MQTT_NS::qos::at_most_once
         };
-        m.insert_or_update(r.topic, r);
+        m.insert_or_assign(r.topic, r);
     }
     {
         retain r {
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE( multi_non_wc_crud ) {
             MQTT_NS::v5::properties {},
             MQTT_NS::qos::at_most_once
         };
-        m.insert_or_update(r.topic, r);
+        m.insert_or_assign(r.topic, r);
     }
 
     // subscribe match
@@ -130,7 +130,7 @@ BOOST_AUTO_TEST_CASE( multi_wc_crud ) {
             MQTT_NS::v5::properties {},
             MQTT_NS::qos::at_most_once
         };
-        m.insert_or_update(r.topic, r);
+        m.insert_or_assign(r.topic, r);
     }
     {
         retain r {
@@ -139,7 +139,7 @@ BOOST_AUTO_TEST_CASE( multi_wc_crud ) {
             MQTT_NS::v5::properties {},
             MQTT_NS::qos::at_most_once
         };
-        m.insert_or_update(r.topic, r);
+        m.insert_or_assign(r.topic, r);
     }
 
     // subscribe match

--- a/test/subscription_map.cpp
+++ b/test/subscription_map.cpp
@@ -22,11 +22,11 @@ BOOST_AUTO_TEST_CASE( failed_erase ) {
     auto v2 = std::make_shared<elem_t>(2);
 
     BOOST_TEST(m.size() == 0);
-    auto it_success1 = m.insert_or_update("a/b/c", "test", v1);
+    auto it_success1 = m.insert_or_assign("a/b/c", "test", v1);
     assert(it_success1.second);
     BOOST_TEST(m.size() == 1);
 
-    auto it_success2 = m.insert_or_update("a/b", "test", v2);
+    auto it_success2 = m.insert_or_assign("a/b", "test", v2);
     assert(it_success2.second);
     BOOST_TEST(m.size() == 2);
 
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE( test_single_subscription ) {
     single_subscription_map< std::string > map;
     auto handle = map.insert(text, text);
     BOOST_TEST(handle.second == "A");
-    BOOST_TEST(map.handle_to_subscription(handle) == text);
+    BOOST_TEST(map.handle_to_topic_filter(handle) == text);
     BOOST_CHECK_THROW(map.insert(text, text), std::exception);
     map.update(handle, "new_value");
     map.erase(handle);
@@ -72,9 +72,9 @@ BOOST_AUTO_TEST_CASE( test_single_subscription ) {
 
     // Attempt to remove entry which has no value
     BOOST_TEST(map.erase("example") == 0);
-    BOOST_TEST(map.erase(map.lookup("example")) == 0);
+    BOOST_TEST(map.erase(*map.lookup("example")) == 0);
     BOOST_TEST(map.erase("example") == 0);
-    BOOST_TEST(map.erase(map.lookup("example")) == 0);
+    BOOST_TEST(map.erase(*map.lookup("example")) == 0);
 
     std::vector<std::string> matches;
     map.find("example/test/A", [&matches](std::string const &a) {
@@ -130,7 +130,7 @@ BOOST_AUTO_TEST_CASE( test_multiple_subscription ) {
 
     multiple_subscription_map<std::string, int> map;
 
-    BOOST_TEST(map.insert_or_update("a/b/c", "123", 0).second == true);
+    BOOST_TEST(map.insert_or_assign("a/b/c", "123", 0).second == true);
     BOOST_TEST(map.size() == 1);
     BOOST_TEST(map.internal_size() == 4);
 
@@ -139,7 +139,7 @@ BOOST_AUTO_TEST_CASE( test_multiple_subscription ) {
         BOOST_TEST(value == 0);
     });
 
-    BOOST_TEST(map.insert_or_update("a/b/c", "123", 1).second == false);
+    BOOST_TEST(map.insert_or_assign("a/b/c", "123", 1).second == false);
     BOOST_TEST(map.size() == 1);
     BOOST_TEST(map.internal_size() == 4);
 
@@ -148,7 +148,7 @@ BOOST_AUTO_TEST_CASE( test_multiple_subscription ) {
         BOOST_TEST(value == 1);
     });
 
-    map.insert_or_update("a/b", "123", 0);
+    map.insert_or_assign("a/b", "123", 0);
     BOOST_TEST(map.size() == 2);
     BOOST_TEST(map.internal_size() == 4);
 
@@ -170,9 +170,9 @@ BOOST_AUTO_TEST_CASE( test_multiple_subscription ) {
     };
 
     // Add some duplicates and overlapping paths
-    map.insert_or_update(values[0], values[0], 0);
-    BOOST_TEST(map.insert_or_update(values[0], values[0], 0).second == false);
-    BOOST_TEST(map.insert_or_update(values[0], "blaat", 0).second == true);
+    map.insert_or_assign(values[0], values[0], 0);
+    BOOST_TEST(map.insert_or_assign(values[0], values[0], 0).second == false);
+    BOOST_TEST(map.insert_or_assign(values[0], "blaat", 0).second == true);
 
     map.erase(values[0], "blaat");
     BOOST_TEST(map.size() == 1);
@@ -181,30 +181,32 @@ BOOST_AUTO_TEST_CASE( test_multiple_subscription ) {
     BOOST_TEST(map.size() == 0);
 
     // Perform test again but this time using handles
-    map.insert_or_update(values[0], values[0], 0);
-    BOOST_TEST(map.insert_or_update(map.lookup(values[0]), values[0], 0).second == false);
-    BOOST_TEST(map.insert_or_update(map.lookup(values[0]), "blaat", 0).second == true);
+    map.insert_or_assign(values[0], values[0], 0);
+    BOOST_TEST(map.insert_or_assign(*map.lookup(values[0]), values[0], 0).second == false);
+    BOOST_TEST(map.insert_or_assign(*map.lookup(values[0]), "blaat", 0).second == true);
 
-    map.erase(map.lookup(values[0]), "blaat");
+    BOOST_TEST(!map.lookup("non/exist"));
+
+    map.erase(*map.lookup(values[0]), "blaat");
     BOOST_TEST(map.size() == 1);
 
-    map.erase(map.lookup(values[0]), values[0]);
+    map.erase(*map.lookup(values[0]), values[0]);
     BOOST_TEST(map.size() == 0);
 
     for (auto const& i : values) {
-        map.insert_or_update(i, i, 0);
+        map.insert_or_assign(i, i, 0);
     }
 
     BOOST_TEST(map.size() == 4);
 
     // Attempt to remove entry which has no value
     BOOST_TEST(map.erase("example", "example") == 0);
-    BOOST_TEST(map.erase(map.lookup("example"), "example") == 0);
+    BOOST_TEST(map.erase(*map.lookup("example"), "example") == 0);
     BOOST_TEST(map.erase("example", "example") == 0);
-    BOOST_TEST(map.erase(map.lookup("example"), "example") == 0);
+    BOOST_TEST(map.erase(*map.lookup("example"), "example") == 0);
 
-    BOOST_TEST(map.lookup(values[0]).second == "A");
-    BOOST_TEST(map.handle_to_subscription(map.lookup(values[0])) == values[0]);
+    BOOST_TEST(map.lookup(values[0])->second == "A");
+    BOOST_TEST(map.handle_to_topic_filter(*map.lookup(values[0])) == values[0]);
 
     std::vector<std::string> matches;
     map.find("example/test/A", [&matches](std::string const &a, int /*value*/) {
@@ -253,8 +255,8 @@ BOOST_AUTO_TEST_CASE( test_multiple_subscription_modify ) {
 
     using mi_t = multiple_subscription_map<std::string, my>;
     mi_t map;
-    map.insert_or_update("a/b/c", "123", my());
-    map.insert_or_update("a/b/c", "456", my());
+    map.insert_or_assign("a/b/c", "123", my());
+    map.insert_or_assign("a/b/c", "456", my());
 
     map.modify("a/b/c", [](std::string const& /*key*/, my &value) {
         value.const_mem_fun();
@@ -276,29 +278,8 @@ BOOST_AUTO_TEST_CASE( test_move_only ) {
 
     using mi_t = multiple_subscription_map<std::string, my>;
     mi_t map;
-    map.insert_or_update("a/b/c", "123", my(1));
-    map.insert_or_update("a/b/c", "456", my(2));
+    map.insert_or_assign("a/b/c", "123", my(1));
+    map.insert_or_assign("a/b/c", "456", my(2));
 }
-
-BOOST_AUTO_TEST_CASE( test_move_construct_only ) {
-
-    struct my {
-        my() = delete;
-        my(int) {}
-        my(my const&) = delete;
-        my(my&&) = default;
-        my& operator=(my const&) = delete;
-        my& operator=(my&&) = delete;
-        ~my() = default;
-    };
-
-    using mi_t = multiple_subscription_map<std::string, my>;
-    mi_t map;
-    map.insert_or_update("a/b/c", "123", my(1));
-    map.insert_or_update("a/b/c", "456", my(2));
-}
-
-
-
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/subscription_map_broker.cpp
+++ b/test/subscription_map_broker.cpp
@@ -230,7 +230,7 @@ BOOST_AUTO_TEST_CASE( multi_non_wc_crud ) {
 
         BOOST_CHECK(!elem.h);
         // new insert or update (insert case)
-        auto h = m.insert_or_update(elem.topic_filter, elem, 0);
+        auto h = m.insert_or_assign(elem.topic_filter, elem, 0);
         auto& idx = scos.get<tag_con_topic_filter>();
         idx.modify(
             it,
@@ -252,7 +252,7 @@ BOOST_AUTO_TEST_CASE( multi_non_wc_crud ) {
         }
         else {
             // new insert
-            auto h = m.insert_or_update(elem.topic_filter, elem, 0);
+            auto h = m.insert_or_assign(elem.topic_filter, elem, 0);
             auto& idx = scos.get<tag_con_topic_filter>();
             idx.modify(
                 it,
@@ -401,7 +401,7 @@ BOOST_AUTO_TEST_CASE( multi_non_wc_crud_ow ) {
 
         BOOST_CHECK(!elem.h);
         // new insert or update (insert case)
-        auto h = m.insert_or_update(elem.topic_filter, elem, 0);
+        auto h = m.insert_or_assign(elem.topic_filter, elem, 0);
         auto& idx = scos.get<tag_con_topic_filter>();
         idx.modify(
             it,
@@ -423,7 +423,7 @@ BOOST_AUTO_TEST_CASE( multi_non_wc_crud_ow ) {
         }
         else {
             // new insert
-            auto h = m.insert_or_update(elem.topic_filter, elem, 0);
+            auto h = m.insert_or_assign(elem.topic_filter, elem, 0);
             auto& idx = scos.get<tag_con_topic_filter>();
             idx.modify(
                 it,
@@ -573,7 +573,7 @@ BOOST_AUTO_TEST_CASE( multi_wc_crud ) {
 
         BOOST_CHECK(!elem.h);
         // new insert or update (insert case)
-        auto h = m.insert_or_update(elem.topic_filter, elem, 0);
+        auto h = m.insert_or_assign(elem.topic_filter, elem, 0);
         auto& idx = scos.get<tag_con_topic_filter>();
         idx.modify(
             it,
@@ -595,7 +595,7 @@ BOOST_AUTO_TEST_CASE( multi_wc_crud ) {
         }
         else {
             // new insert
-            auto h = m.insert_or_update(elem.topic_filter, elem, 0);
+            auto h = m.insert_or_assign(elem.topic_filter, elem, 0);
             auto& idx = scos.get<tag_con_topic_filter>();
             idx.modify(
                 it,

--- a/test/test_broker.hpp
+++ b/test/test_broker.hpp
@@ -1262,7 +1262,7 @@ private:
                 retains_.erase(topic);
             }
             else {
-                retains_.insert_or_update(
+                retains_.insert_or_assign(
                     topic,
                     retain {
                         MQTT_NS::force_move(topic),
@@ -1565,7 +1565,7 @@ private:
              topic_filter(MQTT_NS::force_move(topic_filter)),
              subopts(subopts),
              sid(sid),
-             handle(sco_map.insert_or_update(topic_filter, *this, 0).first) {}
+             handle(sco_map.insert_or_assign(topic_filter, *this, 0).first) {}
 
         ~sub_con_online() {
             sco_map.erase(handle, *this);
@@ -1671,7 +1671,7 @@ private:
              topic_filter(MQTT_NS::force_move(topic_filter)),
              subopts(subopts),
              sid(sid),
-             handle(sco_map.insert_or_update(topic_filter, *this, 0).first) {}
+             handle(sco_map.insert_or_assign(topic_filter, *this, 0).first) {}
 
         ~sub_con_offline() {
             sco_map.erase(handle, *this);


### PR DESCRIPTION
Emplace with piecewise_construct is used now to perform insert_or_update. Also retained map performed a move on const reference. This was also not good.