### PR TITLE
Added broker-side inflight message resend support.

### DIFF
--- a/example/redirect.cpp
+++ b/example/redirect.cpp
@@ -88,7 +88,7 @@ void set_client_handlers(
                 // Inherit store data from c to c2
                 c.for_each_store(
                     [&c2]
-                    (MQTT_NS::message_variant const& msg) {
+                    (MQTT_NS::store_message_variant const& msg) {
                         c2->restore_serialized_message(msg);
                     }
                 );

--- a/include/mqtt/callable_overlay.hpp
+++ b/include/mqtt/callable_overlay.hpp
@@ -1883,7 +1883,7 @@ struct callable_overlay final : public Impl
             [h_publish = force_move(h_publish)]
             (basic_publish_message<sizeof(packet_id_t)> msg) {
                 if (h_publish) {
-                    auto buf = continuous_buffer<sizeof(packet_id_t)>(msg);
+                    auto buf = msg.continuous_buffer();
                     h_publish(msg.packet_id(), buf.data(), buf.size());
                 }
             };
@@ -1891,7 +1891,7 @@ struct callable_overlay final : public Impl
             [h_pubrel = force_move(h_pubrel)]
             (basic_pubrel_message<sizeof(packet_id_t)> msg) {
                 if (h_pubrel) {
-                    auto buf = continuous_buffer<sizeof(packet_id_t)>(msg);
+                    auto buf = msg.continuous_buffer();
                     h_pubrel(msg.packet_id(), buf.data(), buf.size());
                 }
             };
@@ -1912,7 +1912,7 @@ struct callable_overlay final : public Impl
             [h_publish = force_move(h_publish)]
             (v5::basic_publish_message<sizeof(packet_id_t)> msg) {
                 if (h_publish) {
-                    auto buf = continuous_buffer<sizeof(packet_id_t)>(msg);
+                    auto buf = msg.continuous_buffer();
                     h_publish(msg.packet_id(), buf.data(), buf.size());
                 }
             };
@@ -1920,7 +1920,7 @@ struct callable_overlay final : public Impl
             [h_pubrel = force_move(h_pubrel)]
             (v5::basic_pubrel_message<sizeof(packet_id_t)> msg) {
                 if (h_pubrel) {
-                    auto buf = continuous_buffer<sizeof(packet_id_t)>(msg);
+                    auto buf = msg.continuous_buffer();
                     h_pubrel(msg.packet_id(), buf.data(), buf.size());
                 }
             };

--- a/include/mqtt/message_variant.hpp
+++ b/include/mqtt/message_variant.hpp
@@ -86,23 +86,23 @@ struct continuous_buffer_visitor {
 template <std::size_t PacketIdBytes>
 inline std::vector<as::const_buffer> const_buffer_sequence(
     basic_message_variant<PacketIdBytes> const& mv) {
-    return visit(detail::const_buffer_sequence_visitor(), mv);
+    return MQTT_NS::visit(detail::const_buffer_sequence_visitor(), mv);
 }
 
 template <std::size_t PacketIdBytes>
 inline std::size_t size(basic_message_variant<PacketIdBytes> const& mv) {
-    return visit(detail::size_visitor(), mv);
+    return MQTT_NS::visit(detail::size_visitor(), mv);
 }
 
 template <std::size_t PacketIdBytes>
 inline std::size_t num_of_const_buffer_sequence(
     basic_message_variant<PacketIdBytes> const& mv) {
-    return visit(detail::num_of_const_buffer_sequence_visitor(), mv);
+    return MQTT_NS::visit(detail::num_of_const_buffer_sequence_visitor(), mv);
 }
 
 template <std::size_t PacketIdBytes>
 inline std::string continuous_buffer(basic_message_variant<PacketIdBytes> const& mv) {
-    return visit(detail::continuous_buffer_visitor(), mv);
+    return MQTT_NS::visit(detail::continuous_buffer_visitor(), mv);
 }
 
 
@@ -123,7 +123,7 @@ namespace detail {
 template <std::size_t PacketIdBytes>
 struct basic_message_variant_visitor {
     template <typename T>
-    basic_message_variant<PacketIdBytes> operator()(T&& t) const {
+    basic_message_variant<PacketIdBytes> operator()(T const& t) const {
         return t;
     }
 };
@@ -133,8 +133,13 @@ struct basic_message_variant_visitor {
 template <std::size_t PacketIdBytes>
 inline
 basic_message_variant<PacketIdBytes> get_basic_message_variant(
-    basic_store_message_variant<PacketIdBytes> const& smv) {
-    return visit(detail::basic_message_variant_visitor<PacketIdBytes>(), smv);
+    basic_store_message_variant<PacketIdBytes> smv) {
+    return MQTT_NS::visit(detail::basic_message_variant_visitor<PacketIdBytes>(), smv);
+}
+
+template <std::size_t PacketIdBytes>
+inline std::string continuous_buffer(basic_store_message_variant<PacketIdBytes> const& mv) {
+    return MQTT_NS::visit(detail::continuous_buffer_visitor(), mv);
 }
 
 } // namespace MQTT_NS

--- a/include/mqtt/property_variant.hpp
+++ b/include/mqtt/property_variant.hpp
@@ -100,22 +100,22 @@ inline fill_visitor<Iterator> make_fill_visitor(Iterator b, Iterator e) {
 } // namespace property
 
 inline void add_const_buffer_sequence(std::vector<as::const_buffer>& v, property_variant const& pv) {
-    visit(property::detail::add_const_buffer_sequence_visitor(v), pv);
+    MQTT_NS::visit(property::detail::add_const_buffer_sequence_visitor(v), pv);
 }
 
 inline std::size_t size(property_variant const& pv) {
-    return visit(property::detail::size_visitor(), pv);
+    return MQTT_NS::visit(property::detail::size_visitor(), pv);
 }
 
 inline std::size_t num_of_const_buffer_sequence(property_variant const& pv) {
-    return visit(property::detail::num_of_const_buffer_sequence_visitor(), pv);
+    return MQTT_NS::visit(property::detail::num_of_const_buffer_sequence_visitor(), pv);
 }
 
 
 template <typename Iterator>
 inline void fill(property_variant const& pv, Iterator b, Iterator e) {
     auto vis = property::detail::make_fill_visitor(b, e);
-    visit(vis, pv);
+    MQTT_NS::visit(vis, pv);
 }
 
 } // namespace v5

--- a/test/resend_new_client.cpp
+++ b/test/resend_new_client.cpp
@@ -106,7 +106,7 @@ BOOST_AUTO_TEST_CASE( publish_qos1 ) {
             // Inherit store data from c1 to c2
             c1->for_each_store(
                 [&c2]
-                (MQTT_NS::message_variant const& msg) {
+                (MQTT_NS::store_message_variant const& msg) {
                     c2->restore_serialized_message(msg);
                 }
             );
@@ -247,7 +247,7 @@ BOOST_AUTO_TEST_CASE( publish_qos2 ) {
             // Inherit store data from c1 to c2
             c1->for_each_store(
                 [&c2]
-                (MQTT_NS::message_variant const& msg) {
+                (MQTT_NS::store_message_variant const& msg) {
                     c2->restore_serialized_message(msg);
                 }
             );
@@ -393,7 +393,7 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2 ) {
             // Inherit store data from c1 to c2
             c1->for_each_store(
                 [&c2]
-                (MQTT_NS::message_variant const& msg) {
+                (MQTT_NS::store_message_variant const& msg) {
                     c2->restore_serialized_message(msg);
                 }
             );
@@ -544,7 +544,7 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1 ) {
             // Inherit store data from c1 to c2
             c1->for_each_store(
                 [&c2]
-                (MQTT_NS::message_variant const& msg) {
+                (MQTT_NS::store_message_variant const& msg) {
                     c2->restore_serialized_message(msg);
                 }
             );
@@ -762,7 +762,7 @@ BOOST_AUTO_TEST_CASE( publish_qos1_v5 ) {
             // Inherit store data from c1 to c2
             c1->for_each_store(
                 [&c2]
-                (MQTT_NS::message_variant const& msg) {
+                (MQTT_NS::store_message_variant const& msg) {
                     c2->restore_serialized_message(msg);
                 }
             );
@@ -905,7 +905,7 @@ BOOST_AUTO_TEST_CASE( publish_qos2_v5 ) {
             // Inherit store data from c1 to c2
             c1->for_each_store(
                 [&c2]
-                (MQTT_NS::message_variant const& msg) {
+                (MQTT_NS::store_message_variant const& msg) {
                     c2->restore_serialized_message(msg);
                 }
             );
@@ -1103,7 +1103,7 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2_v5 ) {
             // Inherit store data from c1 to c2
             c1->for_each_store(
                 [&c2]
-                (MQTT_NS::message_variant const& msg) {
+                (MQTT_NS::store_message_variant const& msg) {
                     c2->restore_serialized_message(msg);
                 }
             );
@@ -1257,7 +1257,7 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1_v5 ) {
             // Inherit store data from c1 to c2
             c1->for_each_store(
                 [&c2]
-                (MQTT_NS::message_variant const& msg) {
+                (MQTT_NS::store_message_variant const& msg) {
                     c2->restore_serialized_message(msg);
                 }
             );


### PR DESCRIPTION
Fixed for_each_store and restore_serialized_message parameter type.
It should be basic_store_message_variant but it was
basic_message_variant.

basic_store_message_variant could have publish and pubrel.
It is appropriate for storing inflight messages.