### PR TITLE
Added topic alias maximum for receiving functionality.

### DIFF
--- a/include/mqtt/broker/broker.hpp
+++ b/include/mqtt/broker/broker.hpp
@@ -307,6 +307,7 @@ public:
 
         ep.socket().lowest_layer().set_option(as::ip::tcp::no_delay(true));
         ep.set_auto_pub_response(false);
+        ep.set_topic_alias_maximum(MQTT_NS::topic_alias_max);
         // Pass spep to keep lifetime.
         // It makes sure wp.lock() never return nullptr in the handlers below
         // including close_handler and error_handler.

--- a/include/mqtt/topic_alias_recv.hpp
+++ b/include/mqtt/topic_alias_recv.hpp
@@ -76,6 +76,8 @@ public:
         aliases_.clear();
     }
 
+    topic_alias_t max() const { return max_; }
+
 private:
     static constexpr topic_alias_t min_ = 1;
     topic_alias_t max_;

--- a/include/mqtt/topic_alias_send.hpp
+++ b/include/mqtt/topic_alias_send.hpp
@@ -111,6 +111,8 @@ public:
         return idx.begin()->alias;
     }
 
+    topic_alias_t max() const { return max_; }
+
 private:
     static constexpr topic_alias_t min_ = 1;
     topic_alias_t max_;

--- a/test/system/st_topic_alias.cpp
+++ b/test/system/st_topic_alias.cpp
@@ -161,7 +161,11 @@ BOOST_AUTO_TEST_CASE( pubsub ) {
             (packet_id_t) {
                 BOOST_CHECK(false);
             });
-        c->connect();
+        c->connect(
+            MQTT_NS::v5::properties {
+                MQTT_NS::v5::property::topic_alias_maximum(10)
+            }
+        );
         ioc.run();
         BOOST_TEST(chk.all());
     };


### PR DESCRIPTION
It used to be fixed as 0xffff.
Now, we can set it using set_topic_alias_maximum() member function.
The client also set it by connect()/async_connect() with property topic_alias_maximum.