### PR TITLE
Implement message expiry in broker

### DIFF
--- a/test/combi_test.hpp
+++ b/test/combi_test.hpp
@@ -67,6 +67,7 @@ inline void do_test(
                 [&] {
                     s->close();
                     b.clear_all_sessions();
+                    b.clear_all_retained_topics();
                 }
             );
         },
@@ -118,6 +119,7 @@ inline void do_tls_test(
                 [&] {
                     s->close();
                     b.clear_all_sessions();
+                    b.clear_all_retained_topics();
                 }
             );
         },
@@ -167,6 +169,7 @@ inline void do_ws_test(
                 [&] {
                     s->close();
                     b.clear_all_sessions();
+                    b.clear_all_retained_topics();
                 }
             );
         },
@@ -218,6 +221,7 @@ inline void do_tls_ws_test(
                 [&] {
                     s->close();
                     b.clear_all_sessions();
+                    b.clear_all_retained_topics();
                 }
             );
         },

--- a/test/retained_topic_map.hpp
+++ b/test/retained_topic_map.hpp
@@ -71,8 +71,8 @@ class retained_topic_map {
     using wildcard_const_iterator = typename path_entry_set::template index<wildcard_index_tag>::type::const_iterator;
 
     path_entry_set map;
-    size_t map_size = 0;
-    node_id_t next_node_id = root_node_id + 1;
+    size_t map_size;
+    node_id_t next_node_id;
 
     direct_const_iterator root;
 
@@ -271,11 +271,17 @@ class retained_topic_map {
         map_size -= count;
     }
 
+    void init_map() {
+        map_size = 0;
+        // Create the root node
+        root = map.insert(path_entry(root_parent_id, "", root_node_id)).first;
+        next_node_id = root_node_id + 1;
+    }
+
 public:
     retained_topic_map()
     {
-        // Create the root node
-        root = map.insert(path_entry(root_parent_id, "", root_node_id)).first;
+        init_map();
     }
 
     // Insert a value at the specified topic
@@ -321,6 +327,12 @@ public:
 
     // Get the number of entries in the map (for debugging purpose only)
     std::size_t internal_size() const { return map.size(); }
+
+    // Clear all topics
+    void clear() {
+        map.clear();
+        init_map();
+    }
 
     // Dump debug information
     template<typename Output>

--- a/test/test_broker.hpp
+++ b/test/test_broker.hpp
@@ -703,6 +703,38 @@ public:
         sessions_.clear();
     }
 
