### PR TITLE
Updated certificate function call.

### DIFF
--- a/example/broker.cpp
+++ b/example/broker.cpp
@@ -51,7 +51,7 @@ void reload_ctx(Server& server, boost::asio::steady_timer& reload_timer,
     auto context = init_ctx();
 
     boost::system::error_code ec;
-    context.use_certificate_file(certificate_filename, boost::asio::ssl::context::pem, ec);
+    context.use_certificate_chain_file(certificate_filename, ec);
     if (ec) {
         auto message = "Failed to load certificate file: " + ec.message();
         if (first_load) {

--- a/example/tls_both.cpp
+++ b/example/tls_both.cpp
@@ -342,7 +342,7 @@ int main(int argc, char** argv) {
     ctx.set_options(
         boost::asio::ssl::context::default_workarounds |
         boost::asio::ssl::context::single_dh_use);
-    ctx.use_certificate_file(base + "server.crt.pem", boost::asio::ssl::context::pem);
+    ctx.use_certificate_chain_file(base + "server.crt.pem");
     ctx.use_private_key_file(base + "server.key.pem", boost::asio::ssl::context::pem);
 
     boost::asio::io_context iocs;

--- a/example/tls_both_client_cert.cpp
+++ b/example/tls_both_client_cert.cpp
@@ -342,7 +342,7 @@ int main(int argc, char** argv) {
     ctx.set_options(
         boost::asio::ssl::context::default_workarounds |
         boost::asio::ssl::context::single_dh_use);
-    ctx.use_certificate_file(base + "server.crt.pem", boost::asio::ssl::context::pem);
+    ctx.use_certificate_chain_file(base + "server.crt.pem");
     ctx.use_private_key_file(base + "server.key.pem", boost::asio::ssl::context::pem);
     ctx.set_verify_mode(MQTT_NS::tls::verify_peer);
     ctx.load_verify_file(base + "cacert.pem");
@@ -389,7 +389,7 @@ int main(int argc, char** argv) {
     std::uint16_t pid_sub2;
 
     auto c = MQTT_NS::make_tls_sync_client(ioc, "localhost", port);
-    c->get_ssl_context().use_certificate_file(base + "client.crt.pem", boost::asio::ssl::context::pem);
+    c->get_ssl_context().use_certificate_chain_file(base + "client.crt.pem");
     c->get_ssl_context().use_private_key_file(base + "client.key.pem", boost::asio::ssl::context::pem);
     c->get_ssl_context().load_verify_file(base + "cacert.pem");
 

--- a/example/tls_server.cpp
+++ b/example/tls_server.cpp
@@ -72,7 +72,7 @@ int main(int argc, char** argv) {
     ctx.set_options(
         boost::asio::ssl::context::default_workarounds |
         boost::asio::ssl::context::single_dh_use);
-    ctx.use_certificate_file(cert, boost::asio::ssl::context::pem);
+    ctx.use_certificate_chain_file(cert);
     ctx.use_private_key_file(key, boost::asio::ssl::context::pem);
 
     auto s = MQTT_NS::server_tls<>(

--- a/example/tls_ws_both.cpp
+++ b/example/tls_ws_both.cpp
@@ -341,7 +341,7 @@ int main(int argc, char** argv) {
     ctx.set_options(
         boost::asio::ssl::context::default_workarounds |
         boost::asio::ssl::context::single_dh_use);
-    ctx.use_certificate_file(base + "server.crt.pem", boost::asio::ssl::context::pem);
+    ctx.use_certificate_chain_file(base + "server.crt.pem");
     ctx.use_private_key_file(base + "server.key.pem", boost::asio::ssl::context::pem);
 
     boost::asio::io_context iocs;

--- a/example/tls_ws_server.cpp
+++ b/example/tls_ws_server.cpp
@@ -72,7 +72,7 @@ int main(int argc, char** argv) {
     ctx.set_options(
         boost::asio::ssl::context::default_workarounds |
         boost::asio::ssl::context::single_dh_use);
-    ctx.use_certificate_file(cert, boost::asio::ssl::context::pem);
+    ctx.use_certificate_chain_file(cert);
     ctx.use_private_key_file(key, boost::asio::ssl::context::pem);
 
     auto s = MQTT_NS::server_tls_ws<>(

--- a/test/system/test_ctx_init.hpp
+++ b/test/system/test_ctx_init.hpp
@@ -22,7 +22,7 @@ static inline boost::asio::ssl::context test_ctx_init() {
     std::string path = boost::unit_test::framework::master_test_suite().argv[0];
     std::size_t pos = path.find_last_of("/\\");
     std::string base = (pos == std::string::npos) ? "" : path.substr(0, pos + 1);
-    ctx.use_certificate_file(base + "server.crt.pem", boost::asio::ssl::context::pem);
+    ctx.use_certificate_chain_file(base + "server.crt.pem");
     ctx.use_private_key_file(base + "server.key.pem", boost::asio::ssl::context::pem);
     return ctx;
 }


### PR DESCRIPTION
Replaced use_certificate_file with use_certificate_chain_file.
If certificate file contians one certification, both ok.
However, if the certificate file contains intermidiate certificate and
server certificate, then only use_certificate_chain_file works.

See
https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_use_certificate.html