### PR TITLE
Don't use dyn link on windows when compiling tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -96,7 +96,6 @@ ENDIF ()
 FOREACH (source_file ${check_PROGRAMS})
     GET_FILENAME_COMPONENT (source_file_we ${source_file} NAME_WE)
     ADD_EXECUTABLE (${source_file_we} ${source_file})
-    TARGET_COMPILE_DEFINITIONS (${source_file_we} PUBLIC $<IF:$<BOOL:${MQTT_USE_STATIC_BOOST}>,,BOOST_TEST_DYN_LINK>)
     TARGET_LINK_LIBRARIES (
         ${source_file_we} mqtt_cpp_iface Boost::unit_test_framework
     )
@@ -107,6 +106,8 @@ FOREACH (source_file ${check_PROGRAMS})
         )
     ENDIF ()
     IF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+        TARGET_COMPILE_DEFINITIONS (${source_file_we} PUBLIC $<IF:$<BOOL:${MQTT_USE_STATIC_BOOST}>,,BOOST_TEST_DYN_LINK>)
+
         IF (MQTT_CODECOV)
             SET_PROPERTY (TARGET ${source_file_we}
                           APPEND_STRING PROPERTY COMPILE_FLAGS " -O0 -g --coverage -fno-inline")


### PR DESCRIPTION
When compiling the unit tests on windows with msvc, don't use "BOOST_TEST_DYN_LINK", it won't compile :)