### PR TITLE
Apply asio stackless coroutine.

### DIFF
--- a/include/mqtt/endpoint.hpp
+++ b/include/mqtt/endpoint.hpp
@@ -124,6 +124,11 @@ struct std::is_constructible<std::_Head_base<0, std::any, false>, std::_Head_bas
 #undef MQTT_LIBSTDCXX_GCC_910
 #undef MQTT_LIBSTDCXX_GCC_920
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#endif // defined(__GNUC__)
+
 #include <boost/asio/yield.hpp>
 
 namespace MQTT_NS {
@@ -10249,5 +10254,9 @@ private:
 } // namespace MQTT_NS
 
 #include <boost/asio/unyield.hpp>
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif // defined(__GNUC__)
 
 #endif // MQTT_ENDPOINT_HPP

--- a/include/mqtt/packet_id_type.hpp
+++ b/include/mqtt/packet_id_type.hpp
@@ -7,65 +7,18 @@
 #if !defined(MQTT_PACKET_ID_TYPE_HPP)
 #define MQTT_PACKET_ID_TYPE_HPP
 
-#include <cstdint>
-#include <cstdlib>
-
-#include <mqtt/namespace.hpp>
-#include <mqtt/two_byte_util.hpp>
-#include <mqtt/four_byte_util.hpp>
+#include <mqtt/two_or_four_byte_util.hpp>
 
 namespace MQTT_NS {
 
 template <std::size_t PacketIdBytes>
-struct packet_id_type;
-
-template <>
-struct packet_id_type<2> {
-    using type = std::uint16_t;
-};
-
-template <>
-struct packet_id_type<4> {
-    using type = std::uint32_t;
-};
+using packet_id_type = two_or_four_byte_type<PacketIdBytes>;
 
 template <std::size_t PacketIdBytes>
-struct make_packet_id;
-
-template <>
-struct make_packet_id<2> {
-    template <typename It>
-    static constexpr std::uint16_t apply(It b, It e) {
-        return make_uint16_t(b, e);
-    }
-};
-
-template <>
-struct make_packet_id<4> {
-    template <typename It>
-    static constexpr std::uint32_t apply(It b, It e) {
-        return make_uint32_t(b, e);
-    }
-};
+using make_packet_id = make_two_or_four_byte<PacketIdBytes>;
 
 template <std::size_t PacketIdBytes>
-struct add_packet_id_to_buf;
-
-template <>
-struct add_packet_id_to_buf<2> {
-    template <typename T>
-    static void apply(T& buf, std::uint16_t packet_id) {
-        add_uint16_t_to_buf(buf, packet_id);
-    }
-};
-
-template <>
-struct add_packet_id_to_buf<4> {
-    template <typename T>
-    static void apply(T& buf, std::uint32_t packet_id) {
-        add_uint32_t_to_buf(buf, packet_id);
-    }
-};
+using add_packet_id_to_buf = add_two_or_four_byte_to_buf<PacketIdBytes>;
 
 } // namespace MQTT_NS
 

--- a/include/mqtt/two_or_four_byte_util.hpp
+++ b/include/mqtt/two_or_four_byte_util.hpp
@@ -1,0 +1,72 @@
+// Copyright Takatoshi Kondo 2021
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(MQTT_TWO_OR_FOUR_BYTE_UTIL_HPP)
+#define MQTT_TWO_OR_FOUR_BYTE_UTIL_HPP
+
+#include <cstdint>
+#include <cstdlib>
+
+#include <mqtt/namespace.hpp>
+#include <mqtt/two_byte_util.hpp>
+#include <mqtt/four_byte_util.hpp>
+
+namespace MQTT_NS {
+
+template <std::size_t Bytes>
+struct two_or_four_byte_type;
+
+template <>
+struct two_or_four_byte_type<2> {
+    using type = std::uint16_t;
+};
+
+template <>
+struct two_or_four_byte_type<4> {
+    using type = std::uint32_t;
+};
+
+template <std::size_t Bytes>
+struct make_two_or_four_byte;
+
+template <>
+struct make_two_or_four_byte<2> {
+    template <typename It>
+    static constexpr std::uint16_t apply(It b, It e) {
+        return make_uint16_t(b, e);
+    }
+};
+
+template <>
+struct make_two_or_four_byte<4> {
+    template <typename It>
+    static constexpr std::uint32_t apply(It b, It e) {
+        return make_uint32_t(b, e);
+    }
+};
+
+template <std::size_t Bytes>
+struct add_two_or_four_byte_to_buf;
+
+template <>
+struct add_two_or_four_byte_to_buf<2> {
+    template <typename T>
+    static void apply(T& buf, std::uint16_t two_or_four_byte) {
+        add_uint16_t_to_buf(buf, two_or_four_byte);
+    }
+};
+
+template <>
+struct add_two_or_four_byte_to_buf<4> {
+    template <typename T>
+    static void apply(T& buf, std::uint32_t two_or_four_byte) {
+        add_uint32_t_to_buf(buf, two_or_four_byte);
+    }
+};
+
+} // namespace MQTT_NS
+
+#endif // MQTT_TWO_OR_FOUR_BYTE_UTIL_HPP


### PR DESCRIPTION
Applied boost asio's stackless coroutine to `process_mqttpacket` functions.
I expected faster compile time but no significant difference observed.

maset 0a0c6a9bd4ec0d324a0c1314e23e921f48743f17

```
        Command being timed: "make no_tls_both"
        User time (seconds): 37.66
        System time (seconds): 1.81
        Percent of CPU this job got: 99%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:39.54
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 2980752
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 1013237
        Voluntary context switches: 62
        Involuntary context switches: 676
        Swaps: 0
        File system inputs: 0
        File system outputs: 141152
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

This PR

```
        Command being timed: "make no_tls_both"
        User time (seconds): 37.52
        System time (seconds): 1.71
        Percent of CPU this job got: 99%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:39.30
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 3005936
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 1030592
        Voluntary context switches: 62
        Involuntary context switches: 670
        Swaps: 0
        File system inputs: 0
        File system outputs: 155432
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

Time and memory consumption are not changed.

Object size after stripped becomes smaller.

```
-rwxr-xr-x 1 kondo   892272  2月 23 20:28 coro*
-rwxr-xr-x 1 kondo   970096  2月 23 20:28 master*
```

I guess that it is caused by reducing template instantiation by each phase.
But it doesn't make effects to compile times.

I don't decide yet the PR should be merged.
The parsing code looks more straight forward. It is good.

I also checked run time performance by continuous publish. There are no big difference. It is expected result.
