### PR TITLE
Broker release build and command line options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,7 @@ FIND_PACKAGE (Threads REQUIRED)
 
 IF (MQTT_USE_LOG)
     MESSAGE (STATUS "Logging enabled")
-    FIND_PACKAGE (Boost 1.67.0 REQUIRED COMPONENTS system date_time log filesystem thread)
+    FIND_PACKAGE (Boost 1.67.0 REQUIRED COMPONENTS system date_time log filesystem thread program_options)
 ELSE ()
     MESSAGE (STATUS "Logging disabled")
     FIND_PACKAGE (Boost 1.67.0 REQUIRED COMPONENTS system date_time)

--- a/example/broker.cpp
+++ b/example/broker.cpp
@@ -5,16 +5,70 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #include <mqtt/config.hpp>
-
 #include "../test/system/test_server_no_tls.hpp"
 #include <mqtt/setup_log.hpp>
-
 #include <mqtt/broker/broker.hpp>
+#include <boost/program_options.hpp>
 
-int main() {
-    MQTT_NS::setup_log();
-    boost::asio::io_context ioc;
-    MQTT_NS::broker::broker_t b(ioc);
-    test_server_no_tls s(ioc, b);
-    ioc.run();
+void run_broker(boost::program_options::variables_map &vm)
+{
+    try {
+        boost::asio::io_context ioc;
+        MQTT_NS::broker::broker_t b(ioc);
+        test_server_no_tls s(ioc, b, vm["notls.port"].as<uint16_t>());
+        ioc.run();
+    } catch(std::exception &e) {
+        MQTT_LOG("mqtt_broker", error) << e.what();
+    }
+}
+
+int main(int argc, char **argv) {
+    try {
+        boost::program_options::options_description desc("Allowed options");
+        desc.add_options()
+            ("help", "produce help message")
+#ifdef MQTT_USE_LOG
+            ("verbose", boost::program_options::value<unsigned int>()->default_value(1), "set verbose level, possible values:\n 0 - Fatal\n 1 - Error\n 2 - Warning\n 3 - Info\n 4 - Debug\n 5 - Trace")
+#endif
+            ("notls.port", boost::program_options::value<uint16_t>()->default_value(broker_notls_port), "default port (TCP)")
+        ;
+
+        boost::program_options::variables_map vm;
+        boost::program_options::store(boost::program_options::parse_command_line(argc, argv, desc), vm);
+        boost::program_options::notify(vm);
+
+        if (vm.count("help")) {
+            std::cout << desc << std::endl;
+            return 1;
+        }
+
+#ifdef MQTT_USE_LOG
+        switch(vm["verbose"].as<unsigned int>()) {
+        case 5:
+            MQTT_NS::setup_log(mqtt::severity_level::trace);
+            break;
+        case 4:
+            MQTT_NS::setup_log(mqtt::severity_level::debug);
+            break;
+        case 3:
+            MQTT_NS::setup_log(mqtt::severity_level::info);
+            break;
+        case 2:
+            MQTT_NS::setup_log(mqtt::severity_level::warning);
+            break;
+        default:
+            MQTT_NS::setup_log(mqtt::severity_level::error);
+            break;
+        case 0:
+            MQTT_NS::setup_log(mqtt::severity_level::fatal);
+            break;
+        }
+#else
+        MQTT_NS::setup_log();
+#endif
+
+        run_broker(vm);
+    } catch(std::exception &e) {
+        std::cerr << e.what() << std::endl;
+    }
 }

--- a/test/system/test_server_no_tls.hpp
+++ b/test/system/test_server_no_tls.hpp
@@ -21,10 +21,10 @@ using con_sp_t = std::shared_ptr<con_t>;
 
 class test_server_no_tls {
 public:
-    test_server_no_tls(as::io_context& ioc, MQTT_NS::broker::broker_t& b)
+    test_server_no_tls(as::io_context& ioc, MQTT_NS::broker::broker_t& b, uint16_t port = broker_notls_port)
         : server_(
             as::ip::tcp::endpoint(
-                as::ip::tcp::v4(), broker_notls_port
+                as::ip::tcp::v4(), port
             ),
             ioc,
             ioc,


### PR DESCRIPTION
I added command line options (and config file) to configure the broker. Also added some rules to build a (static) executable for linux and MacOS using CI. Linux executable is staticly compiled and compressed using UPX. 

````
General options:
  --help                                produce help message
  --cfg arg                             Load configuration file
  --verbose arg (=1)                    set verbose level, possible values:
                                         0 - Fatal
                                         1 - Error
                                         2 - Warning
                                         3 - Info
                                         4 - Debug
                                         5 - Trace

TCP Server options:
  --tcp.port arg (=1883)                default port (TCP)
  --tcp.enable arg (=1)                 0/1

TCP Websocket Server options:
  --ws.port arg (=10080)                default port (TCP)
  --ws.enable arg (=0)                  0/1

TLS Server options:
  --tls.port arg (=8883)                default port (TLS)
  --tls.enable arg (=0)                 0/1
  --tls.certificate arg (=server.crt.pem)
                                        Certificate file
  --tls.private_key arg (=server.key.pem)
                                        Private key file

TLS Websocket Server options:
  --tlsws.port arg (=10443)             default port (TLS)
  --tlsws.enable arg (=0)               0/1
````