### PR TITLE
Fixed automatic threads_per_ioc logic.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Fixed example broker's invalid sync connack call (#869)
 * Added no CONNACK sending mode to the example broker (#869)
 * Added posting code to acceptors (#867)
-* Added io_context and threads setting options for example broker (#866, #871)
+* Added io_context and threads setting options for example broker (#866, #871, #872)
 * Fixed moved from object access (#865)
 * <<<< breaking change >>>> Removed ioc_con() and ioc_accept() (#866)
 * <<<< breaking change >>>> Unified automatic async/sync choosing flag. (#857, #862)

--- a/example/broker.conf
+++ b/example/broker.conf
@@ -3,8 +3,13 @@ verbose=1
 certificate=server.crt.pem
 private_key=server.key.pem
 
-iocs=1
-threads_per_ioc=1
+# 0 means automatic
+# Num of vCPU
+iocs=0
+
+# 0 means automatic
+# min(4 or Num of vCPU)
+threads_per_ioc=0
 
 # Reload interval for the certificate and private key files (hours)
 # When configured the broker will perform  automatic loading of

--- a/example/broker.cpp
+++ b/example/broker.cpp
@@ -350,7 +350,7 @@ void run_broker(boost::program_options::variables_map const& vm) {
                 return 1;
             } ();
         if (threads_per_ioc == 0) {
-            threads_per_ioc = std::max(std::size_t(std::thread::hardware_concurrency()), std::size_t(4));
+            threads_per_ioc = std::min(std::size_t(std::thread::hardware_concurrency()), std::size_t(4));
             MQTT_LOG("mqtt_broker", info) << "threads_per_ioc set to auto decide (0). Automatically set to " << threads_per_ioc;
         }
 


### PR DESCRIPTION
Set 0 (automatic) is default value of broker.conf