### PR TITLE
Implement message expiry in broker

### DIFF
--- a/test/combi_test.hpp
+++ b/test/combi_test.hpp
@@ -67,6 +67,7 @@ inline void do_test(
                 [&] {
                     s->close();
                     b.clear_all_sessions();
+                    b.clear_all_retained_topics();
                 }
             );
         },
@@ -118,6 +119,7 @@ inline void do_tls_test(
                 [&] {
                     s->close();
                     b.clear_all_sessions();
+                    b.clear_all_retained_topics();
                 }
             );
         },
@@ -167,6 +169,7 @@ inline void do_ws_test(
                 [&] {
                     s->close();
                     b.clear_all_sessions();
+                    b.clear_all_retained_topics();
                 }
             );
         },
@@ -218,6 +221,7 @@ inline void do_tls_ws_test(
                 [&] {
                     s->close();
                     b.clear_all_sessions();
+                    b.clear_all_retained_topics();
                 }
             );
         },

--- a/test/retained_topic_map.hpp
+++ b/test/retained_topic_map.hpp
@@ -71,8 +71,8 @@ class retained_topic_map {
     using wildcard_const_iterator = typename path_entry_set::template index<wildcard_index_tag>::type::const_iterator;
 
     path_entry_set map;
-    size_t map_size = 0;
-    node_id_t next_node_id = root_node_id + 1;
+    size_t map_size;
+    node_id_t next_node_id;
 
     direct_const_iterator root;
 
@@ -271,11 +271,17 @@ class retained_topic_map {
         map_size -= count;
     }
 
+    void init_map() {
+        map_size = 0;
+        // Create the root node
+        root = map.insert(path_entry(root_parent_id, "", root_node_id)).first;
+        next_node_id = root_node_id + 1;
+    }
+
 public:
     retained_topic_map()
     {
-        // Create the root node
-        root = map.insert(path_entry(root_parent_id, "", root_node_id)).first;
+        init_map();
     }
 
     // Insert a value at the specified topic
@@ -321,6 +327,12 @@ public:
 
     // Get the number of entries in the map (for debugging purpose only)
     std::size_t internal_size() const { return map.size(); }
+
+    // Clear all topics
+    void clear() {
+        map.clear();
+        init_map();
+    }
 
     // Dump debug information
     template<typename Output>

--- a/test/will.cpp
+++ b/test/will.cpp
@@ -169,6 +169,180 @@ BOOST_AUTO_TEST_CASE( will_qos0 ) {
     th.join();
 }
 
+BOOST_AUTO_TEST_CASE( will_qo0_timeout ) {
+    boost::asio::io_context iocb;
+    test_broker b(iocb);
+    MQTT_NS::optional<test_server_no_tls> s;
+    std::promise<void> p;
+    auto f = p.get_future();
+    std::thread th(
+        [&] {
+            s.emplace(iocb, b);
+            p.set_value();
+            iocb.run();
+        }
+    );
+    f.wait();
+    auto finish =
+        [&] {
+            as::post(
+                iocb,
+                [&] {
+                    s->close();
+                }
+            );
+        };
+
+    boost::asio::io_context ioc;
+
+    constexpr uint32_t will_expiry_interval = 1;
+    as::steady_timer timeout(ioc);
+    as::steady_timer timeout_2(ioc);
+
+    MQTT_NS::v5::properties ps {
+        MQTT_NS::v5::property::message_expiry_interval(will_expiry_interval),
+    };
+
+    auto c1 = MQTT_NS::make_client(ioc, broker_url, broker_notls_port, MQTT_NS::protocol_version::v5);
+    c1->set_client_id("cid1");
+    c1->set_clean_session(true);
+    c1->set_will(MQTT_NS::will("topic1"_mb, "will_contents"_mb, MQTT_NS::retain::yes, MQTT_NS::force_move(ps)));
+
+    int c1fd_count = 0;
+    auto c1_force_disconnect = [&c1, &c1fd_count] {
+        if (++c1fd_count == 2) c1->force_disconnect();
+    };
+
+    auto c2 = MQTT_NS::make_client(ioc, broker_url, broker_notls_port, MQTT_NS::protocol_version::v5);
+    c2->set_client_id("cid2");
+    c2->set_clean_session(true);
+
+    using packet_id_t = typename std::remove_reference_t<decltype(*c1)>::packet_id_t;
+
+
+    checker chk = {
+        // connect
+        cont("h_connack_1"),
+        // force_disconnect
+        cont("h_error_1"),
+
+        // connect
+        deps("h_connack_2"),
+        // subscribe topic1 QoS0
+        cont("h_suback_2"),
+       // cont("h_publish_2"), // will receive
+        // unsubscribe topic1
+        cont("h_unsuback_2"),
+        // disconnect
+        cont("h_close_2"),
+
+    };
+
+    c1->set_v5_connack_handler(
+        [&chk, &c1_force_disconnect]
+        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
+            MQTT_CHK("h_connack_1");
+            BOOST_TEST(sp == false);
+            BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
+            c1_force_disconnect();
+            return true;
+        });
+    c1->set_close_handler(
+        []
+        () {
+            BOOST_CHECK(false);
+        });
+    c1->set_error_handler(
+        [&chk]
+        (MQTT_NS::error_code) {
+            MQTT_CHK("h_error_1");
+        });
+
+    std::uint16_t pid_sub2;
+    std::uint16_t pid_unsub2;
+
+
+    std::vector<std::string> const expected2 = {
+        "finish",
+    };
+
+    c2->set_v5_connack_handler(
+        [&chk, &c2, &pid_sub2]
+        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
+            MQTT_CHK("h_connack_2");
+            BOOST_TEST(sp == false);
+            BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
+            pid_sub2 = c2->subscribe("topic1", MQTT_NS::qos::at_most_once);
+            return true;
+        });
+    c2->set_close_handler(
+        [&chk, &finish]
+        () {
+            MQTT_CHK("h_close_2");
+            finish();
+        });
+    c2->set_error_handler(
+        []
+        (MQTT_NS::error_code) {
+            BOOST_CHECK(false);
+        });
+    c2->set_v5_suback_handler(
+        [&chk, &c2, &c1_force_disconnect, &pid_sub2, &pid_unsub2, &timeout, &timeout_2, &will_expiry_interval]
+        (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
+            MQTT_CHK("h_suback_2");
+            BOOST_TEST(packet_id == pid_sub2);
+            BOOST_TEST(reasons.size() == 1U);
+            BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_0);
+
+            timeout.expires_after(std::chrono::seconds(1 + will_expiry_interval));
+            timeout.async_wait(
+                [&c1_force_disconnect](MQTT_NS::error_code ec) {
+                    if (!ec) {
+                         c1_force_disconnect();
+                    }
+                }
+            );
+
+            timeout_2.expires_after(std::chrono::seconds(2 + will_expiry_interval));
+            timeout_2.async_wait(
+                [&c2, &pid_unsub2](MQTT_NS::error_code ec) {
+                    if (!ec) {
+                        pid_unsub2 = c2->unsubscribe("topic1");
+                    }
+                }
+            );
+
+            return true;
+        });
+    c2->set_v5_unsuback_handler(
+        [&chk, &c2, &pid_unsub2]
+        (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
+            MQTT_CHK("h_unsuback_2");
+            BOOST_TEST(packet_id == pid_unsub2);
+            c2->disconnect();
+            return true;
+        });
+    c2->set_v5_publish_handler(
+        [&chk, &c2, &pid_unsub2]
+        (MQTT_NS::optional<packet_id_t> packet_id,
+         MQTT_NS::publish_options pubopts,
+         MQTT_NS::buffer topic,
+         MQTT_NS::buffer contents,
+         MQTT_NS::v5::properties /*props*/) {
+
+            // Will should not be received
+            BOOST_TEST(false);
+            return true;
+        });
+
+    c1->connect();
+    c2->connect();
+
+    ioc.run();
+    BOOST_TEST(chk.all());
+    th.join();
+}
+
 BOOST_AUTO_TEST_CASE( will_qos1 ) {
     boost::asio::io_context iocb;
     test_broker b(iocb);
@@ -719,6 +893,7 @@ BOOST_AUTO_TEST_CASE( will_prop ) {
                 iocb,
                 [&] {
                     s->close();
+                    b.clear_all_retained_topics();
                 }
             );
         };


### PR DESCRIPTION
This is what I have so far:
- Retained message expiry (tested)
- Will expiry (tested)
- Offline message expiry (no test)

The message expiry is updated when the message is finally transmitted, this is also untested yet. 

The unit tests for this are a bit of a hassle, is it maybe better to use synchronous clients, much easier to write the test. Also, when the unit test stalls, there is no real timeout on the unit test. That is also why the CI hangs sometimes. 