### PR TITLE
Added async_force_disconnect().

### DIFF
--- a/include/mqtt/async_client.hpp
+++ b/include/mqtt/async_client.hpp
@@ -379,6 +379,7 @@ public:
 
     void connect() = delete;
     void disconnect() = delete;
+    void force_disconnect() = delete;
 
     void publish() = delete;
     void subscribe() = delete;

--- a/include/mqtt/client.hpp
+++ b/include/mqtt/client.hpp
@@ -1078,6 +1078,19 @@ public:
     }
 
     /**
+     * @brief Disconnect by endpoint
+     * @param func A callback function that is called when async operation will finish.
+     * Force disconnect. It is not a clean disconnect sequence.<BR>
+     * When the endpoint disconnects using force_disconnect(), a will will send.<BR>
+     */
+    void async_force_disconnect(
+        async_handler_t func = async_handler_t()) {
+        if (ping_duration_ != std::chrono::steady_clock::duration::zero()) tim_ping_.cancel();
+        tim_close_.cancel();
+        base::async_force_disconnect(force_move(func));
+    }
+
+    /**
      * @brief Set pingreq message sending mode
      * @param b If true then send pingreq asynchronously, otherwise send synchronously.
      */

--- a/include/mqtt/endpoint.hpp
+++ b/include/mqtt/endpoint.hpp
@@ -2215,6 +2215,27 @@ public:
         }
     }
 
+    /**
+     * @brief Disconnect by endpoint
+     * @param func
+     *        functor object who's operator() will be called when the async operation completes.
+     * Force disconnect. It is not a clean disconnect sequence.<BR>
+     * When the endpoint disconnects using force_disconnect(), a will will send.<BR>
+     */
+    void async_force_disconnect(
+        async_handler_t func = {}
+    ) {
+        MQTT_LOG("mqtt_api", info)
+            << MQTT_ADD_VALUE(address, this)
+            << "async_force_disconnect";
+        socket_->post(
+            [this, self = this->shared_from_this(), func = force_move(func)] {
+                shutdown(socket());
+                if (func) func(boost::system::errc::make_error_code(boost::system::errc::success));
+            }
+        );
+    }
+
     // packet_id manual setting version
 
     /**

--- a/include/mqtt/sync_client.hpp
+++ b/include/mqtt/sync_client.hpp
@@ -378,6 +378,7 @@ public:
 
     void async_connect() = delete;
     void async_disconnect() = delete;
+    void async_force_disconnect() = delete;
 
     void async_publish() = delete;
     void async_subscribe() = delete;


### PR DESCRIPTION
It simply post the shutdown process.
It can avoid the pitfall force_disconnect() thread unsafe calling on async_client.