### PR TITLE
Fixed invalid assertion fail on (sync) pubrel sending.

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Test
       working-directory: ${{ runner.temp }}
       run: |
-        ctest -VV
+        CTEST_ARGS="--log_level=all" ctest -VV
   linux:
     runs-on: ubuntu-latest
     strategy:

--- a/include/mqtt/endpoint.hpp
+++ b/include/mqtt/endpoint.hpp
@@ -9159,8 +9159,25 @@ private:
                         msg,
                         force_move(life_keeper)
                     );
-                    (void)ret;
-                    BOOST_ASSERT(ret.second);
+                    // publish store is erased when pubrec is received.
+                    // pubrel store is erased when pubcomp is received.
+                    // If invalid client send pubrec twice with the same packet id,
+                    // then send corresponding pubrel twice is a possible client/server
+                    // implementation.
+                    // In this case, overwrite store_.
+                    if (!ret.second) {
+                        store_.modify(
+                            ret.first,
+                            [&] (auto& e) {
+                                e = store(
+                                    packet_id,
+                                    control_packet_type::pubcomp,
+                                    force_move(msg),
+                                    life_keeper
+                                );
+                            }
+                        );
+                    }
                 }
 
                 (this->*serialize)(msg);

--- a/include/mqtt/endpoint.hpp
+++ b/include/mqtt/endpoint.hpp
@@ -4549,7 +4549,7 @@ public:
                         store_msg,
                         force_move(life_keeper)
                     );
-                    (this->*serialize)(msg);
+                    (this->*serialize)(force_move(store_msg));
                 }
                 do_sync_write(force_move(msg));
             };
@@ -4624,7 +4624,7 @@ public:
                         store_msg,
                         force_move(life_keeper)
                     );
-                    (this->*serialize)(msg);
+                    (this->*serialize)(force_move(store_msg));
                 }
                 do_async_write(force_move(msg), force_move(func));
             };
@@ -9062,10 +9062,10 @@ private:
                         pubopts.get_qos() == qos::at_least_once
                              ? control_packet_type::puback
                              : control_packet_type::pubrec,
-                        store_msg,
+                        force_move(store_msg),
                         force_move(life_keeper)
                     );
-                    (this->*serialize_publish)(store_msg);
+                    (this->*serialize_publish)(msg);
                 }
                 do_sync_write(force_move(msg));
             };
@@ -9172,7 +9172,7 @@ private:
                                 e = store(
                                     packet_id,
                                     control_packet_type::pubcomp,
-                                    force_move(msg),
+                                    msg,
                                     life_keeper
                                 );
                             }
@@ -9453,7 +9453,7 @@ private:
         boost::system::error_code ec;
         if (!connected_) return;
         on_pre_send();
-        total_bytes_sent_ += socket_->write(const_buffer_sequence<PacketIdBytes>(std::forward<MessageVariant>(mv)), ec);
+        total_bytes_sent_ += socket_->write(const_buffer_sequence<PacketIdBytes>(mv), ec);
         // If ec is set as error, the error will be handled by async_read.
         // If `handle_error(ec);` is called here, error_handler would be called twice.
     }
@@ -9566,7 +9566,7 @@ private:
                         BOOST_ASSERT(ret.second);
                     }
 
-                    (this->*serialize_publish)(store_msg);
+                    (this->*serialize_publish)(force_move(store_msg));
                 }
                 do_async_write(
                     force_move(msg),
@@ -9701,7 +9701,7 @@ private:
                                 e = store(
                                     packet_id,
                                     control_packet_type::pubcomp,
-                                    force_move(msg),
+                                    msg,
                                     life_keeper
                                 );
                             }