+    void clear_all_retained_topics() {
+        retains_.clear();
+    }
+
+    template <typename T>
+    static MQTT_NS::optional<T> get_property(MQTT_NS::v5::properties const &props) {
+        MQTT_NS::optional<T> result;
+
+        auto visitor = MQTT_NS::make_lambda_visitor(
+            [&result](T const& t) { result = t; },
+            [](auto&& ...) { }
+        );
+
+        for (auto const& p : props) {
+            MQTT_NS::visit(visitor, p);
+        }
+
+        return result;
+    }
+
+    template <typename T>
+    static void set_property(MQTT_NS::v5::properties const &props, T&& v) {
+        auto visitor = MQTT_NS::make_lambda_visitor(
+            [&v](T& t) mutable { t = std::forward<T>(v); },
+            [](auto&& ...) { }
+        );
+
+        for (auto const& p : props) {
+            MQTT_NS::visit(visitor, p);
+        }
+    }
+
 private:
     /**
      * @brief connect_proc Process an incoming CONNECT packet
@@ -734,21 +766,19 @@ private:
         auto& ep = *spep;
 
         MQTT_NS::optional<std::chrono::steady_clock::duration> session_expiry_interval;
+        MQTT_NS::optional<std::chrono::steady_clock::duration> will_expiry_interval;
 
         if (ep.get_protocol_version() == MQTT_NS::protocol_version::v5) {
-            for (auto const& p : props) {
-                MQTT_NS::visit(
-                    MQTT_NS::make_lambda_visitor(
-                        [&session_expiry_interval](MQTT_NS::v5::property::session_expiry_interval const& t) {
-                            if (t.val() != 0) {
-                                session_expiry_interval.emplace(std::chrono::seconds(t.val()));
-                            }
-                        },
-                        [](auto&& ...) {
-                        }
-                    ),
-                    p
-                );
+            auto v = get_property<MQTT_NS::v5::property::session_expiry_interval>(props);
+            if (v && v.value().val() != 0) {
+                session_expiry_interval.emplace(std::chrono::seconds(v.value().val()));
+            }
+
+            if(will) {
+                auto v = get_property<MQTT_NS::v5::property::message_expiry_interval>(will.value().props());
+                if (v && v.value().val() != 0) {
+                    will_expiry_interval.emplace(std::chrono::seconds(v.value().val()));
+                }
             }
 
             if (h_connect_props_) {
@@ -810,15 +840,26 @@ private:
         auto send_offline_messages =
             [&] (session_state& session) {
                 try {
-                    while (!session.offline_messages.empty()) {
-                        auto const& msg = session.offline_messages.front();
-                        session.con->publish(
-                            msg.topic,
-                            msg.contents,
-                            msg.pubopts,
-                            msg.props
-                        );
-                        session.offline_messages.pop_front();
+                    auto &seq_idx = session.offline_messages.get<tag_seq>();
+                    while(!seq_idx.empty()) {
+                        seq_idx.modify(seq_idx.begin(), [&](auto &i) {
+                            auto props = MQTT_NS::force_move(i.props);
+
+                            if(i.tim_message_expiry) {
+                                set_property<MQTT_NS::v5::property::message_expiry_interval>(props,
+                                    MQTT_NS::v5::property::message_expiry_interval(static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::seconds>(
+                                        i.tim_message_expiry->expiry() - std::chrono::steady_clock::now()).count())));
+                            }
+
+                            session.con->publish(
+                                MQTT_NS::force_move(i.topic),
+                                MQTT_NS::force_move(i.contents),
+                                MQTT_NS::force_move(i.pubopts),
+                                MQTT_NS::force_move(props)
+                            );
+                        });
+
+                        seq_idx.pop_front();
                     }
                 }
                 catch (MQTT_NS::packet_id_exhausted_error const& e) {
@@ -844,12 +885,15 @@ private:
             // new connection
             it = idx.emplace_hint(
                 it,
+                ioc_,
                 subs_map_,
                 spep,
                 client_id,
                 MQTT_NS::force_move(will),
+                MQTT_NS::force_move(will_expiry_interval),
                 MQTT_NS::force_move(session_expiry_interval)
             );
+
             send_connack(false);
         }
         else if (it->online()) {
@@ -863,7 +907,7 @@ private:
                         it,
                         [&](auto& e) {
                             e.clean();
-                            e.will = MQTT_NS::force_move(will);
+                            e.update_will(ioc_, MQTT_NS::force_move(will), will_expiry_interval);
                             // TODO: e.will_delay = MQTT_NS::force_move(will_delay);
                             e.session_expiry_interval = MQTT_NS::force_move(session_expiry_interval);
                             e.tim_session_expiry.reset();
@@ -882,7 +926,7 @@ private:
                                 ep.restore_topic_alias_recv_container(MQTT_NS::force_move(e.topic_alias_recv.value()));
                                 e.topic_alias_recv = MQTT_NS::nullopt;
                             }
-                            e.will = MQTT_NS::force_move(will);
+                            e.update_will(ioc_, MQTT_NS::force_move(will), will_expiry_interval);
                             // TODO: e.will_delay = MQTT_NS::force_move(will_delay);
                             e.session_expiry_interval = MQTT_NS::force_move(session_expiry_interval);
                             e.tim_session_expiry.reset();
@@ -898,10 +942,12 @@ private:
                 // new connection
                 it = idx.emplace_hint(
                     it,
+                    ioc_,
                     subs_map_,
                     spep,
                     client_id,
                     MQTT_NS::force_move(will),
+                    MQTT_NS::force_move(will_expiry_interval),
                     MQTT_NS::force_move(session_expiry_interval)
                 );
                 send_connack(false);
@@ -917,7 +963,7 @@ private:
                     [&](auto& e) {
                         e.clean();
                         e.con = spep;
-                        e.will = MQTT_NS::force_move(will);
+                        e.update_will(ioc_, MQTT_NS::force_move(will), will_expiry_interval);
                         // TODO: e.will_delay = MQTT_NS::force_move(will_delay);
                         e.session_expiry_interval = MQTT_NS::force_move(session_expiry_interval);
                         e.tim_session_expiry.reset();
@@ -936,7 +982,7 @@ private:
                             ep.restore_topic_alias_recv_container(MQTT_NS::force_move(e.topic_alias_recv.value()));
                             e.topic_alias_recv = MQTT_NS::nullopt;
                         }
-                        e.will = MQTT_NS::force_move(will);
+                        e.update_will(ioc_, MQTT_NS::force_move(will), will_expiry_interval);
                         // TODO: e.will_delay = MQTT_NS::force_move(will_delay);
                         e.session_expiry_interval = MQTT_NS::force_move(session_expiry_interval);
                         e.tim_session_expiry.reset();
@@ -995,17 +1041,25 @@ private:
 
         auto do_send_will =
             [&](session_state& session) {
-                if (session.will) {
+                if (session.will()) {
                     if (send_will) {
                         // TODO: This should be triggered by the will delay
                         // Not sent immediately.
                         try {
+                            auto props = MQTT_NS::force_move(session.will().value().props());
+
+                            if(session.get_tim_will_expiry()) {
+                                set_property<MQTT_NS::v5::property::message_expiry_interval>(props,
+                                    MQTT_NS::v5::property::message_expiry_interval(static_cast<uint32_t>(
+                                        std::chrono::duration_cast<std::chrono::seconds>(session.get_tim_will_expiry()->expiry() - std::chrono::steady_clock::now()).count())));
+                            }
+
                             do_publish(
                                 ep,
-                                MQTT_NS::force_move(session.will.value().topic()),
-                                MQTT_NS::force_move(session.will.value().message()),
-                                session.will.value().get_qos() | session.will.value().get_retain(),
-                                MQTT_NS::force_move(session.will.value().props())
+                                MQTT_NS::force_move(session.will().value().topic()),
+                                MQTT_NS::force_move(session.will().value().message()),
+                                session.will().value().get_qos() | session.will().value().get_retain(),
+                                props
                             );
                         }
                         catch (MQTT_NS::packet_id_exhausted_error const& e) {
@@ -1015,7 +1069,7 @@ private:
                         }
                     }
                     else {
-                        session.will = MQTT_NS::nullopt;
+                        session.reset_will();
                     }
                 }
             };
@@ -1052,22 +1106,19 @@ private:
 
                     e.con.reset();
 
-                    auto const& sei_opt = e.session_expiry_interval;
-                    if (sei_opt && sei_opt.value() !=
-                        std::chrono::seconds(MQTT_NS::session_never_expire)) {
-                        e.tim_session_expiry = std::make_shared<as::steady_timer>(ioc_);
-                        e.tim_session_expiry->expires_after(sei_opt.value());
+                    if (e.session_expiry_interval && e.session_expiry_interval.value() != std::chrono::seconds(MQTT_NS::session_never_expire)) {
+                        e.tim_session_expiry = std::make_shared<as::steady_timer>(ioc_, e.session_expiry_interval.value());
                         e.tim_session_expiry->async_wait(
-                            [&, wp = std::weak_ptr<as::steady_timer>(e.tim_session_expiry)]
-                            (MQTT_NS::error_code ec) {
-                                auto sp = wp.lock();
-                                if (!ec) {
-                                    auto& idx = sessions_.get<tag_tim>();
-                                    idx.erase(sp);
+                            [this, wp = std::weak_ptr<as::steady_timer>(e.tim_session_expiry)](MQTT_NS::error_code ec) {
+                                if (auto sp = wp.lock()) {
+                                    if (!ec) {
+                                        sessions_.get<tag_tim>().erase(sp);
+                                    }
                                 }
                             }
                         );
                     }
+
                     // TopicAlias lifetime is the same as Session lifetime
                     // It is different from MQTT v5 spec but practical choice.
                     // See
@@ -1305,6 +1356,11 @@ private:
                 if (sid) {
                     props.push_back(MQTT_NS::v5::property::subscription_identifier(*sid));
                 }
+                if (r.tim_message_expiry) {
+                    set_property<MQTT_NS::v5::property::message_expiry_interval>(props,
+                        MQTT_NS::v5::property::message_expiry_interval(static_cast<uint32_t>(
+                            std::chrono::duration_cast<std::chrono::seconds>(r.tim_message_expiry->expiry() - std::chrono::steady_clock::now()).count())));
+                }
                 ep.publish(
                     r.topic,
                     r.contents,
@@ -1413,19 +1469,9 @@ private:
         } break;
         case MQTT_NS::protocol_version::v5: {
             // Get subscription identifier
-            for (auto const& p : props) {
-                MQTT_NS::visit(
-                    MQTT_NS::make_lambda_visitor(
-                        [&sid](MQTT_NS::v5::property::subscription_identifier const& p) {
-                            if (p.val() != 0) {
-                                sid.emplace(p.val());
-                            }
-                        },
-                        [](auto&& ...) {
-                        }
-                    ),
-                    p
-                );
+            auto v = get_property<MQTT_NS::v5::property::subscription_identifier>(props);
+            if (v && v.value().val() != 0) {
+                sid.emplace(v.value().val());
             }
 
             std::vector<MQTT_NS::v5::suback_reason_code> res;
@@ -1540,6 +1586,7 @@ private:
                 if (sub.sid) {
                     props.push_back(MQTT_NS::v5::property::subscription_identifier(sub.sid.value()));
                     sub.ss.get().deliver(
+                        ioc_,
                         topic,
                         contents,
                         new_pubopts,
@@ -1549,6 +1596,7 @@ private:
                 }
                 else {
                     sub.ss.get().deliver(
+                        ioc_,
                         topic,
                         contents,
                         new_pubopts,
@@ -1558,6 +1606,15 @@ private:
 
             }
         );
+
+        MQTT_NS::optional<std::chrono::steady_clock::duration> message_expiry_interval;
+        if (ep.get_protocol_version() == MQTT_NS::protocol_version::v5) {
+            auto v = get_property<MQTT_NS::v5::property::message_expiry_interval>(props);
+            if (v && v.value().val() != 0) {
+                message_expiry_interval.emplace(std::chrono::seconds(v.value().val()));
+            }
+
+        }
 
         /*
          * If the message is marked as being retained, then we
@@ -1585,13 +1642,28 @@ private:
                 retains_.erase(topic);
             }
             else {
+                std::shared_ptr<as::steady_timer> tim_message_expiry;
+                if(message_expiry_interval) {
+                    tim_message_expiry = std::make_shared<as::steady_timer>(ioc_, message_expiry_interval.value());
+                    tim_message_expiry->async_wait(
+                      [this, topic = topic, wp = std::weak_ptr<as::steady_timer>(tim_message_expiry)]
+                      (boost::system::error_code const& ec) {
+                      if (auto sp = wp.lock()) {
+                          if( ! ec ) {
+                              retains_.erase(topic);
+                          }
+                      }
+                   });
+                }
+
                 retains_.insert_or_assign(
                     topic,
                     retain {
                         MQTT_NS::force_move(topic),
                         MQTT_NS::force_move(contents),
                         MQTT_NS::force_move(props),
-                        pubopts.get_qos()
+                        pubopts.get_qos(),
+                        tim_message_expiry
                     }
                 );
             }
@@ -1599,6 +1671,7 @@ private:
     }
 
 private:
+    struct tag_seq {};
     struct tag_con {};
     struct tag_topic{};
     struct tag_topic_filter{};
@@ -1607,7 +1680,6 @@ private:
     struct tag_cid_topic_filter {};
     struct tag_tim {};
     struct tag_pid {};
-    struct tag_seq {};
 
     struct session_state;
     using session_state_ref = std::reference_wrapper<session_state>;
@@ -1684,16 +1756,35 @@ private:
             MQTT_NS::buffer topic,
             MQTT_NS::buffer contents,
             MQTT_NS::v5::properties props,
-            MQTT_NS::publish_options pubopts)
+            MQTT_NS::publish_options pubopts,
+            std::shared_ptr<as::steady_timer> tim_message_expiry)
             : topic(MQTT_NS::force_move(topic)),
               contents(MQTT_NS::force_move(contents)),
               props(MQTT_NS::force_move(props)),
-              pubopts(pubopts) {}
+              pubopts(pubopts),
+              tim_message_expiry(MQTT_NS::force_move(tim_message_expiry))
+        { }
+
         MQTT_NS::buffer topic;
         MQTT_NS::buffer contents;
         MQTT_NS::v5::properties props;
         MQTT_NS::publish_options pubopts;
+
+        std::shared_ptr<as::steady_timer> tim_message_expiry;
     };
+
+    using mi_offline_message = mi::multi_index_container<
+        offline_message,
+        mi::indexed_by<
+            mi::sequenced<
+                mi::tag<tag_seq>
+            >,
+            mi::ordered_non_unique<
+                mi::tag<tag_tim>,
+                BOOST_MULTI_INDEX_MEMBER(offline_message, std::shared_ptr<as::steady_timer>, tim_message_expiry)
+            >
+        >
+    >;
 
     /**
      * http://docs.oasis-open.org/mqtt/mqtt/v5.0/cs02/mqtt-v5.0-cs02.html#_Session_State
@@ -1715,17 +1806,20 @@ private:
     struct session_state {
         // TODO: Currently not fully implemented...
         session_state(
+            as::io_context& ioc,
             sub_con_map& subs_map,
             con_sp_t con,
             MQTT_NS::buffer client_id,
             MQTT_NS::optional<MQTT_NS::will> will,
+            MQTT_NS::optional<std::chrono::steady_clock::duration> will_expiry_interval,
             MQTT_NS::optional<std::chrono::steady_clock::duration> session_expiry_interval = MQTT_NS::nullopt)
             :subs_map_(subs_map),
              con(MQTT_NS::force_move(con)),
              client_id(MQTT_NS::force_move(client_id)),
-             will(MQTT_NS::force_move(will)),
              session_expiry_interval(MQTT_NS::force_move(session_expiry_interval))
-        {}
+        {
+            update_will(ioc, will, will_expiry_interval);
+        }
 
         session_state() = default;
         session_state(session_state&&) = default;
@@ -1739,6 +1833,7 @@ private:
         }
 
         void deliver(
+            as::io_context& ioc,
             MQTT_NS::buffer pub_topic,
             MQTT_NS::buffer contents,
             MQTT_NS::publish_options pubopts,
@@ -1759,11 +1854,34 @@ private:
                 );
             }
             else {
-                offline_messages.emplace_back(
+                MQTT_NS::optional<std::chrono::steady_clock::duration> message_expiry_interval;
+
+                auto v = get_property<MQTT_NS::v5::property::message_expiry_interval>(props);
+                if (v && v.value().val() != 0) {
+                    message_expiry_interval.emplace(std::chrono::seconds(v.value().val()));
+                }
+
+                std::shared_ptr<as::steady_timer> tim_message_expiry;
+                if (message_expiry_interval) {
+                    tim_message_expiry = std::make_shared<as::steady_timer>(ioc, message_expiry_interval.value());
+                    tim_message_expiry->async_wait(
+                        [this, wp = std::weak_ptr<as::steady_timer>(tim_message_expiry)](MQTT_NS::error_code ec) mutable {
+                            if (auto sp = wp.lock()) {
+                                if (!ec) {
+                                    offline_messages.get<tag_tim>().erase(sp);
+                                }
+                            }
+                        }
+                    );
+                }
+
+                auto& seq_idx = offline_messages.get<tag_seq>();
+                auto i = seq_idx.emplace_back(
                     MQTT_NS::force_move(pub_topic),
                     MQTT_NS::force_move(contents),
                     MQTT_NS::force_move(props),
-                    pubopts
+                    pubopts,
+                    MQTT_NS::force_move(tim_message_expiry)
                 );
             }
         }
@@ -1787,15 +1905,46 @@ private:
         con_sp_t con;
         MQTT_NS::buffer client_id;
 
-        MQTT_NS::optional<MQTT_NS::will> will;
         MQTT_NS::optional<std::chrono::steady_clock::duration> will_delay;
         MQTT_NS::optional<std::chrono::steady_clock::duration> session_expiry_interval;
         std::shared_ptr<as::steady_timer> tim_session_expiry;
         MQTT_NS::optional<MQTT_NS::topic_alias_recv_map_t> topic_alias_recv;
+
         mi_inflight_message inflight_messages;
-        std::deque<offline_message> offline_messages;
         std::set<packet_id_t> qos2_publish_processed;
+
+        mi_offline_message offline_messages;
+
         std::set<sub_con_map::handle> handles; // to efficient remove
+
+        void update_will(as::io_context& ioc, MQTT_NS::optional<MQTT_NS::will> will, MQTT_NS::optional<std::chrono::steady_clock::duration> will_expiry_interval) {
+            tim_will_expiry.reset();
+            will_value = MQTT_NS::force_move(will);
+
+            if (will_value && will_expiry_interval) {
+                tim_will_expiry = std::make_shared<as::steady_timer>(ioc, will_expiry_interval.value());
+                tim_will_expiry->async_wait(
+                    [this, client_id = client_id, wp = std::weak_ptr<as::steady_timer>(tim_will_expiry)](MQTT_NS::error_code ec) {
+                        if (auto sp = wp.lock()) {
+                            reset_will();
+                        }                                           }
+                );
+            }
+        }
+
+        void reset_will() {
+            tim_will_expiry.reset();
+            will_value = MQTT_NS::nullopt;
+        }
+
+        MQTT_NS::optional<MQTT_NS::will>& will() { return will_value; }
+        MQTT_NS::optional<MQTT_NS::will> const& will() const { return will_value; }
+
+        std::shared_ptr<as::steady_timer>& get_tim_will_expiry() { return tim_will_expiry; }
+    private:
+        std::shared_ptr<as::steady_timer> tim_will_expiry;
+        MQTT_NS::optional<MQTT_NS::will> will_value;
+
     };
 
     // The mi_session_online container holds the relevant data about an active connection with the broker.
@@ -1826,16 +1975,20 @@ private:
             MQTT_NS::buffer topic,
             MQTT_NS::buffer contents,
             MQTT_NS::v5::properties props,
-            MQTT_NS::qos qos_value)
+            MQTT_NS::qos qos_value,
+            std::shared_ptr<as::steady_timer> tim_message_expiry = std::shared_ptr<as::steady_timer>())
             :topic(MQTT_NS::force_move(topic)),
              contents(MQTT_NS::force_move(contents)),
              props(MQTT_NS::force_move(props)),
-             qos_value(qos_value)
+             qos_value(qos_value),
+             tim_message_expiry(MQTT_NS::force_move(tim_message_expiry))
         { }
+
         MQTT_NS::buffer topic;
         MQTT_NS::buffer contents;
         MQTT_NS::v5::properties props;
         MQTT_NS::qos qos_value;
+        std::shared_ptr<as::steady_timer> tim_message_expiry;
     };
     using retained_messages = retained_topic_map<retain>;
 

--- a/test/will.cpp
+++ b/test/will.cpp
@@ -169,6 +169,175 @@ BOOST_AUTO_TEST_CASE( will_qos0 ) {
     th.join();
 }
 
+BOOST_AUTO_TEST_CASE( will_qo0_timeout ) {
+    boost::asio::io_context iocb;
+    test_broker b(iocb);
+    MQTT_NS::optional<test_server_no_tls> s;
+    std::promise<void> p;
+    auto f = p.get_future();
+    std::thread th(
+        [&] {
+            s.emplace(iocb, b);
+            p.set_value();
+            iocb.run();
+        }
+    );
+    f.wait();
+    auto finish =
+        [&] {
+            as::post(
+                iocb,
+                [&] {
+                    s->close();
+                }
+            );
+        };
+
+    boost::asio::io_context ioc;
+
+    constexpr uint32_t will_expiry_interval = 1;
+    as::steady_timer timeout(ioc);
+    as::steady_timer timeout_2(ioc);
+
+    MQTT_NS::v5::properties ps {
+        MQTT_NS::v5::property::message_expiry_interval(will_expiry_interval),
+    };
+
+    auto c1 = MQTT_NS::make_client(ioc, broker_url, broker_notls_port, MQTT_NS::protocol_version::v5);
+    c1->set_client_id("cid1");
+    c1->set_clean_session(true);
+    c1->set_will(MQTT_NS::will("topic1"_mb, "will_contents"_mb, MQTT_NS::retain::yes, MQTT_NS::force_move(ps)));
+
+    int c1fd_count = 0;
+    auto c1_force_disconnect = [&c1, &c1fd_count] {
+        if (++c1fd_count == 2) c1->force_disconnect();
+    };
+
+    auto c2 = MQTT_NS::make_client(ioc, broker_url, broker_notls_port, MQTT_NS::protocol_version::v5);
+    c2->set_client_id("cid2");
+    c2->set_clean_session(true);
+
+    using packet_id_t = typename std::remove_reference_t<decltype(*c1)>::packet_id_t;
+
+
+    checker chk = {
+        // connect
+        cont("h_connack_1"),
+        // force_disconnect
+        cont("h_error_1"),
+
+        // connect
+        deps("h_connack_2"),
+        // subscribe topic1 QoS0
+        cont("h_suback_2"),
+       // cont("h_publish_2"), // will receive
+        // unsubscribe topic1
+        cont("h_unsuback_2"),
+        // disconnect
+        cont("h_close_2"),
+
+    };
+
+    c1->set_v5_connack_handler(
+        [&chk, &c1_force_disconnect]
+        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
+            MQTT_CHK("h_connack_1");
+            BOOST_TEST(sp == false);
+            BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
+            c1_force_disconnect();
+            return true;
+        });
+    c1->set_close_handler(
+        []
+        () {
+            BOOST_CHECK(false);
+        });
+    c1->set_error_handler(
+        [&chk]
+        (MQTT_NS::error_code) {
+            MQTT_CHK("h_error_1");
+        });
+
+    std::uint16_t pid_sub2;
+    std::uint16_t pid_unsub2;
+
+    c2->set_v5_connack_handler(
+        [&chk, &c2, &pid_sub2]
+        (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
+            MQTT_CHK("h_connack_2");
+            BOOST_TEST(sp == false);
+            BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
+            pid_sub2 = c2->subscribe("topic1", MQTT_NS::qos::at_most_once);
+            return true;
+        });
+    c2->set_close_handler(
+        [&chk, &finish]
+        () {
+            MQTT_CHK("h_close_2");
+            finish();
+        });
+    c2->set_error_handler(
+        []
+        (MQTT_NS::error_code) {
+            BOOST_CHECK(false);
+        });
+    c2->set_v5_suback_handler(
+        [&chk, &c2, &c1_force_disconnect, &pid_sub2, &pid_unsub2, &timeout, &timeout_2, &will_expiry_interval]
+        (packet_id_t packet_id, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
+            MQTT_CHK("h_suback_2");
+            BOOST_TEST(packet_id == pid_sub2);
+            BOOST_TEST(reasons.size() == 1U);
+            BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_0);
+
+            timeout.expires_after(std::chrono::seconds(1 + will_expiry_interval));
+            timeout.async_wait(
+                [&c1_force_disconnect](MQTT_NS::error_code ec) {
+                    if (!ec) {
+                         c1_force_disconnect();
+                    }
+                }
+            );
+
+            timeout_2.expires_after(std::chrono::seconds(2 + will_expiry_interval));
+            timeout_2.async_wait(
+                [&c2, &pid_unsub2](MQTT_NS::error_code ec) {
+                    if (!ec) {
+                        pid_unsub2 = c2->unsubscribe("topic1");
+                    }
+                }
+            );
+
+            return true;
+        });
+    c2->set_v5_unsuback_handler(
+        [&chk, &c2, &pid_unsub2]
+        (packet_id_t packet_id, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
+            MQTT_CHK("h_unsuback_2");
+            BOOST_TEST(packet_id == pid_unsub2);
+            c2->disconnect();
+            return true;
+        });
+    c2->set_v5_publish_handler(
+        [&chk, &c2, &pid_unsub2]
+        (MQTT_NS::optional<packet_id_t> packet_id,
+         MQTT_NS::publish_options pubopts,
+         MQTT_NS::buffer topic,
+         MQTT_NS::buffer contents,
+         MQTT_NS::v5::properties /*props*/) {
+
+            // Will should not be received
+            BOOST_TEST(false);
+            return true;
+        });
+
+    c1->connect();
+    c2->connect();
+
+    ioc.run();
+    BOOST_TEST(chk.all());
+    th.join();
+}
+
 BOOST_AUTO_TEST_CASE( will_qos1 ) {
     boost::asio::io_context iocb;
     test_broker b(iocb);
@@ -719,6 +888,7 @@ BOOST_AUTO_TEST_CASE( will_prop ) {
                 iocb,
                 [&] {
                     s->close();
+                    b.clear_all_retained_topics();
                 }
             );
         };


### PR DESCRIPTION
This is what I have so far:

Retained message expiry (tested)
Will expiry (tested)
Offline message expiry (no test)
The message expiry is updated when the message is finally transmitted, this is also untested yet.

The unit tests for this are a bit of a hassle, is it maybe better to use synchronous clients, much easier to write the test. Also, when the unit test stalls, there is no real timeout on the unit test. That is also why the CI hangs sometimes.