### PR TITLE
Assign io_context for each thread.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,28 @@
 ## 12.0.0
-* <<<< breaking change >>>> Unified automatic async/sync choosing flag. (#857)
+* Added io_context and threads setting options for example broker (#866)
+* Fixed moved from object access (#865)
+* <<<< breaking change >>>> Removed ioc_con() and ioc_accept() (#866)
+* <<<< breaking change >>>> Unified automatic async/sync choosing flag. (#857, #862)
   endppoint constructor 4th parameter `async_operation` is used.
   set_async_operation() can overwrite the async_operation.
   It should be called before sending any packets.
+* Implemented clean shutdown (WS TLS TCP) (#849, 860, #863, #864)
+* Improved build system (#859)
+* Added DISCONNECT with session taken over reason code (#847)
+* Improved tests (#845, #846, #852)
+* Fixed invalid maximum_qos (2) sending (#844)
+* Added multi thread support for example broker (#842, #855, #866)
+* Replaced example broker's API call from sync to async (#842)
+* Replaced use_certificate_file() with use_certificate_chain_file() to support both server cert and server - intermediate CA cert (#841)
+* <<<< breaking change >>>> Added async_force_disconnect(). force_disconnect() is removed from async_client (#840)
+* Added will delay interval support (#839)
+* Fixed async_handler_t calling timing (#836)
+* Added BOOST_ASIO_NO_TS_EXECUTORS support (#830)
+* Fixed async_unsuback() argument mismatch (#828)
+* Added receive maximum support(#825, #835)
+* Fixed QoS2 packet handling problem (#824)
+* Refined async test mechanism. MQTT_ORDERED() macro is introcuded (#822, #823)
+* Added maximum packet size support (#821, #826, #834))
 
 ## 11.1.0
 * Added Topic Alias Maximum setting functionality. (#816, #817, #818)

--- a/example/broker.conf
+++ b/example/broker.conf
@@ -2,7 +2,9 @@
 verbose=1
 certificate=server.crt.pem
 private_key=server.key.pem
-threads=1
+
+iocs=1
+threads_per_ioc=1
 
 # Reload interval for the certificate and private key files (hours)
 # When configured the broker will perform  automatic loading of

--- a/include/mqtt/broker/broker.hpp
+++ b/include/mqtt/broker/broker.hpp
@@ -256,9 +256,9 @@ static_assert( ! compare_topic_filter("bob/alice/mary/sue/#", "bob/alice/mary/su
 
 class broker_t {
 public:
-    broker_t(as::io_context& ioc)
-        :ioc_(ioc),
-         tim_disconnect_(ioc_)
+    broker_t(as::io_context& timer_ioc)
+        :timer_ioc_(timer_ioc),
+         tim_disconnect_(timer_ioc_)
     {}
 
     // [begin] for test setting
@@ -1096,7 +1096,7 @@ private:
                 << " new connection inserted.";
             it = idx.emplace_hint(
                 it,
-                ioc_,
+                timer_ioc_,
                 mtx_subs_map_,
                 subs_map_,
                 shared_targets_,
@@ -1128,7 +1128,7 @@ private:
                         it,
                         [&](auto& e) {
                             e.clean();
-                            e.update_will(ioc_, force_move(will), will_expiry_interval);
+                            e.update_will(timer_ioc_, force_move(will), will_expiry_interval);
                             // renew_session_expiry updates index
                             e.renew_session_expiry(force_move(session_expiry_interval));
                         },
@@ -1146,7 +1146,7 @@ private:
                         it,
                         [&](auto& e) {
                             e.renew(spep, clean_start);
-                            e.update_will(ioc_, force_move(will), will_expiry_interval);
+                            e.update_will(timer_ioc_, force_move(will), will_expiry_interval);
                             // renew_session_expiry updates index
                             e.renew_session_expiry(force_move(session_expiry_interval));
                             e.send_inflight_messages();
@@ -1165,7 +1165,7 @@ private:
                     << "online connection exists, discard old one due to session_expiry and renew";
                 bool inserted;
                 std::tie(it, inserted) = idx.emplace(
-                    ioc_,
+                    timer_ioc_,
                     mtx_subs_map_,
                     subs_map_,
                     shared_targets_,
@@ -1197,7 +1197,7 @@ private:
                     [&](auto& e) {
                         e.clean();
                         e.renew(spep, clean_start);
-                        e.update_will(ioc_, force_move(will), will_expiry_interval);
+                        e.update_will(timer_ioc_, force_move(will), will_expiry_interval);
                         // renew_session_expiry updates index
                         e.renew_session_expiry(force_move(session_expiry_interval));
                     },
@@ -1215,7 +1215,7 @@ private:
                     it,
                     [&](auto& e) {
                         e.renew(spep, clean_start);
-                        e.update_will(ioc_, force_move(will), will_expiry_interval);
+                        e.update_will(timer_ioc_, force_move(will), will_expiry_interval);
                         // renew_session_expiry updates index
                         e.renew_session_expiry(force_move(session_expiry_interval));
                         e.send_inflight_messages();
@@ -1704,7 +1704,7 @@ private:
                     );
                 }
                 ssr.get().publish(
-                    ioc_,
+                    timer_ioc_,
                     r.topic,
                     r.contents,
                     std::min(r.qos_value, qos_value) | MQTT_NS::retain::yes,
@@ -1929,7 +1929,7 @@ private:
                 if (sub.sid) {
                     props.push_back(v5::property::subscription_identifier(sub.sid.value()));
                     ss.deliver(
-                        ioc_,
+                        timer_ioc_,
                         topic,
                         contents,
                         new_pubopts,
@@ -1939,7 +1939,7 @@ private:
                 }
                 else {
                     ss.deliver(
-                        ioc_,
+                        timer_ioc_,
                         topic,
                         contents,
                         new_pubopts,
@@ -2016,7 +2016,7 @@ private:
             else {
                 std::shared_ptr<as::steady_timer> tim_message_expiry;
                 if (message_expiry_interval) {
-                    tim_message_expiry = std::make_shared<as::steady_timer>(ioc_, message_expiry_interval.value());
+                    tim_message_expiry = std::make_shared<as::steady_timer>(timer_ioc_, message_expiry_interval.value());
                     tim_message_expiry->async_wait(
                         [this, topic = topic, wp = std::weak_ptr<as::steady_timer>(tim_message_expiry)]
                         (boost::system::error_code const& ec) {
@@ -2044,7 +2044,7 @@ private:
     }
 
 private:
-    as::io_context& ioc_; ///< The boost asio context to run this broker on.
+    as::io_context& timer_ioc_; ///< The boost asio context to run this broker on.
     as::steady_timer tim_disconnect_; ///< Used to delay disconnect handling for testing
     optional<std::chrono::steady_clock::duration> delay_disconnect_; ///< Used to delay disconnect handling for testing
 

--- a/include/mqtt/broker/offline_message.hpp
+++ b/include/mqtt/broker/offline_message.hpp
@@ -137,7 +137,7 @@ public:
     }
 
     void push_back(
-        as::io_context& ioc,
+        as::io_context& timer_ioc,
         buffer pub_topic,
         buffer contents,
         publish_options pubopts,
@@ -151,7 +151,7 @@ public:
 
         std::shared_ptr<as::steady_timer> tim_message_expiry;
         if (message_expiry_interval) {
-            tim_message_expiry = std::make_shared<as::steady_timer>(ioc, message_expiry_interval.value());
+            tim_message_expiry = std::make_shared<as::steady_timer>(timer_ioc, message_expiry_interval.value());
             tim_message_expiry->async_wait(
                 [this, wp = std::weak_ptr<as::steady_timer>(tim_message_expiry)](error_code ec) mutable {
                     if (auto sp = wp.lock()) {


### PR DESCRIPTION
The original design was calling `ioc.run()` from multple threads.
It worked well but scale out limit is up to about 8 threads.
The pps is 120,000 publish / second (QoS0). It was pretty nice but only
8 cores ware used.
I tested it on AWS 48 vcpu environment.
When I used 48 threads, the result was the same as 8 threads.

I suspected OS or VM limit. But when I ran the two broker processes that
listens different port, then each broker resulted 120,000 pps.
So total is 240,000 pps.
It indicates the limit is not caused by OS or VM.

Finally, I found the bottle neck. It is io_context.

So I updated as follows:

1. Separated io_contexts.
   For timer, for accepting connections, and for MQTT communication.
   For MQTT communication, I prepared io_context as the same number of
   the threads.

2. Added server constructor that accepts io_context_getter.