### PR TITLE
simplify server creation

### DIFF
--- a/example/no_tls_both.cpp
+++ b/example/no_tls_both.cpp
@@ -340,7 +340,7 @@ int main(int argc, char** argv) {
     auto s = MQTT_NS::server<>(
         boost::asio::ip::tcp::endpoint(
             boost::asio::ip::tcp::v4(),
-            boost::lexical_cast<std::uint16_t>(argv[1])
+            port
         ),
         iocs
     );


### PR DESCRIPTION
The port of the server already gets stored inside a local variable, so we should use this one instead of doing another lexical cast at server creation