### PR TITLE
Unified async/sync selector for automatic operation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 12.0.0
+* <<<< breaking change >>>> Unified automatic async/sync choosing flag. (#857)
+  endppoint constructor 4th parameter `async_operation` is used.
+  set_async_operation() can overwrite the async_operation.
+  It should be called before sending any packets.
+
 ## 11.1.0
 * Added Topic Alias Maximum setting functionality. (#816, #817, #818)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MQTT client/server for C++14 based on Boost.Asio
 
-Version 11.1.0 [![Actions Status](https://github.com/redboltz/mqtt_cpp/workflows/CI/badge.svg)](https://github.com/redboltz/mqtt_cpp/actions)[![Build Status](https://dev.azure.com/redboltz/redboltz/_apis/build/status/redboltz.mqtt_cpp?branchName=master)](https://dev.azure.com/redboltz/redboltz/_build/latest?definitionId=6&branchName=master)[![codecov](https://codecov.io/gh/redboltz/mqtt_cpp/branch/master/graph/badge.svg)](https://codecov.io/gh/redboltz/mqtt_cpp)
+Version 12.0.0 [![Actions Status](https://github.com/redboltz/mqtt_cpp/workflows/CI/badge.svg)](https://github.com/redboltz/mqtt_cpp/actions)[![Build Status](https://dev.azure.com/redboltz/redboltz/_apis/build/status/redboltz.mqtt_cpp?branchName=master)](https://dev.azure.com/redboltz/redboltz/_build/latest?definitionId=6&branchName=master)[![codecov](https://codecov.io/gh/redboltz/mqtt_cpp/branch/master/graph/badge.svg)](https://codecov.io/gh/redboltz/mqtt_cpp)
 
 Important note https://github.com/redboltz/mqtt_cpp/wiki/News.
 

--- a/include/mqtt/async_client.hpp
+++ b/include/mqtt/async_client.hpp
@@ -374,7 +374,7 @@ public:
      * When set auto publish response mode to true, puback, pubrec, pubrel,and pub comp automatically send.<BR>
      */
     void set_auto_pub_response(bool b = true) {
-        base::set_auto_pub_response(b, true);
+        base::set_auto_pub_response(b);
     }
 
     void connect() = delete;
@@ -419,8 +419,6 @@ protected:
            true
     ) {
         set_auto_pub_response();
-        base::set_async_pingreq(true);
-        base::set_async_notify(true);
     }
 };
 

--- a/include/mqtt/broker/broker.hpp
+++ b/include/mqtt/broker/broker.hpp
@@ -308,7 +308,7 @@ public:
 
         ep.socket().lowest_layer().set_option(as::ip::tcp::no_delay(true));
         ep.set_auto_pub_response(false);
-        ep.set_async_notify(true);
+        ep.set_async_operation(true);
         ep.set_topic_alias_maximum(MQTT_NS::topic_alias_max);
         // Pass spep to keep lifetime.
         // It makes sure wp.lock() never return nullptr in the handlers below

--- a/include/mqtt/client.hpp
+++ b/include/mqtt/client.hpp
@@ -1099,14 +1099,6 @@ public:
         base::async_force_disconnect(force_move(func));
     }
 
-    /**
-     * @brief Set pingreq message sending mode
-     * @param b If true then send pingreq asynchronously, otherwise send synchronously.
-     */
-    void set_async_pingreq(bool b) {
-        async_pingreq_ = b;
-    }
-
     std::shared_ptr<Socket> const& socket() const {
         return socket_;
     }
@@ -1125,14 +1117,15 @@ protected:
 #endif // defined(MQTT_USE_WS)
            ,
            protocol_version version = protocol_version::v3_1_1,
-           bool async_store_send = false
+           bool async_operation = false
     )
-        :base(ioc, version, async_store_send),
+        :base(ioc, version, async_operation),
          ioc_(ioc),
          tim_ping_(ioc_),
          tim_close_(ioc_),
          host_(force_move(host)),
-         port_(force_move(port))
+         port_(force_move(port)),
+         async_operation_(async_operation)
 #if defined(MQTT_USE_WS)
          ,
          path_(force_move(path))
@@ -1497,7 +1490,7 @@ protected:
 private:
     void handle_timer(error_code ec) {
         if (!ec) {
-            if (async_pingreq_) {
+            if (async_operation_) {
                 base::async_pingreq();
             }
             else {
@@ -1574,7 +1567,7 @@ private:
     optional<will> will_;
     optional<std::string> user_name_;
     optional<std::string> password_;
-    bool async_pingreq_ = false;
+    bool async_operation_ = false;
 #if defined(MQTT_USE_TLS)
     tls::context ctx_{tls::context::tlsv12};
 #endif // defined(MQTT_USE_TLS)

--- a/include/mqtt/sync_client.hpp
+++ b/include/mqtt/sync_client.hpp
@@ -373,7 +373,7 @@ public:
      * When set auto publish response mode to true, puback, pubrec, pubrel,and pub comp automatically send.<BR>
      */
     void set_auto_pub_response(bool b = true) {
-        base::set_auto_pub_response(b, false);
+        base::set_auto_pub_response(b);
     }
 
     void async_connect() = delete;


### PR DESCRIPTION
- Renamed client's async_store_send to async_operation.
  Now it is not only for sending stored messages but also for all automatic messages.
- Removed set_auto_pub_response()'s 2nd parameter.
- Removed set_async_notify() for DISCONNECT/CONNACK.
- Removed set_async_pingreq().
- Added set_async_operation(). for all automatic operations.