### PR TITLE
Supported ConstBufferSequence payload publish.

### DIFF
--- a/include/mqtt/endpoint.hpp
+++ b/include/mqtt/endpoint.hpp
@@ -1076,7 +1076,7 @@ public:
      * @param topic_name
      *        A topic name to publish
      * @param contents
-     *        The contents to publish
+     *        The contents or the range of contents to publish
      * @param pubopts
      *        qos, retain flag, and dup flag.
      * @param props
@@ -1092,10 +1092,14 @@ public:
      *       internally until the broker has confirmed delivery, which may involve resends, and as such the
      *       life_keeper parameter is important.
      */
-    void publish(
+    template <typename ConstBufferSequence>
+    typename std::enable_if<
+        as::is_const_buffer_sequence<ConstBufferSequence>::value
+    >::type
+    publish(
         packet_id_t packet_id,
         as::const_buffer topic_name,
-        as::const_buffer contents,
+        ConstBufferSequence contents,
         publish_options pubopts,
         v5::properties props,
         any life_keeper
@@ -1114,7 +1118,7 @@ public:
         send_publish(
             packet_id,
             topic_name,
-            contents,
+            force_move(contents),
             pubopts,
             force_move(props),
             force_move(life_keeper)
@@ -1130,7 +1134,7 @@ public:
      * @param topic_name
      *        A topic name to publish
      * @param contents
-     *        The contents to publish
+     *        The contents or the range of contents to publish
      * @param pubopts
      *        qos, retain flag, and dup flag.
      * @param life_keeper
@@ -1142,10 +1146,14 @@ public:
      *       internally until the broker has confirmed delivery, which may involve resends, and as such the
      *       life_keeper parameter is important.
      */
-    void publish(
+    template <typename ConstBufferSequence>
+    typename std::enable_if<
+        as::is_const_buffer_sequence<ConstBufferSequence>::value
+    >::type
+    publish(
         packet_id_t packet_id,
         as::const_buffer topic_name,
-        as::const_buffer contents,
+        ConstBufferSequence contents,
         publish_options pubopts,
         any life_keeper
     ) {
@@ -1163,7 +1171,7 @@ public:
         send_publish(
             packet_id,
             topic_name,
-            contents,
+            force_move(contents),
             pubopts,
             v5::properties{},
             force_move(life_keeper)
@@ -2274,7 +2282,7 @@ public:
      * @param topic_name
      *        A topic name to publish
      * @param contents
-     *        The contents to publish
+     *        The contents or the range of contents to publish
      * @param pubopts
      *        qos, retain flag, and dup flag.
      * @param life_keeper
@@ -2288,10 +2296,14 @@ public:
      *       internally until the broker has confirmed delivery, which may involve resends, and as such the
      *       life_keeper parameter is important.
      */
-    void async_publish(
+    template <typename ConstBufferSequence>
+    typename std::enable_if<
+        as::is_const_buffer_sequence<ConstBufferSequence>::value
+    >::type
+    async_publish(
         packet_id_t packet_id,
         as::const_buffer topic_name,
-        as::const_buffer contents,
+        ConstBufferSequence contents,
         publish_options pubopts = {},
         any life_keeper = {},
         async_handler_t func = {}
@@ -2310,7 +2322,7 @@ public:
         async_send_publish(
             packet_id,
             topic_name,
-            contents,
+            force_move(contents),
             pubopts,
             v5::properties{},
             force_move(life_keeper),
@@ -2327,7 +2339,7 @@ public:
      * @param topic_name
      *        A topic name to publish
      * @param contents
-     *        The contents to publish
+     *        The contents or the range of contents to publish
      * @param pubopts
      *        qos, retain flag, and dup flag.
      * @param props
@@ -2341,10 +2353,14 @@ public:
      * @param func
      *        functor object who's operator() will be called when the async operation completes.
      */
-    void async_publish(
+    template <typename ConstBufferSequence>
+    typename std::enable_if<
+        as::is_const_buffer_sequence<ConstBufferSequence>::value
+    >::type
+    async_publish(
         packet_id_t packet_id,
         as::const_buffer topic_name,
-        as::const_buffer contents,
+        ConstBufferSequence contents,
         publish_options pubopts,
         v5::properties props,
         any life_keeper = {},
@@ -2364,7 +2380,7 @@ public:
         async_send_publish(
             packet_id,
             topic_name,
-            contents,
+            force_move(contents),
             pubopts,
             force_move(props),
             force_move(life_keeper),
@@ -8820,13 +8836,17 @@ private:
         }
     }
 
-    void send_publish(
-        packet_id_t      packet_id,
-        as::const_buffer topic_name,
-        as::const_buffer payload,
-        publish_options  pubopts,
-        v5::properties   props,
-        any              life_keeper) {
+    template <typename ConstBufferSequence>
+    typename std::enable_if<
+        as::is_const_buffer_sequence<ConstBufferSequence>::value
+    >::type
+    send_publish(
+        packet_id_t         packet_id,
+        as::const_buffer    topic_name,
+        ConstBufferSequence payloads,
+        publish_options     pubopts,
+        v5::properties      props,
+        any                 life_keeper) {
 
         auto do_send_publish =
             [&](auto msg, auto const& serialize_publish) {
@@ -8854,7 +8874,7 @@ private:
                 v3_1_1::basic_publish_message<PacketIdBytes>(
                     packet_id,
                     topic_name,
-                    payload,
+                    force_move(payloads),
                     pubopts
                 ),
                 &endpoint::on_serialize_publish_message
@@ -8865,7 +8885,7 @@ private:
                 v5::basic_publish_message<PacketIdBytes>(
                     packet_id,
                     topic_name,
-                    payload,
+                    force_move(payloads),
                     pubopts,
                     force_move(props)
                 ),
@@ -9296,10 +9316,14 @@ private:
         }
     }
 
-    void async_send_publish(
+    template <typename ConstBufferSequence>
+    typename std::enable_if<
+        as::is_const_buffer_sequence<ConstBufferSequence>::value
+    >::type
+    async_send_publish(
         packet_id_t packet_id,
         as::const_buffer topic_name,
-        as::const_buffer payload,
+        ConstBufferSequence payloads,
         publish_options pubopts,
         v5::properties props,
         any life_keeper,
@@ -9339,7 +9363,7 @@ private:
                 v3_1_1::basic_publish_message<PacketIdBytes>(
                     packet_id,
                     topic_name,
-                    payload,
+                    force_move(payloads),
                     pubopts
                 ),
                 &endpoint::on_serialize_publish_message
@@ -9350,7 +9374,7 @@ private:
                 v5::basic_publish_message<PacketIdBytes>(
                     packet_id,
                     topic_name,
-                    payload,
+                    force_move(payloads),
                     pubopts,
                     force_move(props)
                 ),

--- a/test/async_pubsub_2.cpp
+++ b/test/async_pubsub_2.cpp
@@ -1145,6 +1145,224 @@ BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
     do_combi_test_async(test);
 }
 
+BOOST_AUTO_TEST_CASE( publish_function_const_buffer_sequence ) {
+    auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
+        c->set_clean_session(true);
+
+        std::uint16_t pid_sub;
+        std::uint16_t pid_unsub;
+
+
+        checker chk = {
+            // connect
+            cont("h_connack"),
+            // subscribe topic1 QoS1
+            cont("h_suback"),
+            // publish topic1 QoS1
+            cont("h_publish"),
+            cont("h_puback"),
+            cont("h_unsuback"),
+            // disconnect
+            cont("h_close"),
+        };
+
+        switch (c->get_protocol_version()) {
+        case MQTT_NS::protocol_version::v3_1_1:
+            c->set_connack_handler(
+                [&chk, &c, &pid_sub]
+                (bool sp, MQTT_NS::connect_return_code connack_return_code) {
+                    MQTT_CHK("h_connack");
+                    BOOST_TEST(sp == false);
+                    BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(pid_sub, "topic1"_mb, MQTT_NS::qos::at_least_once);
+                    return true;
+                });
+            c->set_puback_handler(
+                [&chk, &c, &pid_unsub]
+                (packet_id_t packet_id) {
+                    MQTT_CHK("h_puback");
+                    BOOST_TEST(packet_id == 1);
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(pid_unsub, "topic1");
+                    return true;
+                });
+            c->set_pubrec_handler(
+                []
+                (std::uint16_t) {
+                    BOOST_CHECK(false);
+                    return true;
+                });
+            c->set_pubcomp_handler(
+                []
+                (std::uint16_t) {
+                    BOOST_CHECK(false);
+                    return true;
+                });
+            c->set_suback_handler(
+                [&chk, &c, &pid_sub]
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
+                    MQTT_CHK("h_suback");
+                    BOOST_TEST(packet_id == pid_sub);
+                    BOOST_TEST(results.size() == 1U);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
+                    c->register_packet_id(1);
+                    auto topic_name = std::make_shared<std::string>("topic1");
+                    auto s1 = std::make_shared<std::string>("topic");
+                    auto s2 = std::make_shared<std::string>("1");
+                    auto s3 = std::make_shared<std::string>("_");
+                    auto s4 = std::make_shared<std::string>("contents");
+                    std::vector<as::const_buffer> cbs {
+                        as::buffer(*s1),
+                        as::buffer(*s2),
+                        as::buffer(*s3),
+                        as::buffer(*s4)
+                    };
+                    c->async_publish(
+                        1,
+                        as::buffer(*topic_name),
+                        cbs,
+                        MQTT_NS::qos::at_least_once | MQTT_NS::dup::yes,
+                        std::make_tuple(topic_name, s1, s2, s3, s4)
+                    );
+                    return true;
+                });
+            c->set_unsuback_handler(
+                [&chk, &c, &pid_unsub]
+                (packet_id_t packet_id) {
+                    MQTT_CHK("h_unsuback");
+                    BOOST_TEST(packet_id == pid_unsub);
+                    c->async_disconnect();
+                    return true;
+                });
+            c->set_publish_handler(
+                [&chk]
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
+                 MQTT_NS::buffer topic,
+                 MQTT_NS::buffer contents) {
+                    MQTT_CHK("h_publish");
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
+                    BOOST_CHECK(packet_id.value() == 1);
+                    BOOST_TEST(topic == "topic1");
+                    BOOST_TEST(contents == "topic1_contents");
+                    return true;
+                });
+            break;
+        case MQTT_NS::protocol_version::v5:
+            c->set_v5_connack_handler(
+                [&chk, &c, &pid_sub]
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
+                    MQTT_CHK("h_connack");
+                    BOOST_TEST(sp == false);
+                    BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
+                    pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(pid_sub, "topic1"_mb, MQTT_NS::qos::at_least_once);
+                    return true;
+                });
+            c->set_v5_puback_handler(
+                [&chk, &c, &pid_unsub]
+                (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
+                    MQTT_CHK("h_puback");
+                    BOOST_TEST(packet_id == 1);
+                    pid_unsub = c->acquire_unique_packet_id();
+                    c->async_unsubscribe(pid_unsub, "topic1");
+                    return true;
+                });
+            c->set_v5_pubrec_handler(
+                []
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
+                    BOOST_CHECK(false);
+                    return true;
+                });
+            c->set_v5_pubcomp_handler(
+                []
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
+                    BOOST_CHECK(false);
+                    return true;
+                });
+            c->set_v5_suback_handler(
+                [&chk, &c, &pid_sub]
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
+                    MQTT_CHK("h_suback");
+                    BOOST_TEST(packet_id == pid_sub);
+                    BOOST_TEST(reasons.size() == 1U);
+                    BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_1);
+                    c->register_packet_id(1);
+                    auto topic_name = std::make_shared<std::string>("topic1");
+                    auto s1 = std::make_shared<std::string>("topic");
+                    auto s2 = std::make_shared<std::string>("1");
+                    auto s3 = std::make_shared<std::string>("_");
+                    auto s4 = std::make_shared<std::string>("contents");
+                    std::vector<as::const_buffer> cbs {
+                        as::buffer(*s1),
+                        as::buffer(*s2),
+                        as::buffer(*s3),
+                        as::buffer(*s4)
+                    };
+                    c->async_publish(
+                        1,
+                        as::buffer(*topic_name),
+                        cbs,
+                        MQTT_NS::qos::at_least_once | MQTT_NS::dup::yes,
+                        std::make_tuple(topic_name, s1, s2, s3, s4)
+                    );
+                    return true;
+                });
+            c->set_v5_unsuback_handler(
+                [&chk, &c, &pid_unsub]
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
+                    MQTT_CHK("h_unsuback");
+                    BOOST_TEST(packet_id == pid_unsub);
+                    BOOST_TEST(reasons.size() == 1U);
+                    BOOST_TEST(reasons[0] == MQTT_NS::v5::unsuback_reason_code::success);
+                    c->async_disconnect();
+                    return true;
+                });
+            c->set_v5_publish_handler(
+                [&chk]
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
+                 MQTT_NS::buffer topic,
+                 MQTT_NS::buffer contents,
+                 MQTT_NS::v5::properties /*props*/) {
+                    MQTT_CHK("h_publish");
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_least_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
+                    BOOST_CHECK(packet_id.value() == 1);
+                    BOOST_TEST(topic == "topic1");
+                    BOOST_TEST(contents == "topic1_contents");
+                    return true;
+                });
+            break;
+        default:
+            BOOST_CHECK(false);
+            break;
+        }
+
+        c->set_close_handler(
+            [&chk, &finish]
+            () {
+                MQTT_CHK("h_close");
+                finish();
+            });
+        c->set_error_handler(
+            []
+            (MQTT_NS::error_code) {
+                BOOST_CHECK(false);
+            });
+        c->async_connect();
+        ioc.run();
+        BOOST_TEST(chk.all());
+    };
+    do_combi_test_async(test);
+}
+
 BOOST_AUTO_TEST_CASE( pub_sub_prop ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         if (c->get_protocol_version() != MQTT_NS::protocol_version::v5) {

--- a/test/message.cpp
+++ b/test/message.cpp
@@ -255,7 +255,7 @@ BOOST_AUTO_TEST_CASE( publish_get_attributes1 ) {
         BOOST_TEST(m.is_retain() == true);
         BOOST_TEST(m.is_dup() == false);
         BOOST_TEST(m.topic() == "1234");
-        BOOST_TEST(m.payload() == "");
+        BOOST_TEST(m.payload().empty());
     }
     catch (...) {
         BOOST_TEST(false);
@@ -283,7 +283,7 @@ BOOST_AUTO_TEST_CASE( publish_get_attributes2 ) {
         BOOST_TEST(m.is_retain() == false);
         BOOST_TEST(m.is_dup() == true);
         BOOST_TEST(m.topic() == "1234");
-        BOOST_TEST(m.payload() == "AB");
+        BOOST_TEST(m.payload().front() == "AB");
         BOOST_TEST(m.continuous_buffer() == buf);
     }
     catch (...) {

--- a/test/pubsub_1.cpp
+++ b/test/pubsub_1.cpp
@@ -2072,6 +2072,213 @@ BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
     do_combi_test_sync(test);
 }
 
+BOOST_AUTO_TEST_CASE( publish_function_const_buffer_sequence ) {
+    auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
+        c->set_clean_session(true);
+
+        packet_id_t pid_sub;
+        packet_id_t pid_unsub;
+
+
+        checker chk = {
+            // connect
+            cont("h_connack"),
+            // subscribe topic1 QoS0
+            cont("h_suback"),
+            // publish topic1 QoS0
+            cont("h_publish"),
+            cont("h_unsuback"),
+            // disconnect
+            cont("h_close"),
+        };
+
+        switch (c->get_protocol_version()) {
+        case MQTT_NS::protocol_version::v3_1_1:
+            c->set_connack_handler(
+                [&chk, &c, &pid_sub]
+                (bool sp, MQTT_NS::connect_return_code connack_return_code) {
+                    MQTT_CHK("h_connack");
+                    BOOST_TEST(sp == false);
+                    BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
+                    pid_sub = c->subscribe("topic1"_mb, MQTT_NS::qos::at_most_once);
+                    return true;
+                });
+            c->set_puback_handler(
+                []
+                (packet_id_t) {
+                    BOOST_CHECK(false);
+                    return true;
+                });
+            c->set_pubrec_handler(
+                []
+                (packet_id_t) {
+                    BOOST_CHECK(false);
+                    return true;
+                });
+            c->set_pubcomp_handler(
+                []
+                (packet_id_t) {
+                    BOOST_CHECK(false);
+                    return true;
+                });
+            c->set_suback_handler(
+                [&chk, &c, &pid_sub]
+                (packet_id_t packet_id, std::vector<MQTT_NS::suback_return_code> results) {
+                    MQTT_CHK("h_suback");
+                    BOOST_TEST(packet_id == pid_sub);
+                    BOOST_TEST(results.size() == 1U);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
+                    auto topic_name = std::make_shared<std::string>("topic1");
+                    auto s1 = std::make_shared<std::string>("topic");
+                    auto s2 = std::make_shared<std::string>("1");
+                    auto s3 = std::make_shared<std::string>("_");
+                    auto s4 = std::make_shared<std::string>("contents");
+                    std::vector<as::const_buffer> cbs {
+                        as::buffer(*s1),
+                        as::buffer(*s2),
+                        as::buffer(*s3),
+                        as::buffer(*s4)
+                    };
+                    c->publish(
+                        as::buffer(*topic_name),
+                        cbs,
+                        MQTT_NS::qos::at_most_once,
+                        std::make_tuple(topic_name, s1, s2, s3, s4)
+                    );
+                    return true;
+                });
+            c->set_unsuback_handler(
+                [&chk, &c, &pid_unsub]
+                (packet_id_t packet_id) {
+                    MQTT_CHK("h_unsuback");
+                    BOOST_TEST(packet_id == pid_unsub);
+                    c->disconnect();
+                    return true;
+                });
+            c->set_publish_handler(
+                [&chk, &c, &pid_unsub]
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
+                 MQTT_NS::buffer topic,
+                 MQTT_NS::buffer contents) {
+                    MQTT_CHK("h_publish");
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
+                    BOOST_CHECK(!packet_id);
+                    BOOST_TEST(topic == "topic1");
+                    BOOST_TEST(contents == "topic1_contents");
+                    pid_unsub = c->unsubscribe("topic1"_mb);
+                    return true;
+                });
+            break;
+        case MQTT_NS::protocol_version::v5:
+            c->set_v5_connack_handler(
+                [&chk, &c, &pid_sub]
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
+                    MQTT_CHK("h_connack");
+                    BOOST_TEST(sp == false);
+                    BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
+                    pid_sub = c->subscribe("topic1"_mb, MQTT_NS::qos::at_most_once);
+                    return true;
+                });
+            c->set_v5_puback_handler(
+                []
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
+                    BOOST_CHECK(false);
+                    return true;
+                });
+            c->set_v5_pubrec_handler(
+                []
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
+                    BOOST_CHECK(false);
+                    return true;
+                });
+            c->set_v5_pubcomp_handler(
+                []
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
+                    BOOST_CHECK(false);
+                    return true;
+                });
+            c->set_v5_suback_handler(
+                [&chk, &c, &pid_sub]
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
+                    MQTT_CHK("h_suback");
+                    BOOST_TEST(packet_id == pid_sub);
+                    BOOST_TEST(reasons.size() == 1U);
+                    BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_0);
+                    auto topic_name = std::make_shared<std::string>("topic1");
+                    auto s1 = std::make_shared<std::string>("topic");
+                    auto s2 = std::make_shared<std::string>("1");
+                    auto s3 = std::make_shared<std::string>("_");
+                    auto s4 = std::make_shared<std::string>("contents");
+                    std::vector<as::const_buffer> cbs {
+                        as::buffer(*s1),
+                        as::buffer(*s2),
+                        as::buffer(*s3),
+                        as::buffer(*s4)
+                    };
+                    c->publish(
+                        as::buffer(*topic_name),
+                        cbs,
+                        MQTT_NS::qos::at_most_once,
+                        std::make_tuple(topic_name, s1, s2, s3, s4)
+                    );
+                    return true;
+                });
+            c->set_v5_unsuback_handler(
+                [&chk, &c, &pid_unsub]
+                (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
+                    MQTT_CHK("h_unsuback");
+                    BOOST_TEST(packet_id == pid_unsub);
+                    BOOST_TEST(reasons.size() == 1U);
+                    BOOST_TEST(reasons[0] == MQTT_NS::v5::unsuback_reason_code::success);
+                    c->disconnect();
+                    return true;
+                });
+            c->set_v5_publish_handler(
+                [&chk, &c, &pid_unsub]
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
+                 MQTT_NS::buffer topic,
+                 MQTT_NS::buffer contents,
+                 MQTT_NS::v5::properties /*props*/) {
+                    MQTT_CHK("h_publish");
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
+                    BOOST_CHECK(!packet_id);
+                    BOOST_TEST(topic == "topic1");
+                    BOOST_TEST(contents == "topic1_contents");
+                    pid_unsub = c->unsubscribe("topic1"_mb);
+                    return true;
+                });
+            break;
+        default:
+            BOOST_CHECK(false);
+            break;
+        }
+
+        c->set_close_handler(
+            [&chk, &finish]
+            () {
+                MQTT_CHK("h_close");
+                finish();
+            });
+        c->set_error_handler(
+            []
+            (MQTT_NS::error_code) {
+                BOOST_CHECK(false);
+            });
+        c->connect();
+        ioc.run();
+        BOOST_TEST(chk.all());
+    };
+    do_combi_test_sync(test);
+}
+
 BOOST_AUTO_TEST_CASE( publish_dup_function ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;


### PR DESCRIPTION
Single boost::asio::const_buffer payload is originally supported.
This PR added scattered payload publish.
It is very useful for request - modify - response ( or forward ) pattern.