### PR TITLE
Refine ordered call test.

### DIFF
--- a/test/system/checker.hpp
+++ b/test/system/checker.hpp
@@ -1,3 +1,9 @@
+// Copyright Takatoshi Kondo 2021
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
 #ifndef MQTT_TEST_CHECKER_HPP
 #define MQTT_TEST_CHECKER_HPP
 

--- a/test/system/ordered_caller.hpp
+++ b/test/system/ordered_caller.hpp
@@ -1,0 +1,49 @@
+// Copyright Takatoshi Kondo 2021
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef MQTT_ORDERED_CALLER_HPP
+#define MQTT_ORDERED_CALLER_HPP
+
+#include <vector>
+#include <string>
+#include <functional>
+
+struct ordered_caller {
+    template <typename... Funcs>
+    ordered_caller(std::size_t& index, Funcs&&... funcs)
+        : index_ {index}, funcs_ { std::forward<Funcs>(funcs)... } {}
+    bool operator()() {
+        if (index_ >= funcs_.size()) {
+            return false;
+        }
+        funcs_[index_++]();
+        return true;
+    }
+private:
+    std::size_t& index_;
+    std::vector<std::function<void()>> funcs_;
+};
+
+static std::map<std::string, std::size_t> ordered_caller_fileline_to_index;
+
+inline void clear_ordered() {
+    ordered_caller_fileline_to_index.clear();
+}
+
+template <typename... Funcs>
+auto make_ordered_caller(std::string file, std::size_t line, Funcs&&... funcs) {
+    return
+        ordered_caller{
+            ordered_caller_fileline_to_index[file + std::to_string(line)],
+            std::forward<Funcs>(funcs)...
+        }();
+}
+
+#define MQTT_ORDERED(...)                                       \
+    make_ordered_caller(__FILE__, __LINE__, __VA_ARGS__)
+
+
+#endif // MQTT_ORDERED_CALLER_HPP

--- a/test/system/st_as_buffer_async_pubsub_1.cpp
+++ b/test/system/st_as_buffer_async_pubsub_1.cpp
@@ -7,6 +7,7 @@
 #include "../common/test_main.hpp"
 #include "combi_test.hpp"
 #include "checker.hpp"
+#include "ordered_caller.hpp"
 #include "../common/global_fixture.hpp"
 
 #include <mqtt/optional.hpp>
@@ -18,6 +19,7 @@ BOOST_AUTO_TEST_SUITE(st_as_buffer_async_pubsub_1)
 
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -233,6 +235,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -460,6 +463,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -689,6 +693,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -903,6 +908,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -1128,6 +1134,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);

--- a/test/system/st_as_buffer_async_pubsub_2.cpp
+++ b/test/system/st_as_buffer_async_pubsub_2.cpp
@@ -7,6 +7,7 @@
 #include "../common/test_main.hpp"
 #include "combi_test.hpp"
 #include "checker.hpp"
+#include "ordered_caller.hpp"
 #include "../common/global_fixture.hpp"
 
 #include <mqtt/optional.hpp>
@@ -18,6 +19,7 @@ BOOST_AUTO_TEST_SUITE(st_as_buffer_async_pubsub_2)
 
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -237,6 +239,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -471,6 +474,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -707,6 +711,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
 
 BOOST_AUTO_TEST_CASE( publish_function ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -920,6 +925,7 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
 
 BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -1127,6 +1133,7 @@ BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
 
 BOOST_AUTO_TEST_CASE( publish_dup_function ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);

--- a/test/system/st_as_buffer_pubsub.cpp
+++ b/test/system/st_as_buffer_pubsub.cpp
@@ -7,6 +7,7 @@
 #include "../common/test_main.hpp"
 #include "combi_test.hpp"
 #include "checker.hpp"
+#include "ordered_caller.hpp"
 #include "../common/global_fixture.hpp"
 
 #include <mqtt/optional.hpp>
@@ -15,6 +16,7 @@ BOOST_AUTO_TEST_SUITE(st_as_buffer_pubsub)
 
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -195,6 +197,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -384,6 +387,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -574,6 +578,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -753,6 +758,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -947,6 +953,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -1144,6 +1151,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -1324,6 +1332,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -1518,6 +1527,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -1715,6 +1725,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
 
 BOOST_AUTO_TEST_CASE( publish_function ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -1890,6 +1901,7 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
 
 BOOST_AUTO_TEST_CASE( publish_dup_function ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);

--- a/test/system/st_as_buffer_sub.cpp
+++ b/test/system/st_as_buffer_sub.cpp
@@ -7,6 +7,7 @@
 #include "../common/test_main.hpp"
 #include "combi_test.hpp"
 #include "checker.hpp"
+#include "ordered_caller.hpp"
 #include "../common/global_fixture.hpp"
 
 #include <mqtt/optional.hpp>
@@ -17,6 +18,7 @@ using namespace std::literals::string_literals;
 
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_single ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -109,6 +111,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_single ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -213,6 +216,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -315,6 +319,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_single_async ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -420,6 +425,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_single_async ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg_async ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -540,6 +546,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_arg_async ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_string_multi_vec_async ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);

--- a/test/system/st_async_pubsub_1.cpp
+++ b/test/system/st_async_pubsub_1.cpp
@@ -7,6 +7,7 @@
 #include "../common/test_main.hpp"
 #include "combi_test.hpp"
 #include "checker.hpp"
+#include "ordered_caller.hpp"
 #include "../common/global_fixture.hpp"
 
 #include <mqtt/optional.hpp>
@@ -18,6 +19,7 @@ BOOST_AUTO_TEST_SUITE(st_async_pubsub_1)
 
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -202,6 +204,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -402,6 +405,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -595,6 +599,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -779,6 +784,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -973,6 +979,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);

--- a/test/system/st_async_pubsub_2.cpp
+++ b/test/system/st_async_pubsub_2.cpp
@@ -7,6 +7,7 @@
 #include "../common/test_main.hpp"
 #include "combi_test.hpp"
 #include "checker.hpp"
+#include "ordered_caller.hpp"
 #include "../common/global_fixture.hpp"
 
 #include <mqtt/optional.hpp>
