### PR TITLE
Fixed #768.

### DIFF
--- a/include/mqtt/broker/broker.hpp
+++ b/include/mqtt/broker/broker.hpp
@@ -330,10 +330,6 @@ public:
                     if (sp->connected()) {
                         sp->disconnect(v5::disconnect_reason_code::protocol_error);
                     }
-                    else if (sp->underlying_connected()){
-                        // underlying layer connected, mqtt connecting
-                        sp->connack(false, v5::connect_reason_code::protocol_error);
-                    }
                 }
                 close_proc(force_move(sp), true);
             });


### PR DESCRIPTION
The broker sent CONNACK even if MQTT connection hadn't been established.
It caused assertion failed.

In this case, the broker should simply close connection.