### PR TITLE
System test broker with crash

### DIFF
--- a/test/system/CMakeLists.txt
+++ b/test/system/CMakeLists.txt
@@ -58,6 +58,7 @@ ENDIF ()
 IF (MQTT_TEST_7)
     LIST (APPEND check_PROGRAMS
         st_async_pubsub_2.cpp
+        st_broker
         st_broker_offline_message.cpp
         st_remaining_length.cpp
         st_utf8string_validate.cpp

--- a/test/system/st_broker.cpp
+++ b/test/system/st_broker.cpp
@@ -1,0 +1,77 @@
+// Copyright Takatoshi Kondo 2020
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include "../common/test_main.hpp"
+#include "combi_test.hpp"
+#include "checker.hpp"
+#include "test_util.hpp"
+#include "../common/global_fixture.hpp"
+
+BOOST_AUTO_TEST_SUITE(broker)
+
+using namespace MQTT_NS::literals;
+
+BOOST_AUTO_TEST_CASE( broker_bug ) {
+
+    boost::asio::io_context iocb;
+    MQTT_NS::broker b(iocb);
+    MQTT_NS::optional<test_server_no_tls> s;
+
+    std::thread th(
+        [&] {
+            s.emplace(iocb, b);
+            iocb.run();
+        }
+    );
+
+    std::vector<std::shared_ptr<std::thread>> client_th;
+
+    unsigned int num_clients = 10;
+
+    auto client_thread_func =
+        [] {
+            boost::asio::io_context ioc;
+
+            int publish_count = 100;
+
+            auto c1 = MQTT_NS::make_client(ioc, broker_url, broker_notls_port);
+            c1->set_clean_session(true);
+            c1->set_client_id("cid1");
+
+            c1->set_connack_handler(
+                [&c1, &publish_count]
+                (bool sp, MQTT_NS::connect_return_code connack_return_code) {
+                    std::cout << "Publish: " << publish_count << std::endl;
+                    for(int i = 0; i < 100; ++i) {
+                        c1->publish("topic1", "topic1_contents1", MQTT_NS::qos::at_most_once);
+                    }
+                    return true;
+                }
+            );
+
+            c1->connect();
+            ioc.run();
+        };
+
+    for(int i = 0; i < num_clients; ++i) {
+        client_th.push_back(std::make_shared<std::thread>(client_thread_func));
+    }
+
+    for(auto& th: client_th) {
+        th->join();
+    }
+
+    as::post(
+        iocb,
+        [&] {
+            s->close();
+        }
+    );
+
+    th.join();
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Following test demonstrates the broker failing on assertions, with multiple clients connecting with the same client_id:

````
Running 1 test case...
Publish: 100
Publish: 100
Publish: 100
Publish: 100
Assertion failed: it != idx.end(), file C:\data\projecten\mqtt_cpp\include\mqtt/broker/broker.hpp, line 1227