@@ -20,6 +21,7 @@ using namespace MQTT_NS::literals;
 
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -204,6 +206,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -401,6 +404,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -600,6 +604,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2_protocol_error_resend_pubrec ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -699,13 +704,11 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2_protocol_error_resend_pubrec ) {
             c->set_pubrel_handler(
                 [&chk, &c, g]
                 (packet_id_t packet_id) mutable {
-                    auto ret = chk.match(
-                        "h_publish",
+                    auto ret = MQTT_ORDERED(
                         [&] {
                             MQTT_CHK("h_pubrel1");
                             c->async_pubcomp(packet_id);
                         },
-                        "h_pubrel1",
                         [&] () {
                             MQTT_CHK("h_pubrel2");
                             c->async_pubcomp(packet_id);
@@ -788,13 +791,11 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2_protocol_error_resend_pubrec ) {
             c->set_v5_pubrel_handler(
                 [&chk, &c, g]
                 (packet_id_t packet_id, MQTT_NS::v5::pubrel_reason_code, MQTT_NS::v5::properties /*props*/) mutable {
-                    auto ret = chk.match(
-                        "h_publish",
+                    auto ret = MQTT_ORDERED(
                         [&] {
                             MQTT_CHK("h_pubrel1");
                             c->async_pubcomp(packet_id);
                         },
-                        "h_pubrel1",
                         [&] () {
                             MQTT_CHK("h_pubrel2");
                             c->async_pubcomp(packet_id);
@@ -831,6 +832,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2_protocol_error_resend_pubrec ) {
 
 BOOST_AUTO_TEST_CASE( publish_function ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -1010,6 +1012,7 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
 
 BOOST_AUTO_TEST_CASE( publish_dup_function ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -1194,6 +1197,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
 
 BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -1378,6 +1382,7 @@ BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
 
 BOOST_AUTO_TEST_CASE( publish_function_buffer_sequence ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -1574,6 +1579,7 @@ BOOST_AUTO_TEST_CASE( publish_function_buffer_sequence ) {
 
 BOOST_AUTO_TEST_CASE( publish_function_const_buffer_sequence ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -1792,6 +1798,7 @@ BOOST_AUTO_TEST_CASE( publish_function_const_buffer_sequence ) {
 
 BOOST_AUTO_TEST_CASE( pub_sub_prop ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         if (c->get_protocol_version() != MQTT_NS::protocol_version::v5) {
             finish();
             return;
@@ -1967,6 +1974,7 @@ BOOST_AUTO_TEST_CASE( pub_sub_prop ) {
 
 BOOST_AUTO_TEST_CASE( puback_props ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& b) {
+        clear_ordered();
         if (c->get_protocol_version() != MQTT_NS::protocol_version::v5) {
             finish();
             return;
@@ -2136,6 +2144,7 @@ BOOST_AUTO_TEST_CASE( puback_props ) {
 
 BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& b) {
+        clear_ordered();
         if (c->get_protocol_version() != MQTT_NS::protocol_version::v5) {
             finish();
             return;

--- a/test/system/st_connect.cpp
+++ b/test/system/st_connect.cpp
@@ -7,6 +7,7 @@
 #include "../common/test_main.hpp"
 #include "combi_test.hpp"
 #include "checker.hpp"
+#include "ordered_caller.hpp"
 #include "../common/global_fixture.hpp"
 
 BOOST_AUTO_TEST_SUITE(st_connect)
@@ -15,6 +16,7 @@ using namespace MQTT_NS::literals;
 
 BOOST_AUTO_TEST_CASE( connect ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         c->set_client_id("cid1");
         c->set_user_name("dummy");
         c->set_password("dummy");
@@ -84,6 +86,7 @@ BOOST_AUTO_TEST_CASE( connect ) {
 
 BOOST_AUTO_TEST_CASE( connect_no_strand ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         c->set_client_id("cid1");
         c->set_clean_session(true);
 
@@ -142,6 +145,7 @@ BOOST_AUTO_TEST_CASE( connect_no_strand ) {
 
 BOOST_AUTO_TEST_CASE( keep_alive ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         c->set_client_id("cid1");
         c->set_clean_session(true);
 
@@ -207,6 +211,7 @@ BOOST_AUTO_TEST_CASE( keep_alive ) {
 
 BOOST_AUTO_TEST_CASE( keep_alive_and_send_control_packet ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         c->set_client_id("cid1");
         c->set_clean_session(true);
 
@@ -307,6 +312,7 @@ BOOST_AUTO_TEST_CASE( keep_alive_and_send_control_packet ) {
 
 BOOST_AUTO_TEST_CASE( pingresp_timeout ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& b) {
+        clear_ordered();
         b.set_pingresp(false);
         c->set_pingresp_timeout(std::chrono::seconds(2));
         c->set_client_id("cid1");
@@ -366,6 +372,7 @@ BOOST_AUTO_TEST_CASE( pingresp_timeout ) {
 
 BOOST_AUTO_TEST_CASE( connect_again ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         c->set_client_id("cid1");
         c->set_clean_session(true);
 
@@ -447,6 +454,7 @@ BOOST_AUTO_TEST_CASE( connect_again ) {
 
 BOOST_AUTO_TEST_CASE( nocid ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         c->set_clean_session(true);
 
         checker chk = {
@@ -504,6 +512,7 @@ BOOST_AUTO_TEST_CASE( nocid ) {
 
 BOOST_AUTO_TEST_CASE( nocid_noclean ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
 
         checker chk = {
             // connect
@@ -558,6 +567,7 @@ BOOST_AUTO_TEST_CASE( nocid_noclean ) {
 
 BOOST_AUTO_TEST_CASE( noclean ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         c->set_client_id("cid1");
 
         checker chk = {
@@ -701,6 +711,7 @@ BOOST_AUTO_TEST_CASE( noclean ) {
 
 BOOST_AUTO_TEST_CASE( disconnect_timeout ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& b) {
+        clear_ordered();
         c->set_client_id("cid1");
         c->set_clean_session(true);
 
@@ -761,6 +772,7 @@ BOOST_AUTO_TEST_CASE( disconnect_timeout ) {
 
 BOOST_AUTO_TEST_CASE( disconnect_not_timeout ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& b) {
+        clear_ordered();
         c->set_client_id("cid1");
         c->set_clean_session(true);
 
@@ -821,6 +833,7 @@ BOOST_AUTO_TEST_CASE( disconnect_not_timeout ) {
 
 BOOST_AUTO_TEST_CASE( async_disconnect_timeout ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& b) {
+        clear_ordered();
         c->set_client_id("cid1");
         c->set_clean_session(true);
 
@@ -892,6 +905,7 @@ BOOST_AUTO_TEST_CASE( async_disconnect_timeout ) {
 
 BOOST_AUTO_TEST_CASE( async_disconnect_not_timeout ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& b) {
+        clear_ordered();
         c->set_client_id("cid1");
         c->set_clean_session(true);
 
@@ -974,6 +988,7 @@ BOOST_AUTO_TEST_CASE( async_disconnect_not_timeout ) {
 
 BOOST_AUTO_TEST_CASE( async_keep_alive ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         c->set_client_id("cid1");
         c->set_clean_session(true);
 
@@ -1039,6 +1054,7 @@ BOOST_AUTO_TEST_CASE( async_keep_alive ) {
 
 BOOST_AUTO_TEST_CASE( async_keep_alive_and_send_control_packet ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         c->set_client_id("cid1");
         c->set_clean_session(true);
 
@@ -1139,6 +1155,7 @@ BOOST_AUTO_TEST_CASE( async_keep_alive_and_send_control_packet ) {
 
 BOOST_AUTO_TEST_CASE( async_pingresp_timeout ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& b) {
+        clear_ordered();
         b.set_pingresp(false);
         c->set_pingresp_timeout(std::chrono::seconds(2));
         c->set_client_id("cid1");
@@ -1198,6 +1215,7 @@ BOOST_AUTO_TEST_CASE( async_pingresp_timeout ) {
 
 BOOST_AUTO_TEST_CASE( connect_prop ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& b) {
+        clear_ordered();
         if (c->get_protocol_version() != MQTT_NS::protocol_version::v5) {
             finish();
             return;
@@ -1319,6 +1337,7 @@ BOOST_AUTO_TEST_CASE( connect_prop ) {
 
 BOOST_AUTO_TEST_CASE( disconnect_prop ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& b) {
+        clear_ordered();
         if (c->get_protocol_version() != MQTT_NS::protocol_version::v5) {
             finish();
             return;
@@ -1425,6 +1444,7 @@ BOOST_AUTO_TEST_CASE( disconnect_prop ) {
 
 BOOST_AUTO_TEST_CASE( connack_prop ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& b) {
+        clear_ordered();
         if (c->get_protocol_version() != MQTT_NS::protocol_version::v5) {
             finish();
             return;

--- a/test/system/st_issue_749.cpp
+++ b/test/system/st_issue_749.cpp
@@ -7,6 +7,7 @@
 #include "../common/test_main.hpp"
 #include "combi_test.hpp"
 #include "checker.hpp"
+#include "ordered_caller.hpp"
 #include "test_util.hpp"
 #include "../common/global_fixture.hpp"
 

--- a/test/system/st_length_check.cpp
+++ b/test/system/st_length_check.cpp
@@ -7,6 +7,7 @@
 #include "../common/test_main.hpp"
 #include "combi_test.hpp"
 #include "checker.hpp"
+#include "ordered_caller.hpp"
 #include "../common/global_fixture.hpp"
 
 #include <mqtt/optional.hpp>
@@ -15,6 +16,7 @@ BOOST_AUTO_TEST_SUITE(st_length_check)
 
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         if (c->get_protocol_version() != MQTT_NS::protocol_version::v3_1_1) {
             finish();
             return;
@@ -78,14 +80,12 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
             [&chk]
             (MQTT_NS::control_packet_type cpt, std::size_t /*len*/) {
                 bool rval = false;;
-                auto ret = chk.match(
-                    "h_connack",
+                auto ret = MQTT_ORDERED(
                     [&] {
                         BOOST_TEST(cpt == MQTT_NS::control_packet_type::suback);
                         MQTT_CHK("h_lc_suback");
                         rval = true;
                     },
-                    "h_suback",
                     [&] {
                         BOOST_TEST(cpt == MQTT_NS::control_packet_type::publish);
                         MQTT_CHK("h_lc_publish");

--- a/test/system/st_manual_publish.cpp
+++ b/test/system/st_manual_publish.cpp
@@ -7,6 +7,7 @@
 #include "../common/test_main.hpp"
 #include "combi_test.hpp"
 #include "checker.hpp"
+#include "ordered_caller.hpp"
 #include "../common/global_fixture.hpp"
 
 #include <mqtt/optional.hpp>
@@ -15,6 +16,7 @@ BOOST_AUTO_TEST_SUITE(st_manual_publish)
 
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);

--- a/test/system/st_maximum_packet_size.cpp
+++ b/test/system/st_maximum_packet_size.cpp
@@ -7,6 +7,7 @@
 #include "../common/test_main.hpp"
 #include "combi_test.hpp"
 #include "checker.hpp"
+#include "ordered_caller.hpp"
 #include "test_util.hpp"
 #include "../common/global_fixture.hpp"
 
@@ -18,6 +19,7 @@ using namespace MQTT_NS::literals;
 
 BOOST_AUTO_TEST_CASE( sync ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& b) {
+        clear_ordered();
 
         if (c->get_protocol_version() != MQTT_NS::protocol_version::v5) {
             finish();
@@ -114,8 +116,7 @@ BOOST_AUTO_TEST_CASE( sync ) {
              MQTT_NS::buffer topic,
              MQTT_NS::buffer contents,
              MQTT_NS::v5::properties /*props*/) {
-                auto ret = chk.match(
-                    "h_suback",
+                auto ret = MQTT_ORDERED(
                     [&] {
                         MQTT_CHK("h_publish50");
                         BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);

--- a/test/system/st_offline.cpp
+++ b/test/system/st_offline.cpp
@@ -7,6 +7,7 @@
 #include "../common/test_main.hpp"
 #include "combi_test.hpp"
 #include "checker.hpp"
+#include "ordered_caller.hpp"
 #include "../common/global_fixture.hpp"
 
 BOOST_AUTO_TEST_SUITE(st_offline)
@@ -49,6 +50,7 @@ inline void async_connect_no_clean(Client& c) {
 
 BOOST_AUTO_TEST_CASE( publish_qos1 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -76,14 +78,12 @@ BOOST_AUTO_TEST_CASE( publish_qos1 ) {
                 [&chk, &c]
                 (bool sp, MQTT_NS::connect_return_code connack_return_code) {
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
-                    auto ret = chk.match(
-                        "start",
+                    auto ret = MQTT_ORDERED(
                         [&] {
                             MQTT_CHK("h_connack1");
                             BOOST_TEST(sp == false);
                             c->disconnect();
                         },
-                        "h_close1",
                         [&] {
                             MQTT_CHK("h_connack2");
                             // Offline publish is enabled only if session is not expired in the broker
@@ -107,14 +107,12 @@ BOOST_AUTO_TEST_CASE( publish_qos1 ) {
                 [&chk, &c]
                 (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
-                    auto ret = chk.match(
-                        "start",
+                    auto ret = MQTT_ORDERED(
                         [&] {
                             MQTT_CHK("h_connack1");
                             BOOST_TEST(sp == false);
                             c->disconnect();
                         },
-                        "h_close1",
                         [&] {
                             MQTT_CHK("h_connack2");
                             // Offline publish is enabled only if session is not expired in the broker
@@ -141,15 +139,13 @@ BOOST_AUTO_TEST_CASE( publish_qos1 ) {
         c->set_close_handler(
             [&chk, &c, &pid_pub, &finish]
             () {
-                auto ret = chk.match(
-                    "h_connack1",
+                auto ret = MQTT_ORDERED(
                     [&] {
                         MQTT_CHK("h_close1");
                         // offline publish
                         pid_pub = c->publish("topic1", "topic1_contents", MQTT_NS::qos::at_least_once);
                         connect_no_clean(c);
                     },
-                    "h_puback",
                     [&] {
                         MQTT_CHK("h_close2");
                         finish();
@@ -172,6 +168,7 @@ BOOST_AUTO_TEST_CASE( publish_qos1 ) {
 
 BOOST_AUTO_TEST_CASE( publish_qos2 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -200,14 +197,12 @@ BOOST_AUTO_TEST_CASE( publish_qos2 ) {
                 [&chk, &c]
                 (bool sp, MQTT_NS::connect_return_code connack_return_code) {
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
-                    auto ret = chk.match(
-                        "start",
+                    auto ret = MQTT_ORDERED(
                         [&] {
                             MQTT_CHK("h_connack1");
                             BOOST_TEST(sp == false);
                             c->disconnect();
                         },
-                        "h_close1",
                         [&] {
                             MQTT_CHK("h_connack2");
                             // Offline publish is enabled only if session is not expired in the broker
@@ -238,14 +233,12 @@ BOOST_AUTO_TEST_CASE( publish_qos2 ) {
                 [&chk, &c]
                 (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
-                    auto ret = chk.match(
-                        "start",
+                    auto ret = MQTT_ORDERED(
                         [&] {
                             MQTT_CHK("h_connack1");
                             BOOST_TEST(sp == false);
                             c->disconnect();
                         },
-                        "h_close1",
                         [&] {
                             MQTT_CHK("h_connack2");
                             // Offline publish is enabled only if session is not expired in the broker
@@ -279,15 +272,13 @@ BOOST_AUTO_TEST_CASE( publish_qos2 ) {
         c->set_close_handler(
             [&chk, &c, &pid_pub, &finish]
             () {
-                auto ret = chk.match(
-                    "h_connack1",
+                auto ret = MQTT_ORDERED(
                     [&] {
                         MQTT_CHK("h_close1");
                         // offline publish
                         pid_pub = c->publish("topic1", "topic1_contents", MQTT_NS::qos::exactly_once);
                         connect_no_clean(c);
                     },
-                    "h_pubcomp",
                     [&] {
                         MQTT_CHK("h_close2");
                         finish();
@@ -310,6 +301,7 @@ BOOST_AUTO_TEST_CASE( publish_qos2 ) {
 
 BOOST_AUTO_TEST_CASE( multi_publish_qos1 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -340,14 +332,12 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1 ) {
                 [&chk, &c]
                 (bool sp, MQTT_NS::connect_return_code connack_return_code) {
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
-                    auto ret = chk.match(
-                        "start",
+                    auto ret = MQTT_ORDERED(
                         [&] {
                             MQTT_CHK("h_connack1");
                             BOOST_TEST(sp == false);
                             c->disconnect();
                         },
-                        "h_close1",
                         [&] {
                             MQTT_CHK("h_connack2");
                             // Offline publish is enabled only if session is not expired in the broker
@@ -360,13 +350,11 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1 ) {
             c->set_puback_handler(
                 [&chk, &c, &pid_pub1, &pid_pub2]
                 (packet_id_t packet_id) {
-                    auto ret = chk.match(
-                        "h_connack2",
+                    auto ret = MQTT_ORDERED(
                         [&] {
                             MQTT_CHK("h_puback1");
                             BOOST_TEST(packet_id == pid_pub1);
                         },
-                        "h_puback1",
                         [&] {
                             MQTT_CHK("h_puback2");
                             BOOST_TEST(packet_id == pid_pub2);
@@ -382,14 +370,12 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1 ) {
                 [&chk, &c]
                 (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
-                    auto ret = chk.match(
-                        "start",
+                    auto ret = MQTT_ORDERED(
                         [&] {
                             MQTT_CHK("h_connack1");
                             BOOST_TEST(sp == false);
                             c->disconnect();
                         },
-                        "h_close1",
                         [&] {
                             MQTT_CHK("h_connack2");
                             // Offline publish is enabled only if session is not expired in the broker
@@ -402,13 +388,11 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1 ) {
             c->set_v5_puback_handler(
                 [&chk, &c, &pid_pub1, &pid_pub2]
                 (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code /*reason*/, MQTT_NS::v5::properties /*props*/) {
-                    auto ret = chk.match(
-                        "h_connack2",
+                    auto ret = MQTT_ORDERED(
                         [&] {
                             MQTT_CHK("h_puback1");
                             BOOST_TEST(packet_id == pid_pub1);
                         },
-                        "h_puback1",
                         [&] {
                             MQTT_CHK("h_puback2");
                             BOOST_TEST(packet_id == pid_pub2);
@@ -427,8 +411,7 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1 ) {
         c->set_close_handler(
             [&chk, &c, &pid_pub1, &pid_pub2, &finish]
             () {
-                auto ret = chk.match(
-                    "h_connack1",
+                auto ret = MQTT_ORDERED(
                     [&] {
                         MQTT_CHK("h_close1");
                         // offline publish
@@ -436,7 +419,6 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1 ) {
                         pid_pub2 = c->publish(/*topic_base()*/ + "987/topic1", "topic1_contents2", MQTT_NS::qos::at_least_once);
                         connect_no_clean(c);
                     },
-                    "h_puback2",
                     [&] {
                         MQTT_CHK("h_close2");
                         finish();
@@ -459,6 +441,7 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1 ) {
 
 BOOST_AUTO_TEST_CASE( async_publish_qos1 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -487,14 +470,12 @@ BOOST_AUTO_TEST_CASE( async_publish_qos1 ) {
                 [&chk, &c]
                 (bool sp, MQTT_NS::connect_return_code connack_return_code) {
                     BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
-                    auto ret = chk.match(
-                        "start",
+                    auto ret = MQTT_ORDERED(
                         [&] {
                             MQTT_CHK("h_connack1");
                             BOOST_TEST(sp == false);
                             c->async_disconnect();
                         },
-                        "h_pub_finish",
                         [&] {
                             MQTT_CHK("h_connack2");
                             // Offline publish is enabled only if session is not expired in the broker
@@ -518,14 +499,12 @@ BOOST_AUTO_TEST_CASE( async_publish_qos1 ) {
                 [&chk, &c]
                 (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
                     BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
-                    auto ret = chk.match(
-                        "start",
+                    auto ret = MQTT_ORDERED(
                         [&] {
                             MQTT_CHK("h_connack1");
                             BOOST_TEST(sp == false);
                             c->async_disconnect();
                         },
-                        "h_pub_finish",
                         [&] {
                             MQTT_CHK("h_connack2");
                             // Offline publish is enabled only if session is not expired in the broker
@@ -552,8 +531,7 @@ BOOST_AUTO_TEST_CASE( async_publish_qos1 ) {
         c->set_close_handler(
             [&chk, &c, &pid_pub, &finish]
             () {
-                auto ret = chk.match(
-                    "h_connack1",
+                auto ret = MQTT_ORDERED(
                     [&] {
                         MQTT_CHK("h_close1");
                         // offline publish
@@ -570,7 +548,6 @@ BOOST_AUTO_TEST_CASE( async_publish_qos1 ) {
                         );
                         async_connect_no_clean(c);
                     },
-                    "h_puback",
                     [&] {
                         MQTT_CHK("h_close2");
                         finish();

--- a/test/system/st_pubsub_1.cpp
+++ b/test/system/st_pubsub_1.cpp
@@ -7,6 +7,7 @@
 #include "../common/test_main.hpp"
 #include "combi_test.hpp"
 #include "checker.hpp"
+#include "ordered_caller.hpp"
 #include "../common/global_fixture.hpp"
 
 #include <mqtt/optional.hpp>
@@ -17,6 +18,7 @@ using namespace MQTT_NS::literals;
 
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -196,6 +198,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos0 ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -393,6 +396,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos0 ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -583,6 +587,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos0 ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -762,6 +767,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos1 ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -955,6 +961,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos1 ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -1152,6 +1159,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos1 ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -1333,6 +1341,7 @@ BOOST_AUTO_TEST_CASE( pub_qos0_sub_qos2 ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -1527,6 +1536,7 @@ BOOST_AUTO_TEST_CASE( pub_qos1_sub_qos2 ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -1724,6 +1734,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2 ) {
 
 BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2_protocol_error_resend_pubrec ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -1820,13 +1831,11 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2_protocol_error_resend_pubrec ) {
             c->set_pubrel_handler(
                 [&chk, &c, g]
                 (packet_id_t packet_id) mutable {
-                    auto ret = chk.match(
-                        "h_publish",
+                    auto ret = MQTT_ORDERED(
                         [&] {
                             MQTT_CHK("h_pubrel1");
                             c->pubcomp(packet_id);
                         },
-                        "h_pubrel1",
                         [&] () {
                             MQTT_CHK("h_pubrel2");
                             c->pubcomp(packet_id);
@@ -1907,13 +1916,11 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2_protocol_error_resend_pubrec ) {
             c->set_v5_pubrel_handler(
                 [&chk, &c, g]
                 (packet_id_t packet_id, MQTT_NS::v5::pubrel_reason_code, MQTT_NS::v5::properties /*props*/) mutable {
-                    auto ret = chk.match(
-                        "h_publish",
+                    auto ret = MQTT_ORDERED(
                         [&] {
                             MQTT_CHK("h_pubrel1");
                             c->pubcomp(packet_id);
                         },
-                        "h_pubrel1",
                         [&] () {
                             MQTT_CHK("h_pubrel2");
                             c->pubcomp(packet_id);
@@ -1951,6 +1958,7 @@ BOOST_AUTO_TEST_CASE( pub_qos2_sub_qos2_protocol_error_resend_pubrec ) {
 
 BOOST_AUTO_TEST_CASE( publish_function ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -2126,6 +2134,7 @@ BOOST_AUTO_TEST_CASE( publish_function ) {
 
 BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -2301,6 +2310,7 @@ BOOST_AUTO_TEST_CASE( publish_function_buffer ) {
 
 BOOST_AUTO_TEST_CASE( publish_function_buffer_sequence ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -2488,6 +2498,7 @@ BOOST_AUTO_TEST_CASE( publish_function_buffer_sequence ) {
 
 BOOST_AUTO_TEST_CASE( publish_function_const_buffer_sequence ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -2695,6 +2706,7 @@ BOOST_AUTO_TEST_CASE( publish_function_const_buffer_sequence ) {
 
 BOOST_AUTO_TEST_CASE( publish_dup_function ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -2875,6 +2887,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function ) {
 
 BOOST_AUTO_TEST_CASE( publish_dup_function_buffer ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -3055,6 +3068,7 @@ BOOST_AUTO_TEST_CASE( publish_dup_function_buffer ) {
 
 BOOST_AUTO_TEST_CASE( pub_sub_prop ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         if (c->get_protocol_version() != MQTT_NS::protocol_version::v5) {
             finish();
             return;
@@ -3231,6 +3245,7 @@ BOOST_AUTO_TEST_CASE( pub_sub_prop ) {
 
 BOOST_AUTO_TEST_CASE( puback_prop ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& b) {
+        clear_ordered();
         if (c->get_protocol_version() != MQTT_NS::protocol_version::v5) {
             finish();
             return;
@@ -3396,6 +3411,7 @@ BOOST_AUTO_TEST_CASE( puback_prop ) {
 
 BOOST_AUTO_TEST_CASE( pubrec_rel_comp_prop ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& b) {
+        clear_ordered();
         if (c->get_protocol_version() != MQTT_NS::protocol_version::v5) {
             finish();
             return;

--- a/test/system/st_pubsub_no_strand.cpp
+++ b/test/system/st_pubsub_no_strand.cpp
@@ -10,6 +10,7 @@
 #include "test_settings.hpp"
 #include "test_server_no_tls.hpp"
 #include "checker.hpp"
+#include "ordered_caller.hpp"
 #include "../common/global_fixture.hpp"
 
 #include <mqtt/client.hpp>

--- a/test/system/st_remaining_length.cpp
+++ b/test/system/st_remaining_length.cpp
@@ -7,6 +7,7 @@
 #include "../common/test_main.hpp"
 #include "combi_test.hpp"
 #include "checker.hpp"
+#include "ordered_caller.hpp"
 #include "../common/global_fixture.hpp"
 
 #include <mqtt/optional.hpp>
@@ -15,6 +16,7 @@ BOOST_AUTO_TEST_SUITE(st_remaining_length)
 
 BOOST_AUTO_TEST_CASE( pub_sub_over_127 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         if (c->get_protocol_version() != MQTT_NS::protocol_version::v3_1_1) {
             finish();
             return;
@@ -126,6 +128,7 @@ BOOST_AUTO_TEST_CASE( pub_sub_over_127 ) {
 
 BOOST_AUTO_TEST_CASE( pub_sub_over_16384 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         if (c->get_protocol_version() != MQTT_NS::protocol_version::v3_1_1) {
             finish();
             return;
@@ -239,6 +242,7 @@ BOOST_AUTO_TEST_CASE( pub_sub_over_16384 ) {
 
 BOOST_AUTO_TEST_CASE( pub_sub_over_2097152 ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         if (c->get_protocol_version() != MQTT_NS::protocol_version::v3_1_1) {
             finish();
             return;

--- a/test/system/st_resend_new_client.cpp
+++ b/test/system/st_resend_new_client.cpp
@@ -7,6 +7,7 @@
 #include "../common/test_main.hpp"
 #include "combi_test.hpp"
 #include "checker.hpp"
+#include "ordered_caller.hpp"
 #include "test_util.hpp"
 #include "../common/global_fixture.hpp"
 
@@ -75,14 +76,12 @@ BOOST_AUTO_TEST_CASE( publish_qos1 ) {
         [&chk, &c1, &pid_pub]
         (bool sp, MQTT_NS::connect_return_code connack_return_code) {
             BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
-            auto ret = chk.match(
-                "start",
+            auto ret = MQTT_ORDERED(
                 [&] {
                     MQTT_CHK("h_connack1");
                     BOOST_TEST(sp == false);
                     c1->disconnect();
                 },
-                "h_close1",
                 [&] {
                     MQTT_CHK("h_connack2");
                     BOOST_TEST(sp == false);
@@ -216,14 +215,12 @@ BOOST_AUTO_TEST_CASE( publish_qos2 ) {
         [&chk, &c1, &pid_pub]
         (bool sp, MQTT_NS::connect_return_code connack_return_code) {
             BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
-            auto ret = chk.match(
-                "start",
+            auto ret = MQTT_ORDERED(
                 [&] {
                     MQTT_CHK("h_connack1");
                     BOOST_TEST(sp == false);
                     c1->disconnect();
                 },
-                "h_close1",
                 [&] {
                     MQTT_CHK("h_connack2");
                     BOOST_TEST(sp == false);
@@ -363,14 +360,12 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2 ) {
         [&chk, &c1, &pid_pub]
         (bool sp, MQTT_NS::connect_return_code connack_return_code) {
             BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
-            auto ret = chk.match(
-                "start",
+            auto ret = MQTT_ORDERED(
                 [&] {
                     MQTT_CHK("h_connack1");
                     BOOST_TEST(sp == false);
                     c1->disconnect();
                 },
-                "h_close1",
                 [&] {
                     MQTT_CHK("h_connack2");
                     BOOST_TEST(sp == false);
@@ -512,14 +507,12 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1 ) {
         [&chk, &c1, &pid_pub1, &pid_pub2]
         (bool sp, MQTT_NS::connect_return_code connack_return_code) {
             BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
-            auto ret = chk.match(
-                "start",
+            auto ret = MQTT_ORDERED(
                 [&] {
                     MQTT_CHK("h_connack1");
                     BOOST_TEST(sp == false);
                     c1->disconnect();
                 },
-                "h_close1",
                 [&] {
                     MQTT_CHK("h_connack2");
                     BOOST_TEST(sp == false);
@@ -580,13 +573,11 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1 ) {
     c2->set_puback_handler(
         [&chk, &c2, &pid_pub1, &pid_pub2]
         (MQTT_NS::broker::packet_id_t packet_id) {
-            auto ret = chk.match(
-                "start",
+            auto ret = MQTT_ORDERED(
                 [&] {
                     MQTT_CHK("h_puback1");
                     BOOST_TEST(packet_id == pid_pub1);
                 },
-                "h_puback1",
                 [&] {
                     MQTT_CHK("h_puback2");
                     BOOST_TEST(packet_id == pid_pub2);
@@ -729,14 +720,12 @@ BOOST_AUTO_TEST_CASE( publish_qos1_v5 ) {
         [&chk, &c1, &pid_pub, ps = std::move(ps)]
         (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
             BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
-            auto ret = chk.match(
-                "start",
+            auto ret = MQTT_ORDERED(
                 [&] {
                     MQTT_CHK("h_connack1");
                     BOOST_TEST(sp == false);
                     c1->disconnect();
                 },
-                "h_close1",
                 [&, ps = std::move(ps)] {
                     MQTT_CHK("h_connack2");
                     // The previous connection is not set Session Expiry Interval.
@@ -872,14 +861,12 @@ BOOST_AUTO_TEST_CASE( publish_qos2_v5 ) {
         [&chk, &c1, &pid_pub]
         (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
             BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
-            auto ret = chk.match(
-                "start",
+            auto ret = MQTT_ORDERED(
                 [&] {
                     MQTT_CHK("h_connack1");
                     BOOST_TEST(sp == false);
                     c1->disconnect();
                 },
-                "h_close1",
                 [&] {
                     MQTT_CHK("h_connack2");
                     // The previous connection is not set Session Expiry Interval.
@@ -1071,14 +1058,12 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2_v5 ) {
         [&chk, &c1, &pid_pub]
         (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
             BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
-            auto ret = chk.match(
-                "start",
+            auto ret = MQTT_ORDERED(
                 [&] {
                     MQTT_CHK("h_connack1");
                     BOOST_TEST(sp == false);
                     c1->disconnect();
                 },
-                "h_close1",
                 [&] {
                     MQTT_CHK("h_connack2");
                     // The previous connection is not set Session Expiry Interval.
@@ -1223,14 +1208,12 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1_v5 ) {
         [&chk, &c1, &pid_pub1, &pid_pub2]
         (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
             BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
-            auto ret = chk.match(
-                "start",
+            auto ret = MQTT_ORDERED(
                 [&] {
                     MQTT_CHK("h_connack1");
                     BOOST_TEST(sp == false);
                     c1->disconnect();
                 },
-                "h_close1",
                 [&] {
                     MQTT_CHK("h_connack2");
                     // The previous connection is not set Session Expiry Interval.
@@ -1293,13 +1276,11 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1_v5 ) {
     c2->set_v5_puback_handler(
         [&chk, &c2, &pid_pub1, &pid_pub2]
         (MQTT_NS::broker::packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
-            auto ret = chk.match(
-                "start",
+            auto ret = MQTT_ORDERED(
                 [&] {
                     MQTT_CHK("h_puback1");
                     BOOST_TEST(packet_id == pid_pub1);
                 },
-                "h_puback1",
                 [&] {
                     MQTT_CHK("h_puback2");
                     BOOST_TEST(packet_id == pid_pub2);

--- a/test/system/st_resend_serialize.cpp
+++ b/test/system/st_resend_serialize.cpp
@@ -7,6 +7,7 @@
 #include "../common/test_main.hpp"
 #include "combi_test.hpp"
 #include "checker.hpp"
+#include "ordered_caller.hpp"
 #include "test_util.hpp"
 #include "../common/global_fixture.hpp"
 
@@ -167,14 +168,12 @@ BOOST_AUTO_TEST_CASE( publish_qos1 ) {
         [&chk, &c1, &pid_pub]
         (bool sp, MQTT_NS::connect_return_code connack_return_code) {
             BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
-            auto ret = chk.match(
-                "start",
+            auto ret = MQTT_ORDERED(
                 [&] {
                     MQTT_CHK("h_connack1");
                     BOOST_TEST(sp == false);
                     c1->disconnect();
                 },
-                "h_close1",
                 [&] {
                     MQTT_CHK("h_connack2");
                     BOOST_TEST(sp == false);
@@ -326,14 +325,12 @@ BOOST_AUTO_TEST_CASE( publish_qos2 ) {
         [&chk, &c1, &pid_pub]
         (bool sp, MQTT_NS::connect_return_code connack_return_code) {
             BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
-            auto ret = chk.match(
-                "start",
+            auto ret = MQTT_ORDERED(
                 [&] {
                     MQTT_CHK("h_connack1");
                     BOOST_TEST(sp == false);
                     c1->disconnect();
                 },
-                "h_close1",
                 [&] {
                     MQTT_CHK("h_connack2");
                     BOOST_TEST(sp == false);
@@ -491,14 +488,12 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2 ) {
         [&chk, &c1, &pid_pub]
         (bool sp, MQTT_NS::connect_return_code connack_return_code) {
             BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
-            auto ret = chk.match(
-                "start",
+            auto ret = MQTT_ORDERED(
                 [&] {
                     MQTT_CHK("h_connack1");
                     BOOST_TEST(sp == false);
                     c1->disconnect();
                 },
-                "h_close1",
                 [&] {
                     MQTT_CHK("h_connack2");
                     BOOST_TEST(sp == false);
@@ -658,14 +653,12 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1 ) {
         [&chk, &c1, &pid_pub1, &pid_pub2]
         (bool sp, MQTT_NS::connect_return_code connack_return_code) {
             BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
-            auto ret = chk.match(
-                "start",
+            auto ret = MQTT_ORDERED(
                 [&] {
                     MQTT_CHK("h_connack1");
                     BOOST_TEST(sp == false);
                     c1->disconnect();
                 },
-                "h_close1",
                 [&] {
                     MQTT_CHK("h_connack2");
                     BOOST_TEST(sp == false);
@@ -730,13 +723,11 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1 ) {
     c2->set_puback_handler(
         [&chk, &c2, &pid_pub1, &pid_pub2]
         (packet_id_t packet_id) {
-            auto ret = chk.match(
-                "start",
+            auto ret = MQTT_ORDERED(
                 [&] {
                     MQTT_CHK("h_puback1");
                     BOOST_TEST(packet_id == pid_pub1);
                 },
-                "h_puback1",
                 [&] {
                     MQTT_CHK("h_puback2");
                     BOOST_TEST(packet_id == pid_pub2);
@@ -973,14 +964,12 @@ BOOST_AUTO_TEST_CASE( publish_qos1_v5 ) {
         [&chk, &c1, &pid_pub, ps = std::move(ps)]
         (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
             BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
-            auto ret = chk.match(
-                "start",
+            auto ret = MQTT_ORDERED(
                 [&] {
                     MQTT_CHK("h_connack1");
                     BOOST_TEST(sp == false);
                     c1->disconnect();
                 },
-                "h_close1",
                 [&, ps = std::move(ps)] {
                     MQTT_CHK("h_connack2");
                     // The previous connection is not set Session Expiry Interval.
@@ -1134,14 +1123,12 @@ BOOST_AUTO_TEST_CASE( publish_qos2_v5 ) {
         [&chk, &c1, &pid_pub]
         (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
             BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
-            auto ret = chk.match(
-                "start",
+            auto ret = MQTT_ORDERED(
                 [&] {
                     MQTT_CHK("h_connack1");
                     BOOST_TEST(sp == false);
                     c1->disconnect();
                 },
-                "h_close1",
                 [&] {
                     MQTT_CHK("h_connack2");
                     // The previous connection is not set Session Expiry Interval.
@@ -1351,14 +1338,12 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2_v5 ) {
         [&chk, &c1, &pid_pub]
         (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
             BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
-            auto ret = chk.match(
-                "start",
+            auto ret = MQTT_ORDERED(
                 [&] {
                     MQTT_CHK("h_connack1");
                     BOOST_TEST(sp == false);
                     c1->disconnect();
                 },
-                "h_close1",
                 [&] {
                     MQTT_CHK("h_connack2");
                     // The previous connection is not set Session Expiry Interval.
@@ -1521,14 +1506,12 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1_v5 ) {
         [&chk, &c1, &pid_pub1, &pid_pub2]
         (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
             BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
-            auto ret = chk.match(
-                "start",
+            auto ret = MQTT_ORDERED(
                 [&] {
                     MQTT_CHK("h_connack1");
                     BOOST_TEST(sp == false);
                     c1->disconnect();
                 },
-                "h_close1",
                 [&] {
                     MQTT_CHK("h_connack2");
                     // The previous connection is not set Session Expiry Interval.
@@ -1595,13 +1578,11 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1_v5 ) {
     c2->set_v5_puback_handler(
         [&chk, &c2, &pid_pub1, &pid_pub2]
         (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
-            auto ret = chk.match(
-                "start",
+            auto ret = MQTT_ORDERED(
                 [&] {
                     MQTT_CHK("h_puback1");
                     BOOST_TEST(packet_id == pid_pub1);
                 },
-                "h_puback1",
                 [&] {
                     MQTT_CHK("h_puback2");
                     BOOST_TEST(packet_id == pid_pub2);

--- a/test/system/st_resend_serialize_ptr_size.cpp
+++ b/test/system/st_resend_serialize_ptr_size.cpp
@@ -7,6 +7,7 @@
 #include "../common/test_main.hpp"
 #include "combi_test.hpp"
 #include "checker.hpp"
+#include "ordered_caller.hpp"
 #include "test_util.hpp"
 #include "../common/global_fixture.hpp"
 
@@ -105,14 +106,12 @@ BOOST_AUTO_TEST_CASE( publish_qos1 ) {
         [&chk, &c1, &pid_pub]
         (bool sp, MQTT_NS::connect_return_code connack_return_code) {
             BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
-            auto ret = chk.match(
-                "start",
+            auto ret = MQTT_ORDERED(
                 [&] {
                     MQTT_CHK("h_connack1");
                     BOOST_TEST(sp == false);
                     c1->disconnect();
                 },
-                "h_close1",
                 [&] {
                     MQTT_CHK("h_connack2");
                     BOOST_TEST(sp == false);
@@ -250,14 +249,12 @@ BOOST_AUTO_TEST_CASE( publish_qos2 ) {
         [&chk, &c1, &pid_pub]
         (bool sp, MQTT_NS::connect_return_code connack_return_code) {
             BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
-            auto ret = chk.match(
-                "start",
+            auto ret = MQTT_ORDERED(
                 [&] {
                     MQTT_CHK("h_connack1");
                     BOOST_TEST(sp == false);
                     c1->disconnect();
                 },
-                "h_close1",
                 [&] {
                     MQTT_CHK("h_connack2");
                     BOOST_TEST(sp == false);
@@ -401,14 +398,12 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2 ) {
         [&chk, &c1, &pid_pub]
         (bool sp, MQTT_NS::connect_return_code connack_return_code) {
             BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
-            auto ret = chk.match(
-                "start",
+            auto ret = MQTT_ORDERED(
                 [&] {
                     MQTT_CHK("h_connack1");
                     BOOST_TEST(sp == false);
                     c1->disconnect();
                 },
-                "h_close1",
                 [&] {
                     MQTT_CHK("h_connack2");
                     BOOST_TEST(sp == false);
@@ -554,14 +549,12 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1 ) {
         [&chk, &c1, &pid_pub1, &pid_pub2]
         (bool sp, MQTT_NS::connect_return_code connack_return_code) {
             BOOST_TEST(connack_return_code == MQTT_NS::connect_return_code::accepted);
-            auto ret = chk.match(
-                "start",
+            auto ret = MQTT_ORDERED(
                 [&] {
                     MQTT_CHK("h_connack1");
                     BOOST_TEST(sp == false);
                     c1->disconnect();
                 },
-                "h_close1",
                 [&] {
                     MQTT_CHK("h_connack2");
                     BOOST_TEST(sp == false);
@@ -618,13 +611,11 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1 ) {
     c2->set_puback_handler(
         [&chk, &c2, &pid_pub1, &pid_pub2]
         (packet_id_t packet_id) {
-            auto ret = chk.match(
-                "h_connack3",
+            auto ret = MQTT_ORDERED(
                 [&] {
                     MQTT_CHK("h_puback1");
                     BOOST_TEST(packet_id == pid_pub1);
                 },
-                "h_puback1",
                 [&] {
                     MQTT_CHK("h_puback2");
                     BOOST_TEST(packet_id == pid_pub2);
@@ -799,14 +790,12 @@ BOOST_AUTO_TEST_CASE( publish_qos1_v5 ) {
         [&chk, &c1, &pid_pub, ps = std::move(ps)]
         (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
             BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
-            auto ret = chk.match(
-                "start",
+            auto ret = MQTT_ORDERED(
                 [&] {
                     MQTT_CHK("h_connack1");
                     BOOST_TEST(sp == false);
                     c1->disconnect();
                 },
-                "h_close1",
                 [&] {
                     MQTT_CHK("h_connack2");
                     // The previous connection is not set Session Expiry Interval.
@@ -946,14 +935,12 @@ BOOST_AUTO_TEST_CASE( publish_qos2_v5 ) {
         [&chk, &c1, &pid_pub]
         (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
             BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
-            auto ret = chk.match(
-                "start",
+            auto ret = MQTT_ORDERED(
                 [&] {
                     MQTT_CHK("h_connack1");
                     BOOST_TEST(sp == false);
                     c1->disconnect();
                 },
-                "h_close1",
                 [&] {
                     MQTT_CHK("h_connack2");
                     // The previous connection is not set Session Expiry Interval.
@@ -1149,14 +1136,12 @@ BOOST_AUTO_TEST_CASE( pubrel_qos2_v5 ) {
         [&chk, &c1, &pid_pub]
         (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
             BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
-            auto ret = chk.match(
-                "start",
+            auto ret = MQTT_ORDERED(
                 [&] {
                     MQTT_CHK("h_connack1");
                     BOOST_TEST(sp == false);
                     c1->disconnect();
                 },
-                "h_close1",
                 [&] {
                     MQTT_CHK("h_connack2");
                     // The previous connection is not set Session Expiry Interval.
@@ -1305,14 +1290,12 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1_v5 ) {
         [&chk, &c1, &pid_pub1, &pid_pub2]
         (bool sp, MQTT_NS::v5::connect_reason_code connack_return_code, MQTT_NS::v5::properties /*props*/) {
             BOOST_TEST(connack_return_code == MQTT_NS::v5::connect_reason_code::success);
-            auto ret = chk.match(
-                "start",
+            auto ret = MQTT_ORDERED(
                 [&] {
                     MQTT_CHK("h_connack1");
                     BOOST_TEST(sp == false);
                     c1->disconnect();
                 },
-                "h_close1",
                 [&] {
                     MQTT_CHK("h_connack2");
                     // The previous connection is not set Session Expiry Interval.
@@ -1371,13 +1354,11 @@ BOOST_AUTO_TEST_CASE( multi_publish_qos1_v5 ) {
     c2->set_v5_puback_handler(
         [&chk, &c2, &pid_pub1, &pid_pub2]
         (packet_id_t packet_id, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
-            auto ret = chk.match(
-                "h_connack3",
+            auto ret = MQTT_ORDERED(
                 [&] {
                     MQTT_CHK("h_puback1");
                     BOOST_TEST(packet_id == pid_pub1);
                 },
-                "h_puback1",
                 [&] {
                     MQTT_CHK("h_puback2");
                     BOOST_TEST(packet_id == pid_pub2);

--- a/test/system/st_retain_1.cpp
+++ b/test/system/st_retain_1.cpp
@@ -7,6 +7,7 @@
 #include "../common/test_main.hpp"
 #include "combi_test.hpp"
 #include "checker.hpp"
+#include "ordered_caller.hpp"
 #include "../common/global_fixture.hpp"
 
 #include <mqtt/optional.hpp>
@@ -17,6 +18,7 @@ using namespace MQTT_NS::literals;
 
 BOOST_AUTO_TEST_CASE( simple ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -196,6 +198,7 @@ BOOST_AUTO_TEST_CASE( simple ) {
 
 BOOST_AUTO_TEST_CASE( overwrite ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);

--- a/test/system/st_shared_sub.cpp
+++ b/test/system/st_shared_sub.cpp
@@ -7,6 +7,7 @@
 #include "../common/test_main.hpp"
 #include "combi_test.hpp"
 #include "checker.hpp"
+#include "ordered_caller.hpp"
 #include "../common/global_fixture.hpp"
 
 using namespace MQTT_NS::literals;
@@ -198,8 +199,7 @@ BOOST_AUTO_TEST_CASE( qos0 ) {
          MQTT_NS::buffer topic,
          MQTT_NS::buffer contents,
          MQTT_NS::v5::properties /*props*/) mutable {
-            auto ret = chk.match(
-                "h_suback_s1",
+            auto ret = MQTT_ORDERED(
                 [&] {
                     MQTT_CHK("h_publish_s1_1");
                     BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
@@ -209,7 +209,6 @@ BOOST_AUTO_TEST_CASE( qos0 ) {
                     BOOST_TEST(topic == "t1");
                     BOOST_TEST(contents == "contents1");
                 },
-                "h_publish_s1_1",
                 [&]{
                     MQTT_CHK("h_publish_s1_2");
                     BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
@@ -219,7 +218,6 @@ BOOST_AUTO_TEST_CASE( qos0 ) {
                     BOOST_TEST(topic == "t2");
                     BOOST_TEST(contents == "contents4");
                 },
-                "h_publish_s1_2",
                 [&]{
                     MQTT_CHK("h_publish_s1_3");
                     BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
@@ -243,8 +241,7 @@ BOOST_AUTO_TEST_CASE( qos0 ) {
          MQTT_NS::buffer topic,
          MQTT_NS::buffer contents,
          MQTT_NS::v5::properties /*props*/) mutable {
-            auto ret = chk.match(
-                "h_suback_s2",
+            auto ret = MQTT_ORDERED(
                 [&] {
                     MQTT_CHK("h_publish_s2_1");
                     BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
@@ -254,7 +251,6 @@ BOOST_AUTO_TEST_CASE( qos0 ) {
                     BOOST_TEST(topic == "t2");
                     BOOST_TEST(contents == "contents2");
                 },
-                "h_publish_s2_1",
                 [&]{
                     MQTT_CHK("h_publish_s2_2");
                     BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
@@ -278,8 +274,7 @@ BOOST_AUTO_TEST_CASE( qos0 ) {
          MQTT_NS::buffer topic,
          MQTT_NS::buffer contents,
          MQTT_NS::v5::properties /*props*/) mutable {
-            auto ret = chk.match(
-                "h_suback_s3",
+            auto ret = MQTT_ORDERED(
                 [&] {
                     MQTT_CHK("h_publish_s3_1");
                     BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
@@ -289,7 +284,6 @@ BOOST_AUTO_TEST_CASE( qos0 ) {
                     BOOST_TEST(topic == "t1");
                     BOOST_TEST(contents == "contents3");
                 },
-                "h_publish_s3_1",
                 [&]{
                     MQTT_CHK("h_publish_s3_2");
                     BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);
@@ -299,7 +293,6 @@ BOOST_AUTO_TEST_CASE( qos0 ) {
                     BOOST_TEST(topic == "t1");
                     BOOST_TEST(contents == "contents5");
                 },
-                "h_publish_s3_2",
                 [&]{
                     MQTT_CHK("h_publish_s3_3");
                     BOOST_TEST(pubopts.get_dup() == MQTT_NS::dup::no);

--- a/test/system/st_sub.cpp
+++ b/test/system/st_sub.cpp
@@ -7,6 +7,7 @@
 #include "../common/test_main.hpp"
 #include "combi_test.hpp"
 #include "checker.hpp"
+#include "ordered_caller.hpp"
 #include "../common/global_fixture.hpp"
 
 #include <mqtt/optional.hpp>
@@ -19,6 +20,7 @@ using namespace std::literals::string_literals;
 
 BOOST_AUTO_TEST_CASE( qos0_sub_string_single ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -117,6 +119,7 @@ BOOST_AUTO_TEST_CASE( qos0_sub_string_single ) {
 
 BOOST_AUTO_TEST_CASE( sub_update ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -152,18 +155,15 @@ BOOST_AUTO_TEST_CASE( sub_update ) {
                 [&chk, &c]
                 (packet_id_t /*packet_id*/, std::vector<MQTT_NS::suback_return_code> results) {
                     BOOST_TEST(results.size() == 1);
-                    auto ret = chk.match(
-                        "h_connack",
+                    auto ret = MQTT_ORDERED(
                         [&] {
                             MQTT_CHK("h_suback_1");
                             BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_0);
                         },
-                        "h_suback_1",
                         [&] {
                             MQTT_CHK("h_suback_2");
                             BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_1);
                         },
-                        "h_suback_2",
                         [&] {
                             MQTT_CHK("h_suback_3");
                             BOOST_TEST(results[0] == MQTT_NS::suback_return_code::success_maximum_qos_2);
@@ -197,18 +197,15 @@ BOOST_AUTO_TEST_CASE( sub_update ) {
                 [&chk, &c]
                 (packet_id_t /*packet_id*/, std::vector<MQTT_NS::v5::suback_reason_code> reasons, MQTT_NS::v5::properties /*props*/) {
                     BOOST_TEST(reasons.size() == 1);
-                    auto ret = chk.match(
-                        "h_connack",
+                    auto ret = MQTT_ORDERED(
                         [&] {
                             MQTT_CHK("h_suback_1");
                             BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_0);
                         },
-                        "h_suback_1",
                         [&] {
                             MQTT_CHK("h_suback_2");
                             BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_1);
                         },
-                        "h_suback_2",
                         [&] {
                             MQTT_CHK("h_suback_3");
                             BOOST_TEST(reasons[0] == MQTT_NS::v5::suback_reason_code::granted_qos_2);
@@ -253,6 +250,7 @@ BOOST_AUTO_TEST_CASE( sub_update ) {
 
 BOOST_AUTO_TEST_CASE( sub_v5_options ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -348,6 +346,7 @@ BOOST_AUTO_TEST_CASE( sub_v5_options ) {
 
 BOOST_AUTO_TEST_CASE( qos0_sub_string_multi_arg ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -452,6 +451,7 @@ BOOST_AUTO_TEST_CASE( qos0_sub_string_multi_arg ) {
 
 BOOST_AUTO_TEST_CASE( qos0_sub_string_multi_vec ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -560,6 +560,7 @@ BOOST_AUTO_TEST_CASE( qos0_sub_string_multi_vec ) {
 
 BOOST_AUTO_TEST_CASE( qos0_sub_string_single_async ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -652,6 +653,7 @@ BOOST_AUTO_TEST_CASE( qos0_sub_string_single_async ) {
 
 BOOST_AUTO_TEST_CASE( qos0_sub_string_multi_arg_async ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -770,6 +772,7 @@ BOOST_AUTO_TEST_CASE( qos0_sub_string_multi_arg_async ) {
 
 BOOST_AUTO_TEST_CASE( qos0_sub_string_multi_vec_async ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& /*b*/) {
+        clear_ordered();
         using packet_id_t = typename std::remove_reference_t<decltype(*c)>::packet_id_t;
         c->set_client_id("cid1");
         c->set_clean_session(true);
@@ -890,6 +893,7 @@ BOOST_AUTO_TEST_CASE( qos0_sub_string_multi_vec_async ) {
 
 BOOST_AUTO_TEST_CASE( sub_unsub_prop ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& b) {
+        clear_ordered();
         if (c->get_protocol_version() != MQTT_NS::protocol_version::v5) {
             finish();
             return;
@@ -1033,6 +1037,7 @@ BOOST_AUTO_TEST_CASE( sub_unsub_prop ) {
 
 BOOST_AUTO_TEST_CASE( suback_unsuback_prop ) {
     auto test = [](boost::asio::io_context& ioc, auto& c, auto finish, auto& b) {
+        clear_ordered();
         if (c->get_protocol_version() != MQTT_NS::protocol_version::v5) {
             finish();
             return;

--- a/test/system/st_underlying_timeout.cpp
+++ b/test/system/st_underlying_timeout.cpp
@@ -9,6 +9,7 @@
 #include "test_settings.hpp"
 #include "test_ctx_init.hpp"
 #include "checker.hpp"
+#include "ordered_caller.hpp"
 #include "../common/global_fixture.hpp"
 
 BOOST_AUTO_TEST_SUITE(st_underlying_timeout)

--- a/test/system/test_util.hpp
+++ b/test/system/test_util.hpp
@@ -8,6 +8,7 @@
 #define MQTT_TEST_TEST_UTIL_HPP
 
 #include "checker.hpp"
+#include "ordered_caller.hpp"
 #include <mqtt/sync_client.hpp>
 
 template <typename Client>


### PR DESCRIPTION
If you just need ordered call for the same handler, you can use
MQTT_ORDERED(handler1, handler2, ...).
In this case, you need to call cleard_ordered() on the top of test.
It should be called before the each tests (tcp, tls, ws, wss).

If you need to call handler based on topological sorting, then you can
use chk.match("label1", handler1, "label2", handler2, ...).