### PR TITLE
Improved packet_id allocation.

### DIFF
--- a/include/mqtt/packet_id_manager.hpp
+++ b/include/mqtt/packet_id_manager.hpp
@@ -1,0 +1,69 @@
+// Copyright Takatoshi Kondo 2020
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(MQTT_PACKET_ID_MANAGER_HPP)
+#define MQTT_PACKET_ID_MANAGER_HPP
+
+#include <mqtt/config.hpp> // should be top to configure variant limit
+
+#include <mqtt/optional.hpp>
+#include <mqtt/value_allocator.hpp>
+
+namespace MQTT_NS {
+
+template <typename PacketId>
+class packet_id_manager {
+    using packet_id_t = PacketId;
+
+public:
+
+    /**
+     * @brief Acquire the new unique packet id.
+     *        If all packet ids are already in use, then returns nullopt
+     *        After acquiring the packet id, you can call acquired_* functions.
+     *        The ownership of packet id is moved to the library.
+     *        Or you can call release_packet_id to release it.
+     * @return packet id
+     */
+    optional<packet_id_t> acquire_unique_id() {
+        return va_.allocate();
+    }
+
+    /**
+     * @brief Register packet_id to the library.
+     *        After registering the packet_id, you can call acquired_* functions.
+     *        The ownership of packet id is moved to the library.
+     *        Or you can call release_packet_id to release it.
+     * @return If packet_id is successfully registerd then return true, otherwise return false.
+     */
+    bool register_id(packet_id_t packet_id) {
+        return va_.use(packet_id);
+    }
+
+    /**
+     * @brief Release packet_id.
+     * @param packet_id packet id to release.
+     *                   only the packet_id gotten by acquire_unique_packet_id, or
+     *                   register_packet_id is permitted.
+     */
+    void release_id(packet_id_t packet_id) {
+        va_.deallocate(packet_id);
+    }
+
+    /**
+     * @brief Clear all packet ids.
+     */
+    void clear() {
+        va_.clear();
+    }
+
+private:
+    value_allocator<packet_id_t> va_ {1, std::numeric_limits<packet_id_t>::max()};
+};
+
+} // namespace MQTT_NS
+
+#endif // MQTT_PACKET_ID_MANAGER_HPP

