### PR TITLE
Added workaround code for windows.

### DIFF
--- a/include/mqtt/broker/broker.hpp
+++ b/include/mqtt/broker/broker.hpp
@@ -18,6 +18,7 @@
 #include <mqtt/property.hpp>
 #include <mqtt/visitor_util.hpp>
 
+#include <mqtt/broker/broker_config.hpp>
 #include <mqtt/broker/session_state.hpp>
 #include <mqtt/broker/sub_con_map.hpp>
 #include <mqtt/broker/retained_messages.hpp>
@@ -1299,6 +1300,39 @@ private:
                 );
             };
 
+#if defined(_MSC_VER)
+        // This is sending DISCONNECT packet and then close the socket from the broker side.
+        // If the client receive DISCONNECT packet then the client is expected that close
+        // the socket from the client side. But not all clients do that.
+        // So the broker should close the socket from the broker side.
+        // mqtt_cpp uses Boost.Asio's async_write..
+        // See https://www.boost.org/doc/libs/1_77_0/doc/html/boost_asio/reference/async_write/overload1.html
+        // **In the WriteHandler**, call force_disconnect() that closes the socket.
+        // It works on Linux and osx. However Windows doesn't.
+        // After some try and error, Windows requires some wait.
+        // So I inserted wait code.
+        auto disconnect_and_force_disconnect =
+            [this, force_disconnect]
+            (con_sp_t spep, v5::disconnect_reason_code rc) mutable {
+                auto p = spep.get();
+                p->async_disconnect(
+                    rc,
+                    v5::properties{},
+                    [this, spep = force_move(spep), force_disconnect = force_move(force_disconnect)]
+                    (error_code) mutable {
+                        auto tim = std::make_shared<as::steady_timer>(ioc_, windows_close_delay);
+                        tim->async_wait(
+                            [tim, spep = force_move(spep), force_disconnect = force_move(force_disconnect)]
+                            (boost::system::error_code const& ec) mutable {
+                                if (!ec) {
+                                    force_disconnect(force_move(spep));
+                                }
+                            }
+                        );
+                    }
+                );
+            };
+#else  // defined(_MSC_VER)
         auto disconnect_and_force_disconnect =
             [force_disconnect]
             (con_sp_t spep, v5::disconnect_reason_code rc) mutable {
@@ -1312,6 +1346,7 @@ private:
                     }
                 );
             };
+#endif // defined(_MSC_VER)
 
         if (session_clear) {
             // const_cast is appropriate here

--- a/include/mqtt/broker/broker_config.hpp
+++ b/include/mqtt/broker/broker_config.hpp
@@ -1,0 +1,22 @@
+// Copyright Takatoshi Kondo 2021
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(MQTT_BROKER_CONFIG_HPP)
+#define MQTT_BROKER_CONFIG_HPP
+
+#include <mqtt/config.hpp>
+
+#include <chrono>
+
+#include <mqtt/broker/broker_namespace.hpp>
+
+MQTT_BROKER_NS_BEGIN
+
+static constexpr std::chrono::seconds windows_close_delay(3);
+
+MQTT_BROKER_NS_END
+
+#endif // MQTT_BROKER_CONFIG_HPP

--- a/test/system/st_connect.cpp
+++ b/test/system/st_connect.cpp
@@ -1635,15 +1635,11 @@ BOOST_AUTO_TEST_CASE( session_taken_over ) {
         // connect
         cont("h_connack1"),
         // connect
-#if !defined(_MSC_VER)
         cont("h_disconnect1"),
-#endif // !defined(_MSC_VER)
         cont("h_error1"),
         deps("h_connack2", "h_connack1"),
         // connect
-#if !defined(_MSC_VER)
         cont("h_disconnect2"),
-#endif // !defined(_MSC_VER)
         cont("h_error2"),
         deps("h_connack3", "h_connack2"),
         // disconnect


### PR DESCRIPTION
MQTT requires to send DISCONNECT with reason code and then close the
connection from the broker side but Windows requires some delay.