--- a/include/mqtt/endpoint.hpp
+++ b/include/mqtt/endpoint.hpp
@@ -9166,6 +9166,10 @@ private:
                     // implementation.
                     // In this case, overwrite store_.
                     if (!ret.second) {
+                        MQTT_LOG("mqtt_impl", warning)
+                            << MQTT_ADD_VALUE(address, this)
+                            << "overwrite pubrel"
+                            << " packet_id:" << packet_id;
                         store_.modify(
                             ret.first,
                             [&] (auto& e) {
@@ -9695,6 +9699,10 @@ private:
                     // implementation.
                     // In this case, overwrite store_.
                     if (!ret.second) {
+                        MQTT_LOG("mqtt_impl", warning)
+                            << MQTT_ADD_VALUE(address, this)
+                            << "overwrite pubrel"
+                            << " packet_id:" << packet_id;
                         store_.modify(
                             ret.first,
                             [&] (auto& e) {

--- a/test/system/st_async_pubsub_2.cpp
+++ b/test/system/st_async_pubsub_2.cpp
@@ -611,17 +611,16 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2_protocol_error_resend_pubrec ) {
             // subscribe topic1 QoS0
             cont("h_suback"),
             // publish topic1 QoS2
-            cont("h_publish"),
             cont("h_pubrec"),
+            cont("h_pubcomp"),
+            deps("h_publish", "h_suback"),
             // pubrec send twice
             cont("h_pubrel1"),
             cont("h_pubrel2"),
-            deps("h_pubcomp", "h_pubrec"),
-            cont("h_unsuback"),
+            deps("h_unsuback", "h_pubcomp", "h_pubrel2"),
             // disconnect
             cont("h_close"),
         };
-
 
         auto g = MQTT_NS::shared_scope_guard(
             [&c] {

--- a/test/system/st_async_pubsub_2.cpp
+++ b/test/system/st_async_pubsub_2.cpp
@@ -598,6 +598,238 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
     do_combi_test_async(test);
 }
 
+BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2_protocol_error_resend_pubrec ) {
+    auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
+        c->set_clean_session(true);
+        c->set_auto_pub_response(false);
+
+        checker chk = {
+            // connect
+            cont("h_connack"),
+            // subscribe topic1 QoS0
+            cont("h_suback"),
+            // publish topic1 QoS2
+            cont("h_publish"),
+            cont("h_pubrec"),
+            // pubrec send twice
+            cont("h_pubrel1"),
+            cont("h_pubrel2"),
+            deps("h_pubcomp", "h_pubrec"),
+            cont("h_unsuback"),
+            // disconnect
+            cont("h_close"),
+        };
+
+
+        auto g = MQTT_NS::shared_scope_guard(
+            [&c] {
+                auto unsub_pid = c->acquire_unique_packet_id();
+                c->async_unsubscribe(unsub_pid, "topic1");
+            }
+        );
+
+        switch (c->get_protocol_version()) {
+        case MQTT_NS::protocol_version::v3_1_1:
+            c->set_connack_handler(
+                [&chk, &c]
+                (bool sp, MQTT_NS::connect_return_code connack_return_code) {
+                    MQTT_CHK("h_connack");
+                    BOOST_TEST(sp == false);
+                    BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
+                    auto pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(pid_sub, "topic1", MQTT_NS::qos::exactly_once);
+                    return true;
+                });
+            c->set_puback_handler(
+                []
+                (std::uint16_t) {
+                    BOOST_CHECK(false);
+                    return true;
+                });
+            c->set_pubrec_handler(
+                [&chk, &c]
+                (packet_id_t packet_id) {
+                    MQTT_CHK("h_pubrec");
+                    c->async_pubrel(packet_id);
+                    return true;
+                });
+            c->set_pubcomp_handler(
+                [&chk, g]
+                (packet_id_t) mutable {
+                    MQTT_CHK("h_pubcomp");
+                    g.reset();
+                    return true;
+                });
+            c->set_suback_handler(
+                [&chk, &c]
+                (packet_id_t, std::vector<MQTT_NS::suback_return_code> results) {
+                    MQTT_CHK("h_suback");
+                    BOOST_TEST(results.size() == 1U);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_2);
+                    auto pid_pub = c->acquire_unique_packet_id();
+                    c->async_publish(pid_pub, "topic1", "topic1_contents", MQTT_NS::qos::exactly_once);
+                    return true;
+                });
+            c->set_unsuback_handler(
+                [&chk, &c]
+                (packet_id_t) {
+                    MQTT_CHK("h_unsuback");
+                    c->async_disconnect();
+                    return true;
+                });
+            c->set_publish_handler(
+                [&chk, &c]
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
+                 MQTT_NS::buffer topic,
+                 MQTT_NS::buffer contents) {
+                    MQTT_CHK("h_publish");
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::exactly_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
+                    BOOST_TEST(*packet_id != 0);
+                    BOOST_TEST(topic == "topic1");
+                    BOOST_TEST(contents == "topic1_contents");
+                    // send pubrec twice
+                    c->async_pubrec(*packet_id);
+                    c->async_pubrec(*packet_id);
+                    return true;
+                });
+            c->set_pubrel_handler(
+                [&chk, &c, g]
+                (packet_id_t packet_id) mutable {
+                    auto ret = chk.match(
+                        "h_publish",
+                        [&] {
+                            MQTT_CHK("h_pubrel1");
+                            c->async_pubcomp(packet_id);
+                        },
+                        "h_pubrel1",
+                        [&] () {
+                            MQTT_CHK("h_pubrel2");
+                            c->async_pubcomp(packet_id);
+                            g.reset();
+                        }
+                    );
+                    BOOST_TEST(ret);
+                    return true;
+                });
+            break;
+        case MQTT_NS::protocol_version::v5:
+            c->set_v5_connack_handler(
+                [&chk, &c]
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
+                    MQTT_CHK("h_connack");
+                    BOOST_TEST(sp == false);
+                    BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
+                    auto pid_sub = c->acquire_unique_packet_id();
+                    c->async_subscribe(pid_sub, "topic1", MQTT_NS::qos::exactly_once);
+                    return true;
+                });
+            c->set_v5_puback_handler(
+                []
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
+                    BOOST_CHECK(false);
+                    return true;
+                });
+            c->set_v5_pubrec_handler(
+                [&chk, &c]
+                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
+                    MQTT_CHK("h_pubrec");
+                    c->async_pubrel(packet_id);
+                    return true;
+                });
+            c->set_v5_pubcomp_handler(
+                [&chk, g]
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) mutable {
+                    MQTT_CHK("h_pubcomp");
+                    g.reset();
+                    return true;
+                });
+            c->set_v5_suback_handler(
+                [&chk, &c]
+                (packet_id_t, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
+                    MQTT_CHK("h_suback");
+                    BOOST_TEST(reasons.size() == 1U);
+                    BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_2);
+                    auto pid_pub = c->acquire_unique_packet_id();
+                    c->async_publish(pid_pub, "topic1", "topic1_contents", MQTT_NS::qos::exactly_once);
+                    return true;
+                });
+            c->set_v5_unsuback_handler(
+                [&chk, &c]
+                (packet_id_t, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
+                    MQTT_CHK("h_unsuback");
+                    BOOST_TEST(reasons.size() == 1U);
+                    BOOST_TEST(reasons[0] == MQTT_NS::v5::unsuback_reason_code::success);
+                    c->async_disconnect();
+                    return true;
+                });
+            c->set_v5_publish_handler(
+                [&chk, &c]
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
+                 MQTT_NS::buffer topic,
+                 MQTT_NS::buffer contents,
+                 MQTT_NS::v5::properties /*props*/) {
+                    MQTT_CHK("h_publish");
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::exactly_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
+                    BOOST_TEST(*packet_id != 0);
+                    BOOST_TEST(topic == "topic1");
+                    BOOST_TEST(contents == "topic1_contents");
+                    // send pubrec twice
+                    c->async_pubrec(*packet_id);
+                    c->async_pubrec(*packet_id);
+                    return true;
+                });
+            c->set_v5_pubrel_handler(
+                [&chk, &c, g]
+                (packet_id_t packet_id, MQTT_NS::v5::pubrel_reason_code, MQTT_NS::v5::properties /*props*/) mutable {
+                    auto ret = chk.match(
+                        "h_publish",
+                        [&] {
+                            MQTT_CHK("h_pubrel1");
+                            c->async_pubcomp(packet_id);
+                        },
+                        "h_pubrel1",
+                        [&] () {
+                            MQTT_CHK("h_pubrel2");
+                            c->async_pubcomp(packet_id);
+                            g.reset();
+                        }
+                    );
+                    BOOST_TEST(ret);
+                    return true;
+                });
+            break;
+        default:
+            BOOST_CHECK(false);
+            break;
+        }
+
+        c->set_close_handler(
+            [&chk, &finish]
+            () {
+                MQTT_CHK("h_close");
+                finish();
+            });
+        c->set_error_handler(
+            []
+            (MQTT_NS::error_code) {
+                BOOST_CHECK(false);
+            });
+        g.reset();
+        c->async_connect();
+        ioc.run();
+        BOOST_TEST(chk.all());
+    };
+    do_combi_test_async(test);
+}
+
 BOOST_AUTO_TEST_CASE( publish_function ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;

--- a/test/system/st_pubsub_1.cpp
+++ b/test/system/st_pubsub_1.cpp
@@ -1735,13 +1735,13 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2_protocol_error_resend_pubrec ) {
             // subscribe topic1 QoS0
             cont("h_suback"),
             // publish topic1 QoS2
-            cont("h_publish"),
             cont("h_pubrec"),
+            cont("h_pubcomp"),
+            deps("h_publish", "h_suback"),
             // pubrec send twice
             cont("h_pubrel1"),
             cont("h_pubrel2"),
-            cont("h_pubcomp"),
-            cont("h_unsuback"),
+            deps("h_unsuback", "h_pubcomp", "h_pubrel2"),
             // disconnect
             cont("h_close"),
         };