--- a/include/mqtt/value_allocator.hpp
+++ b/include/mqtt/value_allocator.hpp
@@ -1,0 +1,275 @@
+// Copyright Takatoshi Kondo 2020
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(MQTT_VALUE_ALLOCATOR_HPP)
+#define MQTT_VALUE_ALLOCATOR_HPP
+
+#include <mqtt/config.hpp> // should be top to configure variant limit
+
+#include <ostream>
+#include <limits>
+
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/identity.hpp>
+
+#include <mqtt/optional.hpp>
+
+namespace MQTT_NS {
+
+namespace mi = boost::multi_index;
+
+template <typename T>
+class value_allocator {
+    using value_type = T;
+
+    class value_interval {
+    public:
+        explicit value_interval(value_type v) : low_{v}, high_{v} {}
+        value_interval(value_type l, value_type h) : low_{l}, high_{h} {}
+
+        // true
+        // | lhs |   | rhs |
+        //
+        // false
+        // | lhs |
+        //      | rhs |
+        //
+        // false
+        // |   lhs   |
+        //   | rhs |
+        //
+        // false
+        //   | lhs |
+        // |   rhs   |
+        //
+        // false
+        //   | lhs |
+        // | rhs |
+        //
+        // false
+        // | rhs |   | lhs |
+        //
+        friend bool operator<(value_interval const& lhs, value_interval const& rhs) {
+            return
+                (lhs.low_ < rhs.low_) &&
+                (lhs.high_ < rhs.low_);
+        }
+        value_type low() const {
+            return low_;
+        }
+        value_type high() const {
+            return high_;
+        }
+
+        friend std::ostream& operator<<(std::ostream& o, value_interval const v) {
+            o << '[' << v.low() << ',' << v.high() << ']';
+            return o;
+        }
+
+    private:
+        value_type low_;
+        value_type high_;
+    };
+
+public:
+    /**
+     * @brief Create value_allocator
+     *        The allocator has [lowest, highest] values.
+     * @param lowest The lowest value
+     * @param highest The highest value.
+     */
+    value_allocator(value_type lowest, value_type highest)
+        :lowest_{lowest}, highest_{highest} {
+
+        BOOST_ASSERT(std::numeric_limits<value_type>::min() <= lowest);
+        BOOST_ASSERT(highest <= std::numeric_limits<value_type>::max());
+        // create one interval that contains whole values
+        pool_.emplace(lowest_, highest_);
+    }
+
+    /**
+     * @brief Allocate one value.
+     * @return If allocator has at least one value, then returns lowest value, otherwise return nullopt.
+     */
+    optional<value_type> allocate() {
+        if (pool_.empty()) return nullopt;
+
+        // The smallest interval is the target.
+        auto it = pool_.begin();
+        value_type value = it->low();
+
+        if (it->low() + 1 <= it->high()) {
+            // If the interval contains other value, then update the interval.
+            pool_.modify(
+                it,
+                [&](auto& e) {
+                    BOOST_ASSERT(it->low() < highest_);
+                    e = value_interval{value_type(it->low() + 1) , it->high()};
+                }
+            );
+        }
+        else {
+            pool_.erase(it);
+        }
+
+        return value;
+    }
+
+    /**
+     * @brief Dellocate one value.
+     * @param value value to deallocate. The value must be gotten by allocate() or declared by use().
+     */
+    void deallocate(value_type value) {
+        BOOST_ASSERT(lowest_ <= value && value <= highest_);
+        auto itr = pool_.upper_bound(value_interval{value});
+        if (itr == pool_.end()) {
+
+            // ..... v
+
+            if (itr == pool_.begin()) {
+                // value is fully allocated
+                pool_.emplace(value);
+                return;
+            }
+
+            auto itl = itr;
+            --itl;
+            if (itl->high() + 1 == value) { // Can concat to the left interval
+                // Concat left
+                pool_.modify(
+                    itl,
+                    [&](auto& e) {
+                        e = value_interval{itl->low(), value};
+                    }
+                );
+            }
+            else {
+                // No concat
+                pool_.emplace(value);
+            }
+        }
+        else if (itr == pool_.begin()) {
+
+            // v .....
+
+            if (value + 1 == itr->low()) { // Can concat to the right interval
+                // Concat right
+                pool_.modify(
+                    itr,
+                    [&](auto& e) {
+                        e = value_interval{value, itr->high()};
+                    }
+                );
+            }
+            else {
+                // No concat
+                pool_.emplace(value);
+            }
+        }
+        else {
+
+            // .. v ..
+
+            auto itl = itr;
+            --itl;
+            if (itl->high() + 1 == value) { // Can concat to the left interval
+                if (value + 1 == itr->low()) { // Can concat to the right interval
+                    // Concat both
+                    auto right = itr->high();
+                    pool_.erase(itr);
+                    pool_.modify(
+                        itl,
+                        [&](auto& e) {
+                            e = value_interval{itl->low(), right};
+                        }
+                    );
+
+                }
+                else {
+                    // Concat left
+                    pool_.modify(
+                        itl,
+                        [&](auto& e) {
+                            e = value_interval{itl->low(), value};
+                        }
+                    );
+                }
+            }
+            else {
+                if (value + 1 == itr->low()) { // Can concat to the right interval
+                    // Concat right
+                    pool_.modify(
+                        itr,
+                        [&](auto& e) {
+                            e = value_interval{value, itr->high()};
+                        }
+                    );
+                }
+                else {
+                    // No concat
+                    pool_.emplace(value);
+                }
+            }
+        }
+    }
+
+    /**
+     * @brief Declare the value as used.
+     * @param value The value to declare using
+     * @return If value is not used or allocated then true, otherwise false
+     */
+    bool use(value_type value) {
+        auto it = pool_.find(value_interval{value});
+        if (it == pool_.end()) return false;
+
+        value_interval iv = *it;
+        pool_.erase (it);
+        if (iv.low() < value) {
+            pool_.emplace(iv.low(), value - 1);
+        }
+        if (value + 1 <= iv.high()) {
+            pool_.emplace(value + 1, iv.high());
+        }
+        return true;
+    }
+
+    /**
+     * @brief Clear all allocated or used values.
+     */
+    void clear() {
+        pool_.clear();
+        pool_.emplace(lowest_, highest_);
+    }
+
+    std::size_t interval_count() const {
+        return pool_.size();
+    }
+
+    std::ostream& dump(std::ostream& o) {
+        for (auto const& e : pool_) {
+            o << e;
+        }
+        o << std::endl;
+        return o;
+    }
+private:
+    using mi_value_interval = mi::multi_index_container<
+        value_interval,
+        mi::indexed_by<
+            mi::ordered_unique<
+                mi::identity<value_interval>
+            >
+        >
+    >;
+    mi_value_interval pool_;
+    value_type lowest_;
+    value_type highest_;
+};
+
+} // namespace MQTT_NS
+
+#endif // MQTT_VALUE_ALLOCATOR_HPP

