### PR TITLE
feature: add method to allow user to send ping requests to broker

### DIFF
--- a/include/mqtt/client.hpp
+++ b/include/mqtt/client.hpp
@@ -910,6 +910,20 @@ public:
     }
 
     /**
+     * @brief send_ping_req
+     * Send a ping regarding of the configuration. Will be called from ping req timer.
+     * If the user want to implement a ping req stragy, this method must be called to send a ping<BR>
+     */
+    void send_ping_req() {
+        if (async_pingreq_) {
+            base::async_pingreq();
+        }
+        else {
+            base::pingreq();
+        }
+    }
+
+    /**
      * @brief Set pingreq message sending mode
      * @param b If true then send pingreq asynchronously, otherwise send synchronously.
      */
@@ -1312,12 +1326,7 @@ protected:
 private:
     void handle_timer(error_code ec) {
         if (!ec) {
-            if (async_pingreq_) {
-                base::async_pingreq();
-            }
-            else {
-                base::pingreq();
-            }
+            send_ping_req();
         }
     }
 


### PR DESCRIPTION
The applied changes allows the user to send the ping request to the mqtt broker.

This is necessary, if the default ping request strategy (disconnect after missing one ping response) of mqtt_cpp didn't fit the requirements of the application of the user.

The default ping request of mqtt_cpp can be disbaled by passing duration::zero() to set_keep_alive_sec, eg.

```
client->set_keep_alive_sec(keepAliveInterval, std::chrono::steady_clock::duration::zero());
```