--- a/test/system/st_pubsub_1.cpp
+++ b/test/system/st_pubsub_1.cpp
@@ -1722,6 +1722,233 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
     do_combi_test_sync(test);
 }
 
+BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2_protocol_error_resend_pubrec ) {
+    auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
+        c->set_clean_session(true);
+        c->set_auto_pub_response(false);
+
+        checker chk = {
+            // connect
+            cont("h_connack"),
+            // subscribe topic1 QoS0
+            cont("h_suback"),
+            // publish topic1 QoS2
+            cont("h_publish"),
+            cont("h_pubrec"),
+            // pubrec send twice
+            cont("h_pubrel1"),
+            cont("h_pubrel2"),
+            cont("h_pubcomp"),
+            cont("h_unsuback"),
+            // disconnect
+            cont("h_close"),
+        };
+
+        auto g = MQTT_NS::shared_scope_guard(
+            [&c] {
+                c->unsubscribe("topic1");
+            }
+        );
+
+        switch (c->get_protocol_version()) {
+        case MQTT_NS::protocol_version::v3_1_1:
+            c->set_connack_handler(
+                [&chk, &c]
+                (bool sp, MQTT_NS::connect_return_code connack_return_code) {
+                    MQTT_CHK("h_connack");
+                    BOOST_TEST(sp == false);
+                    BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
+                    c->subscribe("topic1", MQTT_NS::qos::exactly_once);
+                    return true;
+                });
+            c->set_puback_handler(
+                []
+                (packet_id_t) {
+                    BOOST_CHECK(false);
+                    return true;
+                });
+            c->set_pubrec_handler(
+                [&chk, &c]
+                (packet_id_t packet_id) {
+                    MQTT_CHK("h_pubrec");
+                    c->pubrel(packet_id);
+                    return true;
+                });
+            c->set_pubcomp_handler(
+                [&chk, g]
+                (packet_id_t) mutable {
+                    MQTT_CHK("h_pubcomp");
+                    g.reset();
+                    return true;
+                });
+            c->set_suback_handler(
+                [&chk, &c]
+                (packet_id_t, std::vector<MQTT_NS::suback_return_code> results) {
+                    MQTT_CHK("h_suback");
+                    BOOST_TEST(results.size() == 1U);
+                    BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_2);
+                    c->publish("topic1", "topic1_contents", MQTT_NS::qos::exactly_once);
+                    return true;
+                });
+            c->set_unsuback_handler(
+                [&chk, &c]
+                (packet_id_t) {
+                    MQTT_CHK("h_unsuback");
+                    c->disconnect();
+                    return true;
+                });
+            c->set_publish_handler(
+                [&chk, &c]
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
+                 MQTT_NS::buffer topic,
+                 MQTT_NS::buffer contents) {
+                    MQTT_CHK("h_publish");
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::exactly_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
+                    BOOST_TEST(*packet_id != 0);
+                    BOOST_TEST(topic == "topic1");
+                    BOOST_TEST(contents == "topic1_contents");
+                    // send pubrec twice
+                    c->pubrec(*packet_id);
+                    c->pubrec(*packet_id);
+                    return true;
+                });
+            c->set_pubrel_handler(
+                [&chk, &c, g]
+                (packet_id_t packet_id) mutable {
+                    auto ret = chk.match(
+                        "h_publish",
+                        [&] {
+                            MQTT_CHK("h_pubrel1");
+                            c->pubcomp(packet_id);
+                        },
+                        "h_pubrel1",
+                        [&] () {
+                            MQTT_CHK("h_pubrel2");
+                            c->pubcomp(packet_id);
+                            g.reset();
+                        }
+                    );
+                    BOOST_TEST(ret);
+                    return true;
+                });
+            break;
+        case MQTT_NS::protocol_version::v5:
+            c->set_v5_connack_handler(
+                [&chk, &c]
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
+                    MQTT_CHK("h_connack");
+                    BOOST_TEST(sp == false);
+                    BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
+                    c->subscribe("topic1", MQTT_NS::qos::exactly_once);
+                    return true;
+                });
+            c->set_v5_puback_handler(
+                []
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
+                    BOOST_CHECK(false);
+                    return true;
+                });
+            c->set_v5_pubrec_handler(
+                [&chk, &c]
+                (packet_id_t packet_id, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
+                    MQTT_CHK("h_pubrec");
+                    c->pubrel(packet_id);
+                    return true;
+                });
+            c->set_v5_pubcomp_handler(
+                [&chk, g]
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) mutable {
+                    MQTT_CHK("h_pubcomp");
+                    g.reset();
+                    return true;
+                });
+            c->set_v5_suback_handler(
+                [&chk, &c]
+                (packet_id_t, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
+                    MQTT_CHK("h_suback");
+                    BOOST_TEST(reasons.size() == 1U);
+                    BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_2);
+                    c->publish("topic1", "topic1_contents", MQTT_NS::qos::exactly_once);
+                    return true;
+                });
+            c->set_v5_unsuback_handler(
+                [&chk, &c]
+                (packet_id_t, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
+                    MQTT_CHK("h_unsuback");
+                    BOOST_TEST(reasons.size() == 1U);
+                    BOOST_TEST(reasons[0] == MQTT_NS::v5::unsuback_reason_code::success);
+                    c->disconnect();
+                    return true;
+                });
+            c->set_v5_publish_handler(
+                [&chk, &c]
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
+                 MQTT_NS::buffer topic,
+                 MQTT_NS::buffer contents,
+                 MQTT_NS::v5::properties /*props*/) {
+                    MQTT_CHK("h_publish");
+                    BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                    BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::exactly_once);
+                    BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
+                    BOOST_TEST(*packet_id != 0);
+                    BOOST_TEST(topic == "topic1");
+                    BOOST_TEST(contents == "topic1_contents");
+                    // send pubrec twice
+                    c->pubrec(*packet_id);
+                    c->pubrec(*packet_id);
+                    return true;
+                });
+            c->set_v5_pubrel_handler(
+                [&chk, &c, g]
+                (packet_id_t packet_id, MQTT_NS::v5::pubrel_reason_code, MQTT_NS::v5::properties /*props*/) mutable {
+                    auto ret = chk.match(
+                        "h_publish",
+                        [&] {
+                            MQTT_CHK("h_pubrel1");
+                            c->pubcomp(packet_id);
+                        },
+                        "h_pubrel1",
+                        [&] () {
+                            MQTT_CHK("h_pubrel2");
+                            c->pubcomp(packet_id);
+                            g.reset();
+                        }
+                    );
+                    BOOST_TEST(ret);
+                    return true;
+                });
+            break;
+        default:
+            BOOST_CHECK(false);
+            break;
+        }
+
+        c->set_close_handler(
+            [&chk, &finish]
+            () {
+                MQTT_CHK("h_close");
+                finish();
+            });
+        c->set_error_handler(
+            []
+            (MQTT_NS::error_code) {
+                BOOST_CHECK(false);
+            });
+
+        g.reset();
+        c->connect();
+        ioc.run();
+        BOOST_TEST(chk.all());
+    };
+    do_combi_test_sync(test);
+}
+
 BOOST_AUTO_TEST_CASE( publish_function ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;


### PR DESCRIPTION
Invalid client may send pubrec twice with the same packet_id.
Then the broker send pubrel twice and the second one causes assertion
fail.
But assertion fail is for logic error. It is actually happened by the
invalid client.
So, just overwrite pubrel message to the store. No assertion fail.