### PR TITLE
Fixed TopicAlias functionality.

### DIFF
--- a/include/mqtt/broker/broker.hpp
+++ b/include/mqtt/broker/broker.hpp
@@ -854,11 +854,22 @@ private:
                     );
                     break;
                 case protocol_version::v5:
-                    ep.connack(
-                        session_present,
-                        v5::connect_reason_code::success,
-                        connack_props_
-                    );
+                    if (connack_props_.empty()) {
+                        ep.connack(
+                            session_present,
+                            v5::connect_reason_code::success,
+                            v5::properties{
+                                v5::property::topic_alias_maximum{topic_alias_max}
+                            }
+                        );
+                    }
+                    else {
+                        ep.connack(
+                            session_present,
+                            v5::connect_reason_code::success,
+                            connack_props_
+                        );
+                    }
                     break;
                 default:
                     BOOST_ASSERT(false);
@@ -930,7 +941,6 @@ private:
                         it,
                         [&](auto& e) {
                             e.reset_con(spep);
-                            e.restore_topic_alias_recv();
                             e.update_will(ioc_, force_move(will), will_expiry_interval);
                             // TODO: e.will_delay = force_move(will_delay);
                             e.renew_session_expiry(force_move(session_expiry_interval));
@@ -995,7 +1005,6 @@ private:
                     it,
                     [&](auto& e) {
                         e.reset_con(spep);
-                        e.restore_topic_alias_recv();
                         e.update_will(ioc_, force_move(will), will_expiry_interval);
                         // TODO: e.will_delay = force_move(will_delay);
                         e.renew_session_expiry(force_move(session_expiry_interval));

--- a/include/mqtt/broker/inflight_message.hpp
+++ b/include/mqtt/broker/inflight_message.hpp
@@ -56,15 +56,12 @@ public:
                 make_lambda_visitor(
                     [&](v5::basic_publish_message<sizeof(packet_id_t)> const& m) {
                         auto updated_msg = m;
-                        auto& props = updated_msg.props();
-
                         auto d =
                             std::chrono::duration_cast<std::chrono::seconds>(
                                 tim_message_expiry_->expiry() - std::chrono::steady_clock::now()
                             ).count();
                         if (d < 0) d = 0;
-                        set_property<v5::property::message_expiry_interval>(
-                            props,
+                        updated_msg.update_prop(
                             v5::property::message_expiry_interval(
                                 static_cast<uint32_t>(d)
                             )

--- a/include/mqtt/broker/session_state.hpp
+++ b/include/mqtt/broker/session_state.hpp
@@ -127,11 +127,6 @@ struct session_state {
             }
         );
 
-        // TopicAlias lifetime is the same as Session lifetime
-        // It is different from MQTT v5 spec but practical choice.
-        // See
-        // https://lists.oasis-open.org/archives/mqtt-comment/202009/msg00000.html
-        topic_alias_recv_ = con_->get_topic_alias_recv_container();
         reset_con();
 
         if (session_expiry_interval_ &&
@@ -237,7 +232,6 @@ struct session_state {
     }
 
     void clean() {
-        topic_alias_recv_ = nullopt;
         inflight_messages_.clear();
         offline_messages_.clear();
         qos2_publish_processed_.clear();
@@ -412,14 +406,6 @@ struct session_state {
 
     std::shared_ptr<as::steady_timer>& get_tim_will_expiry() { return tim_will_expiry_; }
 
-    void restore_topic_alias_recv() {
-        BOOST_ASSERT(con_);
-        if (topic_alias_recv_) {
-            con_->restore_topic_alias_recv_container(force_move(topic_alias_recv_.value()));
-            topic_alias_recv_ = nullopt;
-        }
-    }
-
 private:
     friend class session_states;
 
@@ -435,7 +421,6 @@ private:
     optional<std::chrono::steady_clock::duration> will_delay_;
     optional<std::chrono::steady_clock::duration> session_expiry_interval_;
     std::shared_ptr<as::steady_timer> tim_session_expiry_;
-    optional<topic_alias_recv_map_t> topic_alias_recv_;
 
     inflight_messages inflight_messages_;
     std::set<packet_id_t> qos2_publish_processed_;

--- a/include/mqtt/broker/shared_target.hpp
+++ b/include/mqtt/broker/shared_target.hpp
@@ -19,10 +19,10 @@
 
 #include <mqtt/buffer.hpp>
 #include <mqtt/optional.hpp>
+#include <mqtt/time_point_t.hpp>
 
 #include <mqtt/broker/broker_namespace.hpp>
 #include <mqtt/broker/session_state_fwd.hpp>
-#include <mqtt/broker/time_point_t.hpp>
 #include <mqtt/broker/tags.hpp>
 
 MQTT_BROKER_NS_BEGIN

--- a/include/mqtt/property.hpp
+++ b/include/mqtt/property.hpp
@@ -84,6 +84,14 @@ struct n_bytes_property {
     }
 
     /**
+     * @brief Get property::id
+     * @return id
+     */
+    property::id id() const {
+        return id_;
+    }
+
+    /**
      * @brief Get whole size of sequence
      * @return whole size
      */
@@ -138,6 +146,14 @@ struct binary_property {
         std::copy(length_.begin(), length_.end(), b);
         std::advance(b, static_cast<dt>(length_.size()));
         std::copy(buf_.begin(), buf_.end(), b);
+    }
+
+    /**
+     * @brief Get property::id
+     * @return id
+     */
+    property::id id() const {
+        return id_;
     }
 
     /**
@@ -203,6 +219,14 @@ struct variable_property {
         BOOST_ASSERT(static_cast<std::size_t>(std::distance(b, e)) >= size());
         *b++ = static_cast<typename std::iterator_traits<It>::value_type>(id_);
         std::copy(value_.begin(), value_.end(), b);
+    }
+
+    /**
+     * @brief Get property::id
+     * @return id
+     */
+    property::id id() const {
+        return id_;
     }
 
     /**
@@ -547,6 +571,14 @@ public:
             std::copy(ptr, std::next(ptr, static_cast<dt>(size)), b);
             std::advance(b, static_cast<dt>(size));
         }
+    }
+
+    /**
+     * @brief Get property::id
+     * @return id
+     */
+    property::id id() const {
+        return id_;
     }
 
     /**

--- a/include/mqtt/property_variant.hpp
+++ b/include/mqtt/property_variant.hpp
@@ -63,6 +63,13 @@ struct add_const_buffer_sequence_visitor {
     std::vector<as::const_buffer>& v;
 };
 
+struct id_visitor {
+    template <typename T>
+    id operator()(T const& t) const {
+        return t.id();
+    }
+};
+
 struct size_visitor {
     template <typename T>
     std::size_t operator()(T&& t) const {
@@ -101,6 +108,10 @@ inline fill_visitor<Iterator> make_fill_visitor(Iterator b, Iterator e) {
 
 inline void add_const_buffer_sequence(std::vector<as::const_buffer>& v, property_variant const& pv) {
     MQTT_NS::visit(property::detail::add_const_buffer_sequence_visitor(v), pv);
+}
+
+inline property::id id(property_variant const& pv) {
+    return MQTT_NS::visit(property::detail::id_visitor(), pv);
 }
 
 inline std::size_t size(property_variant const& pv) {

--- a/include/mqtt/time_point_t.hpp
+++ b/include/mqtt/time_point_t.hpp
@@ -1,0 +1,20 @@
+// Copyright Takatoshi Kondo 2020
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(MQTT_TIME_POINT_T_HPP)
+#define MQTT_TIME_POINT_T_HPP
+
+#include <mqtt/config.hpp>
+
+#include <chrono>
+
+namespace MQTT_NS {
+
+using time_point_t = std::chrono::time_point<std::chrono::steady_clock>;
+
+} // namespace MQTT_NS
+
+#endif // MQTT_TIME_POINT_T_HPP

--- a/include/mqtt/topic_alias_send.hpp
+++ b/include/mqtt/topic_alias_send.hpp
@@ -1,0 +1,157 @@
+// Copyright Takatoshi Kondo 2020
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(MQTT_TOPIC_ALIAS_SEND_HPP)
+#define MQTT_TOPIC_ALIAS_SEND_HPP
+
+#include <string>
+#include <unordered_map>
+#include <array>
+
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/member.hpp>
+#include <boost/multi_index/mem_fun.hpp>
+
+#include <mqtt/namespace.hpp>
+#include <mqtt/string_view.hpp>
+#include <mqtt/constant.hpp>
+#include <mqtt/type.hpp>
+#include <mqtt/move.hpp>
+#include <mqtt/log.hpp>
+#include <mqtt/time_point_t.hpp>
+#include <mqtt/optional.hpp>
+#include <mqtt/value_allocator.hpp>
+
+namespace MQTT_NS {
+
+namespace mi = boost::multi_index;
+
+class topic_alias_send {
+public:
+    topic_alias_send(topic_alias_t max)
+        :max_{max}, va_{min_, max_} {}
+
+    void insert_or_update(string_view topic, topic_alias_t alias) {
+        MQTT_LOG("mqtt_impl", trace)
+            << MQTT_ADD_VALUE(address, this)
+            << "topic_alias_send insert"
+            << " topic:" << topic
+            << " alias:" << alias;
+        BOOST_ASSERT(!topic.empty() && alias >= min_ && alias <= max_);
+        va_.use(alias);
+        auto& idx = aliases_.get<tag_alias>();
+        auto it = idx.lower_bound(alias);
+        if (it == idx.end() || it->alias != alias) {
+            idx.emplace_hint(it, std::string(topic), alias, std::chrono::steady_clock::now());
+        }
+        else {
+            idx.modify(
+                it,
+                [&](entry& e) {
+                    e.topic = std::string{topic};
+                    e.tp = std::chrono::steady_clock::now();
+                },
+                [](auto&) { BOOST_ASSERT(false); }
+            );
+
+        }
+    }
+
+    std::string find(topic_alias_t alias) {
+        MQTT_LOG("mqtt_impl", trace)
+            << MQTT_ADD_VALUE(address, this)
+            << "find_topic_by_alias"
+            << " alias:" << alias;
+
+        BOOST_ASSERT(alias >= min_ && alias <= max_);
+        auto& idx = aliases_.get<tag_alias>();
+        auto it = idx.find(alias);
+        if (it == idx.end()) return std::string();
+
+        idx.modify(
+            it,
+            [&](entry& e) {
+                e.tp = std::chrono::steady_clock::now();
+            },
+            [](auto&) { BOOST_ASSERT(false); }
+        );
+        return it->topic;
+    }
+
+    optional<topic_alias_t> find(string_view topic) const {
+        MQTT_LOG("mqtt_impl", trace)
+            << MQTT_ADD_VALUE(address, this)
+            << "find_alias_by_topic"
+            << " topic:" << topic;
+
+        auto& idx = aliases_.get<tag_topic_name>();
+        auto it = idx.find(topic);
+        if (it == idx.end()) return nullopt;
+        return it->alias;
+    }
+
+    void clear() {
+        MQTT_LOG("mqtt_impl", info)
+            << MQTT_ADD_VALUE(address, this)
+            << "clear_topic_alias";
+        aliases_.clear();
+        va_.clear();
+    }
+
+    topic_alias_t get_lru_alias() const {
+        BOOST_ASSERT(max_ > 0);
+        if (auto alias_opt = va_.first_vacant()) {
+            return alias_opt.value();
+        }
+        auto& idx = aliases_.get<tag_tp>();
+        return idx.begin()->alias;
+    }
+
+private:
+    static constexpr topic_alias_t min_ = 1;
+    topic_alias_t max_;
+
+    struct entry {
+        entry(std::string topic, topic_alias_t alias, time_point_t tp)
+            : topic{force_move(topic)}, alias{alias}, tp{force_move(tp)} {}
+
+        string_view get_topic_as_view() const {
+            return topic;
+        }
+
+        std::string topic;
+        topic_alias_t alias;
+        time_point_t tp;
+    };
+    struct tag_tp {};
+    struct tag_alias {};
+    struct tag_topic_name {};
+    using mi_topic_alias = mi::multi_index_container<
+        entry,
+        mi::indexed_by<
+            mi::ordered_unique<
+                mi::tag<tag_alias>,
+                BOOST_MULTI_INDEX_MEMBER(entry, topic_alias_t, alias)
+            >,
+            mi::ordered_unique<
+                mi::tag<tag_topic_name>,
+                BOOST_MULTI_INDEX_CONST_MEM_FUN(entry, string_view, get_topic_as_view)
+            >,
+            mi::ordered_non_unique<
+                mi::tag<tag_tp>,
+                BOOST_MULTI_INDEX_MEMBER(entry, time_point_t, tp)
+            >
+        >
+    >;
+
+    mi_topic_alias aliases_;
+    value_allocator<topic_alias_t> va_;
+};
+
+} // namespace MQTT_NS
+
+#endif // MQTT_TOPIC_ALIAS_SEND_HPP

--- a/include/mqtt/value_allocator.hpp
+++ b/include/mqtt/value_allocator.hpp
@@ -120,6 +120,18 @@ public:
     }
 
     /**
+     * @brief Get the first vacant value.
+     * @return If allocator has at least one vacant value, then returns lowest value, otherwise return nullopt.
+     */
+    optional<value_type> first_vacant() const {
+        if (pool_.empty()) return nullopt;
+
+        // The smallest interval is the target.
+        auto it = pool_.begin();
+        return it->low();
+    }
+
+    /**
      * @brief Dellocate one value.
      * @param value value to deallocate. The value must be gotten by allocate() or declared by use().
      */

--- a/test/system/CMakeLists.txt
+++ b/test/system/CMakeLists.txt
@@ -15,7 +15,7 @@ IF (MQTT_TEST_2)
         st_connect.cpp
         st_underlying_timeout.cpp
         st_as_buffer_sub.cpp
-        st_topic_alias_recv.cpp
+        st_topic_alias.cpp
         st_as_buffer_pubsub.cpp
         st_shared_sub.cpp
     )

--- a/test/system/st_topic_alias.cpp
+++ b/test/system/st_topic_alias.cpp
@@ -12,7 +12,7 @@
 
 #include <mqtt/optional.hpp>
 
-BOOST_AUTO_TEST_SUITE(st_topic_alias_recv)
+BOOST_AUTO_TEST_SUITE(st_topic_alias)
 
 using namespace MQTT_NS::literals;
 
@@ -94,6 +94,156 @@ BOOST_AUTO_TEST_CASE( pubsub ) {
                         MQTT_NS::v5::properties {
                             MQTT_NS::v5::property::topic_alias(0x1U)
                         }
+                    );
+                    return true;
+                });
+            c->set_v5_unsuback_handler(
+                [&chk, &c]
+                (packet_id_t, std::vector<MQTT_NS::v5::unsuback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
+                    MQTT_CHK("h_unsuback");
+                    BOOST_TEST(reasons.size() == 1U);
+                    BOOST_TEST(reasons[0] == MQTT_NS::v5::unsuback_reason_code::success);
+                    c->disconnect();
+                    return true;
+                });
+            c->set_v5_publish_handler(
+                [&chk, &c]
+                (MQTT_NS::optional<packet_id_t> packet_id,
+                 MQTT_NS::publish_options pubopts,
+                 MQTT_NS::buffer topic,
+                 MQTT_NS::buffer contents,
+                 MQTT_NS::v5::properties /*props*/) {
+                    auto ret = chk.match(
+                        "h_suback",
+                        [&] {
+                            MQTT_CHK("h_publsh1");
+                            BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                            BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                            BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
+                            BOOST_CHECK(!packet_id);
+                            BOOST_TEST(topic == "topic1");
+                            BOOST_TEST(contents == "topic1_contents_1");
+                        },
+                        "h_publsh1",
+                        [&] {
+                            MQTT_CHK("h_publish2");
+                            BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
+                            BOOST_TEST(pubopts.get_qos() == MQTT_NS::qos::at_most_once);
+                            BOOST_TEST(pubopts.get_retain() == MQTT_NS::retain::no);
+                            BOOST_CHECK(!packet_id);
+                            BOOST_TEST(topic == "topic1");
+                            BOOST_TEST(contents == "topic1_contents_2");
+                            c->unsubscribe("topic1");
+                        }
+                    );
+                    BOOST_TEST(ret);
+                    return true;
+                });
+            break;
+        default:
+            BOOST_CHECK(false);
+            break;
+        }
+
+        c->set_close_handler(
+            [&chk, &finish]
+            () {
+                MQTT_CHK("h_close");
+                finish();
+            });
+        c->set_error_handler(
+            []
+            (MQTT_NS::error_code) {
+                BOOST_CHECK(false);
+            });
+        c->set_pub_res_sent_handler(
+            []
+            (packet_id_t) {
+                BOOST_CHECK(false);
+            });
+        c->connect();
+        ioc.run();
+        BOOST_TEST(chk.all());
+    };
+    do_combi_test_sync(test);
+}
+
+BOOST_AUTO_TEST_CASE( auto_replace ) {
+    auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+
+        if (c->get_protocol_version() != MQTT_NS::protocol_version::v5) {
+            finish();
+            return;
+        }
+
+        using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
+        c->set_client_id("cid1");
+        c->set_clean_session(true);
+        c->set_auto_replace_topic_alias_send();
+        
+        checker chk = {
+            // connect
+            cont("h_connack"),
+            // subscribe topic1 QoS0
+            cont("h_suback"),
+            // publish topic1 alias1 QoS0
+            // publish alias1 QoS0
+            cont("h_publsh1"),
+            cont("h_publish2"),
+            cont("h_unsuback"),
+            // disconnect
+            cont("h_close"),
+        };
+
+        switch (c->get_protocol_version()) {
+        case MQTT_NS::protocol_version::v5:
+            c->set_v5_connack_handler(
+                [&chk, &c]
+                (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
+                    MQTT_CHK("h_connack");
+                    BOOST_TEST(sp == false);
+                    BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
+                    c->subscribe("topic1", MQTT_NS::qos::at_most_once);
+                    return true;
+                });
+            c->set_v5_puback_handler(
+                []
+                (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
+                    BOOST_CHECK(false);
+                    return true;
+                });
+            c->set_v5_pubrec_handler(
+                []
+                (packet_id_t, MQTT_NS::v5::pubrec_reason_code, MQTT_NS::v5::properties /*props*/) {
+                    BOOST_CHECK(false);
+                    return true;
+                });
+            c->set_v5_pubcomp_handler(
+                []
+                (packet_id_t, MQTT_NS::v5::pubcomp_reason_code, MQTT_NS::v5::properties /*props*/) {
+                    BOOST_CHECK(false);
+                    return true;
+                });
+            c->set_v5_suback_handler(
+                [&chk, &c]
+                (packet_id_t, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
+                    MQTT_CHK("h_suback");
+                    BOOST_TEST(reasons.size() == 1U);
+                    BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_0);
+                    // register topic alias
+                    c->publish(
+                        "topic1",
+                        "topic1_contents_1",
+                        MQTT_NS::qos::at_most_once,
+                        MQTT_NS::v5::properties {
+                            MQTT_NS::v5::property::topic_alias(0x1U)
+                        }
+                    );
+                    // use topic alias automatically
+                    c->publish(
+                        "topic1",
+                        "topic1_contents_2",
+                        MQTT_NS::qos::at_most_once
                     );
                     return true;
                 });

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -14,6 +14,7 @@ IF (MQTT_TEST_1)
     LIST (APPEND check_PROGRAMS
         ut_utf8string_validate.cpp
         ut_packet_id.cpp
+        ut_topic_alias.cpp
         ut_message.cpp
         ut_property.cpp
         ut_subscription_map.cpp

--- a/test/unit/ut_topic_alias.cpp
+++ b/test/unit/ut_topic_alias.cpp
@@ -1,0 +1,75 @@
+// Copyright Takatoshi Kondo 2021
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include "../common/test_main.hpp"
+#include "../common/global_fixture.hpp"
+
+#include <mqtt/topic_alias_send.hpp>
+#include <mqtt/topic_alias_recv.hpp>
+
+BOOST_AUTO_TEST_SUITE(ut_topic_alias)
+
+
+BOOST_AUTO_TEST_CASE( send ) {
+    MQTT_NS::topic_alias_send tas{5};
+    tas.insert_or_update("topic1", 1);
+    tas.insert_or_update("topic3", 3);
+    BOOST_TEST(tas.find(1) == "topic1");
+    BOOST_TEST(tas.find(3) == "topic3");
+    BOOST_TEST(tas.find(2) == ""); // not registered
+    BOOST_TEST(tas.get_lru_alias() == 2); // first vacant
+    tas.insert_or_update("topic2", 2);
+    BOOST_TEST(tas.get_lru_alias() == 4); // first vacant
+    tas.insert_or_update("topic4", 4);
+    BOOST_TEST(tas.get_lru_alias() == 5); // first vacant
+    tas.insert_or_update("topic5", 5);
+
+    // map fullfilled
+
+    BOOST_TEST(tas.get_lru_alias() == 1); // least recently used
+    tas.insert_or_update("topic10", 1);   // update
+    BOOST_TEST(tas.get_lru_alias() == 3); // least recently used
+    BOOST_TEST(tas.find(1) == "topic10");
+
+    BOOST_TEST(tas.find(3) == "topic3");
+    BOOST_TEST(tas.get_lru_alias() == 2); // least recently used
+
+    // find from topic to alias
+    BOOST_TEST(tas.find("topic2").value() == 2);
+    BOOST_TEST(tas.get_lru_alias() == 2); // LRU doesn't update
+    BOOST_TEST(!tas.find("non exist"));
+
+    tas.clear();
+    BOOST_TEST(tas.get_lru_alias() == 1);
+    BOOST_TEST(tas.find(1) == "");
+    BOOST_TEST(tas.find(2) == "");
+    BOOST_TEST(tas.find(3) == "");
+    BOOST_TEST(tas.find(4) == "");
+    BOOST_TEST(tas.find(5) == "");
+    tas.insert_or_update("topic1", 1);
+    BOOST_TEST(tas.find(1) == "topic1");
+
+}
+
+BOOST_AUTO_TEST_CASE( recv ) {
+    MQTT_NS::topic_alias_send tar{5};
+    tar.insert_or_update("topic1", 1);
+    tar.insert_or_update("topic3", 3);
+    BOOST_TEST(tar.find(1) == "topic1");
+    BOOST_TEST(tar.find(3) == "topic3");
+    BOOST_TEST(tar.find(2) == ""); // not registered
+    tar.insert_or_update("topic10", 1);  // update
+    BOOST_TEST(tar.find(1) == "topic10");
+
+    tar.clear();
+
+    BOOST_TEST(tar.find(1) == ""); // not registered
+    BOOST_TEST(tar.find(3) == ""); // not registered
+    tar.insert_or_update("topic1", 1);
+    BOOST_TEST(tar.find(1) == "topic1");
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The the TopicAlias map should be cleared on disconnection.
If the inflight message has the TopicAlias property, remove it.
If the inflight message has the empty TopicName and the TopicAlias,
the original TopicName is recovered from the TopicAlias at the first
sent, and remove TopicAlias property.

It works well with mosquitto MQTT broker.
The original mqtt_cpp implementation cause protocol error because of
using cleared topic alias on resend.