### PR TITLE
Fixed #843.

### DIFF
--- a/include/mqtt/broker/broker.hpp
+++ b/include/mqtt/broker/broker.hpp
@@ -1058,7 +1058,6 @@ private:
                             v5::connect_reason_code::success,
                             v5::properties{
                                 v5::property::topic_alias_maximum{topic_alias_max},
-                                v5::property::maximum_qos{qos::exactly_once},
                                 v5::property::receive_maximum{receive_maximum_max}
                             }
                         );

--- a/test/system/st_connect.cpp
+++ b/test/system/st_connect.cpp
@@ -1464,7 +1464,7 @@ BOOST_AUTO_TEST_CASE( connack_prop ) {
         MQTT_NS::v5::properties ps {
             MQTT_NS::v5::property::session_expiry_interval(0),
             MQTT_NS::v5::property::receive_maximum(0x1234),
-            MQTT_NS::v5::property::maximum_qos(MQTT_NS::qos::exactly_once),
+            MQTT_NS::v5::property::maximum_qos(MQTT_NS::qos::at_least_once),
             MQTT_NS::v5::property::retain_available(true),
             MQTT_NS::v5::property::maximum_packet_size(100000),
             MQTT_NS::v5::property::assigned_client_identifier("test cid"_mb),
@@ -1506,7 +1506,7 @@ BOOST_AUTO_TEST_CASE( connack_prop ) {
                                 BOOST_TEST(t.val() == 0x1234);
                             },
                             [&](MQTT_NS::v5::property::maximum_qos const& t) {
-                                BOOST_TEST(t.val() == 2);
+                                BOOST_TEST(t.val() == 1);
                             },
                             [&](MQTT_NS::v5::property::retain_available const& t) {
                                 BOOST_TEST(t.val() == true);

--- a/test/system/st_topic_alias.cpp
+++ b/test/system/st_topic_alias.cpp
@@ -827,10 +827,9 @@ BOOST_AUTO_TEST_CASE( resend_publish ) {
                     return true;
                 });
             c->set_v5_puback_handler(
-                [&chk, &c]
+                [&chk]
                 (packet_id_t, MQTT_NS::v5::puback_reason_code, MQTT_NS::v5::properties /*props*/) {
                     MQTT_CHK("h_puback");
-                    c->disconnect();
                     return true;
                 });
             c->set_v5_pubrec_handler(

--- a/test/unit/ut_property.cpp
+++ b/test/unit/ut_property.cpp
@@ -87,9 +87,9 @@ BOOST_AUTO_TEST_CASE( topic_alias ) {
 }
 
 BOOST_AUTO_TEST_CASE( maximum_qos ) {
-    MQTT_NS::v5::property::maximum_qos v { MQTT_NS::qos::exactly_once };
+    MQTT_NS::v5::property::maximum_qos v { MQTT_NS::qos::at_most_once };
 
-    BOOST_TEST(boost::lexical_cast<std::string>(v) == "2");
+    BOOST_TEST(boost::lexical_cast<std::string>(v) == "0");
 }
 
 BOOST_AUTO_TEST_CASE( retain_available ) {


### PR DESCRIPTION
Removed invalid maximum_qos (exactly_once) property.
It should be absent if exactly_once.
Only at_most_once (0), or at_least_once (1) is allowed.