--- a/include/mqtt/value_allocator.hpp
+++ b/include/mqtt/value_allocator.hpp
@@ -253,7 +253,6 @@ public:
         for (auto const& e : pool_) {
             o << e;
         }
-        o << std::endl;
         return o;
     }
 private:

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -21,6 +21,7 @@ IF (MQTT_TEST_1)
         ut_shared_subscriptions.cpp
         ut_subscription_map_broker.cpp
         ut_retained_topic_map_broker.cpp
+        ut_value_allocator.cpp
     )
 ENDIF ()
 

--- a/test/unit/ut_packet_id.cpp
+++ b/test/unit/ut_packet_id.cpp
@@ -53,8 +53,8 @@ BOOST_AUTO_TEST_CASE( release_but_increment ) {
     BOOST_TEST(c->acquire_unique_packet_id() == 2);
     BOOST_TEST(c->acquire_unique_packet_id() == 3);
     c->release_packet_id(2);
+    BOOST_TEST(c->acquire_unique_packet_id() == 2);
     BOOST_TEST(c->acquire_unique_packet_id() == 4);
-    BOOST_TEST(c->acquire_unique_packet_id() == 5);
 }
 
 BOOST_AUTO_TEST_CASE( rotate ) {

--- a/test/unit/ut_value_allocator.cpp
+++ b/test/unit/ut_value_allocator.cpp
@@ -1,0 +1,288 @@
+// Copyright Takatoshi Kondo 2020
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include "../common/test_main.hpp"
+#include "../common/global_fixture.hpp"
+
+#include <mqtt/value_allocator.hpp>
+
+BOOST_AUTO_TEST_SUITE(ut_value_allocator)
+
+BOOST_AUTO_TEST_CASE( one ) {
+    MQTT_NS::value_allocator<std::size_t> a{0, 0};
+    BOOST_TEST(a.interval_count() == 1);
+    {
+        auto value_opt = a.allocate();
+        BOOST_CHECK(value_opt);
+        BOOST_TEST(value_opt.value() == 0);
+        BOOST_TEST(a.interval_count() == 0);
+    }
+    {
+        auto value_opt = a.allocate();
+        BOOST_CHECK(!value_opt);
+    }
+    a.deallocate(0);
+    BOOST_TEST(a.interval_count() == 1);
+    {
+        auto value_opt = a.allocate();
+        BOOST_CHECK(value_opt);
+        BOOST_TEST(value_opt.value() == 0);
+        BOOST_TEST(a.interval_count() == 0);
+    }
+    {
+        auto value_opt = a.allocate();
+        BOOST_CHECK(!value_opt);
+    }
+    BOOST_TEST(a.use(0) == false);
+    BOOST_TEST(a.use(1) == false);
+    a.deallocate(0);
+    BOOST_TEST(a.interval_count() == 1);
+    BOOST_TEST(a.use(0) == true);
+    BOOST_TEST(a.interval_count() == 0);
+    BOOST_TEST(a.use(1) == false);
+    {
+        auto value_opt = a.allocate();
+        BOOST_CHECK(!value_opt);
+    }
+    a.deallocate(0);
+    BOOST_TEST(a.interval_count() == 1);
+    {
+        auto value_opt = a.allocate();
+        BOOST_CHECK(value_opt);
+        BOOST_TEST(value_opt.value() == 0);
+        BOOST_TEST(a.interval_count() == 0);
+    }
+}
+
+BOOST_AUTO_TEST_CASE( offset ) {
+    MQTT_NS::value_allocator<std::size_t> a{5, 5};
+    {
+        auto value_opt = a.allocate();
+        BOOST_CHECK(value_opt);
+        BOOST_TEST(value_opt.value() == 5);
+    }
+    {
+        auto value_opt = a.allocate();
+        BOOST_CHECK(!value_opt);
+    }
+    a.deallocate(5);
+    {
+        auto value_opt = a.allocate();
+        BOOST_CHECK(value_opt);
+        BOOST_TEST(value_opt.value() == 5);
+    }
+    {
+        auto value_opt = a.allocate();
+        BOOST_CHECK(!value_opt);
+    }
+    BOOST_TEST(a.use(5) == false);
+    BOOST_TEST(a.use(1) == false);
+    a.deallocate(5);
+    BOOST_TEST(a.use(5) == true);
+    BOOST_TEST(a.use(1) == false);
+    {
+        auto value_opt = a.allocate();
+        BOOST_CHECK(!value_opt);
+    }
+    a.deallocate(5);
+    {
+        auto value_opt = a.allocate();
+        BOOST_CHECK(value_opt);
+        BOOST_TEST(value_opt.value() == 5);
+    }
+}
+
+BOOST_AUTO_TEST_CASE( allocate ) {
+    MQTT_NS::value_allocator<std::size_t> a{0, 4};
+    BOOST_TEST(a.interval_count() == 1);
+    {
+        auto value_opt = a.allocate();
+        BOOST_CHECK(value_opt);
+        BOOST_TEST(value_opt.value() == 0);
+        BOOST_TEST(a.interval_count() == 1);
+    }
+    {
+        auto value_opt = a.allocate();
+        BOOST_CHECK(value_opt);
+        BOOST_TEST(value_opt.value() == 1);
+        BOOST_TEST(a.interval_count() == 1);
+    }
+    {
+        auto value_opt = a.allocate();
+        BOOST_CHECK(value_opt);
+        BOOST_TEST(value_opt.value() == 2);
+        BOOST_TEST(a.interval_count() == 1);
+    }
+    {
+        auto value_opt = a.allocate();
+        BOOST_CHECK(value_opt);
+        BOOST_TEST(value_opt.value() == 3);
+        BOOST_TEST(a.interval_count() == 1);
+    }
+    {
+        auto value_opt = a.allocate();
+        BOOST_CHECK(value_opt);
+        BOOST_TEST(value_opt.value() == 4);
+        BOOST_TEST(a.interval_count() == 0);
+    }
+    {
+        auto value_opt = a.allocate();
+        BOOST_CHECK(!value_opt);
+    }
+    a.deallocate(2);
+    BOOST_TEST(a.interval_count() == 1);
+    {
+        auto value_opt = a.allocate();
+        BOOST_CHECK(value_opt);
+        BOOST_TEST(value_opt.value() == 2);
+        BOOST_TEST(a.interval_count() == 0);
+    }
+}
+
+BOOST_AUTO_TEST_CASE( use ) {
+    MQTT_NS::value_allocator<std::size_t> a{0, 4};
+    BOOST_TEST(a.interval_count() == 1);
+    BOOST_TEST(a.use(1) == true);
+    BOOST_TEST(a.interval_count() == 2);
+    BOOST_TEST(a.use(3) == true);
+    BOOST_TEST(a.interval_count() == 3);
+    BOOST_TEST(a.use(2) == true);
+    BOOST_TEST(a.interval_count() == 2);
+    BOOST_TEST(a.use(0) == true);
+    BOOST_TEST(a.interval_count() == 1);
+    BOOST_TEST(a.use(4) == true);
+    BOOST_TEST(a.interval_count() == 0);
+    BOOST_TEST(a.use(0) == false);
+    BOOST_TEST(a.use(1) == false);
+    BOOST_TEST(a.use(2) == false);
+    BOOST_TEST(a.use(3) == false);
+    BOOST_TEST(a.use(4) == false);
+    a.deallocate(2);
+    BOOST_TEST(a.interval_count() == 1);
+    BOOST_TEST(a.use(2) == true);
+    BOOST_TEST(a.interval_count() == 0);
+}
+
+BOOST_AUTO_TEST_CASE( clear ) {
+    MQTT_NS::value_allocator<std::size_t> a{0, 4};
+    {
+        auto value_opt = a.allocate();
+        BOOST_CHECK(value_opt);
+        BOOST_TEST(value_opt.value() == 0);
+        BOOST_TEST(a.interval_count() == 1);
+    }
+    BOOST_TEST(a.use(1) == true);
+    {
+        auto value_opt = a.allocate();
+        BOOST_CHECK(value_opt);
+        BOOST_TEST(value_opt.value() == 2);
+        BOOST_TEST(a.interval_count() == 1);
+    }
+    BOOST_TEST(a.use(3) == true);
+    {
+        auto value_opt = a.allocate();
+        BOOST_CHECK(value_opt);
+        BOOST_TEST(value_opt.value() == 4);
+        BOOST_TEST(a.interval_count() == 0);
+    }
+
+    a.clear();
+    BOOST_TEST(a.interval_count() == 1);
+
+    {
+        auto value_opt = a.allocate();
+        BOOST_CHECK(value_opt);
+        BOOST_TEST(value_opt.value() == 0);
+        BOOST_TEST(a.interval_count() == 1);
+    }
+    BOOST_TEST(a.use(1) == true);
+    {
+        auto value_opt = a.allocate();
+        BOOST_CHECK(value_opt);
+        BOOST_TEST(value_opt.value() == 2);
+        BOOST_TEST(a.interval_count() == 1);
+    }
+    BOOST_TEST(a.use(3) == true);
+    {
+        auto value_opt = a.allocate();
+        BOOST_CHECK(value_opt);
+        BOOST_TEST(value_opt.value() == 4);
+        BOOST_TEST(a.interval_count() == 0);
+    }
+}
+
+BOOST_AUTO_TEST_CASE( interval_management ) {
+    MQTT_NS::value_allocator<std::size_t> a{0, 4};
+    BOOST_TEST(a.use(0) == true);
+    BOOST_TEST(a.use(1) == true);
+    BOOST_TEST(a.use(2) == true);
+    BOOST_TEST(a.use(3) == true);
+    BOOST_TEST(a.use(4) == true);
+
+    {
+        auto ca = a;
+        ca.deallocate(0);
+        BOOST_TEST(ca.interval_count() == 1);
+        ca.deallocate(4);
+        BOOST_TEST(ca.interval_count() == 2);
+        ca.deallocate(2);
+        BOOST_TEST(ca.interval_count() == 3);
+        ca.deallocate(1);
+        BOOST_TEST(ca.interval_count() == 2);
+        // concat both
+        ca.deallocate(3);
+        BOOST_TEST(ca.interval_count() == 1);
+    }
+    {
+        auto ca = a;
+        ca.deallocate(3);
+        BOOST_TEST(ca.interval_count() == 1);
+        // end concat right
+        ca.deallocate(4);
+        BOOST_TEST(ca.interval_count() == 1);
+    }
+    {
+        auto ca = a;
+        ca.deallocate(2);
+        BOOST_TEST(ca.interval_count() == 1);
+        // concat right
+        ca.deallocate(3);
+        BOOST_TEST(ca.interval_count() == 1);
+    }
+    {
+        auto ca = a;
+        ca.deallocate(1);
+        BOOST_TEST(ca.interval_count() == 1);
+        // begin concat left
+        ca.deallocate(0);
+        BOOST_TEST(ca.interval_count() == 1);
+    }
+    {
+        auto ca = a;
+        ca.deallocate(2);
+        BOOST_TEST(ca.interval_count() == 1);
+        // concat left
+        ca.deallocate(1);
+        BOOST_TEST(ca.interval_count() == 1);
+    }
+}
+
+BOOST_AUTO_TEST_CASE( signed_value ) {
+    MQTT_NS::value_allocator<int> a{-2, 3};
+    BOOST_TEST(a.interval_count() == 1);
+    BOOST_TEST(a.use(2) == true);
+    BOOST_TEST(a.interval_count() == 2);
+    {
+        auto value_opt = a.allocate();
+        BOOST_CHECK(value_opt);
+        BOOST_TEST(value_opt.value() == -2);
+        BOOST_TEST(a.interval_count() == 2);
+    }
+    BOOST_TEST(a.use(0) == true);
+    BOOST_TEST(a.interval_count() == 3);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
1. Added generic value_allocator class template. It is more efficient
that the original implementation.
2. Moved packet_id management code to the separated file
`packet_id_manager.hpp` that uses value_allocator.
3. Removed retun value of release_packet_id() to support efficient implementation.

NOTE:
The packet_id allocation algorithm has been changed.
The smallest value that is vacant is always allocated.