### PR TITLE
Compile fix for broker

### DIFF
--- a/include/mqtt/broker/broker.hpp
+++ b/include/mqtt/broker/broker.hpp
@@ -1537,7 +1537,7 @@ private:
                         forward_props.push_back(force_move(p));
                     }
                 ),
-                force_move(p)
+                p
             );
         }
 


### PR DESCRIPTION
I got the following compile error in the broker: 
````
[100%] Building CXX object example/CMakeFiles/broker.dir/broker.cpp.o
In file included from /usr/include/boost/thread/lock_types.hpp:11,
                 from /usr/include/boost/thread/pthread/recursive_mutex.hpp:13,
                 from /usr/include/boost/thread/recursive_mutex.hpp:16,
                 from /usr/include/boost/log/sinks/sync_frontend.hpp:33,
                 from /usr/include/boost/log/utility/setup/console.hpp:27,
                 from /home/kleunen/mqtt_cpp/include/mqtt/log.hpp:22,
                 from /home/kleunen/mqtt_cpp/include/mqtt/setup_log.hpp:18,
                 from /home/kleunen/mqtt_cpp/example/broker.cpp:8:
/usr/include/boost/thread/detail/move.hpp: In instantiation of â€˜struct boost::detail::thread_move_t<mqtt::v5::property::payload_format_indicator&>â€™:
/usr/include/boost/variant/variant.hpp:1021:41:   required from â€˜typename boost::enable_if_c<(MoveSemantics && boost::is_same<Value2, Value2>::value), typename Visitor::result_type>::type boost::detail::variant::invoke_visitor<Visitor, MoveSemantics>::internal_visit(T&&, int) [with T = mqtt::v5::property::payload_format_indicator&; Visitor = boost::detail::variant::result_wrapper1<mqtt::lambda_visitor<mqtt::broker::broker_t::publish_handler(mqtt::broker::con_sp_t, boost::optional<short unsigned int>, mqtt::publish_options, mqtt::buffer, mqtt::buffer, mqtt::v5::properties)::<lambda(mqtt::v5::property::topic_alias&&)>, mqtt::broker::broker_t::publish_handler(mqtt::broker::con_sp_t, boost::optional<short unsigned int>, mqtt::publish_options, mqtt::buffer, mqtt::buffer, mqtt::v5::properties)::<lambda(mqtt::v5::property::subscription_identifier&&)>, mqtt::broker::broker_t::publish_handler(mqtt::broker::con_sp_t, boost::optional<short unsigned int>, mqtt::publish_options, mqtt::buffer, mqtt::buffer, mqtt::v5::properties)::<lambda(auto:131&&)> >, boost::variant<mqtt::v5::property::payload_format_indicator, mqtt::v5::property::message_expiry_interval, mqtt::v5::property::content_type, mqtt::v5::property::response_topic, mqtt::v5::property::correlation_data, mqtt::v5::property::subscription_identifier, mqtt::v5::property::session_expiry_interval, mqtt::v5::property::assigned_client_identifier, mqtt::v5::property::server_keep_alive, mqtt::v5::property::authentication_method, mqtt::v5::property::authentication_data, mqtt::v5::property::request_problem_information, mqtt::v5::property::will_delay_interval, mqtt::v5::property::request_response_information, mqtt::v5::property::response_information, mqtt::v5::property::server_reference, mqtt::v5::property::reason_string, mqtt::v5::property::receive_maximum, mqtt::v5::property::topic_alias_maximum, mqtt::v5::property::topic_alias, mqtt::v5::property::maximum_qos, mqtt::v5::property::retain_available, mqtt::v5::property::user_property, mqtt::v5::property::maximum_packet_size, mqtt::v5::property::wildcard_subscription_available, mqtt::v5::property::subscription_identifier_available, mqtt::v5::property::shared_subscription_available> >; bool MoveSemantics = true; typename boost::enable_if_c<(MoveSemantics && boost::is_same<Value2, Value2>::value), typename Visitor::result_type>::type = void]â€™
/usr/include/boost/variant/detail/visitation_impl.hpp:112:9:   required from â€˜typename Visitor::result_type boost::detail::variant::visitation_impl_invoke_impl(int, Visitor&, VoidPtrCV, T*, mpl_::true_) [with Visitor = boost::detail::variant::invoke_visitor<boost::detail::variant::result_wrapper1<mqtt::lambda_visitor<mqtt::broker::broker_t::publish_handler(mqtt::broker::con_sp_t, boost::optional<short unsigned int>, mqtt::publish_options, mqtt::buffer, mqtt::buffer, mqtt::v5::properties)::<lambda(mqtt::v5::property::topic_alias&&)>, mqtt::broker::broker_t::publish_handler(mqtt::broker::con_sp_t, boost::optional<short unsigned int>, mqtt::publish_options, mqtt::buffer, mqtt::buffer, mqtt::v5::properties)::<lambda(mqtt::v5::property::subscription_identifier&&)>, mqtt::broker::broker_t::publish_handler(mqtt::broker::con_sp_t, boost::optional<short unsigned int>, mqtt::publish_options, mqtt::buffer, mqtt::buffer, mqtt::v5::properties)::<lambda(auto:131&&)> >, boost::variant<mqtt::v5::property::payload_format_indicator, mqtt::v5::property::message_expiry_interval, mqtt::v5::property::content_type, mqtt::v5::property::response_topic, mqtt::v5::property::correlation_data, mqtt::v5::property::subscription_identifier, mqtt::v5::property::session_expiry_interval, mqtt::v5::property::assigned_client_identifier, mqtt::v5::property::server_keep_alive, mqtt::v5::property::authentication_method, mqtt::v5::property::authentication_data, mqtt::v5::property::request_problem_information, mqtt::v5::property::will_delay_interval, mqtt::v5::property::request_response_information, mqtt::v5::property::response_information, mqtt::v5::property::server_reference, mqtt::v5::property::reason_string, mqtt::v5::property::receive_maximum, mqtt::v5::property::topic_alias_maximum, mqtt::v5::property::topic_alias, mqtt::v5::property::maximum_qos, mqtt::v5::property::retain_available, mqtt::v5::property::user_property, mqtt::v5::property::maximum_packet_size, mqtt::v5::property::wildcard_subscription_available, mqtt::v5::property::subscription_identifier_available, mqtt::v5::property::shared_subscription_available> >, true>; VoidPtrCV = void*; T = mqtt::v5::property::payload_format_indicator; typename Visitor::result_type = void; mpl_::true_ = mpl_::bool_<true>]â€™
/usr/include/boost/variant/detail/visitation_impl.hpp:150:41:   required from â€˜typename Visitor::result_type boost::detail::variant::visitation_impl_invoke(int, Visitor&, VoidPtrCV, T*, NoBackupFlag, int) [with Visitor = boost::detail::variant::invoke_visitor<boost::detail::variant::result_wrapper1<mqtt::lambda_visitor<mqtt::broker::broker_t::publish_handler(mqtt::broker::con_sp_t, boost::optional<short unsigned int>, mqtt::publish_options, mqtt::buffer, mqtt::buffer, mqtt::v5::properties)::<lambda(mqtt::v5::property::topic_alias&&)>, mqtt::broker::broker_t::publish_handler(mqtt::broker::con_sp_t, boost::optional<short unsigned int>, mqtt::publish_options, mqtt::buffer, mqtt::buffer, mqtt::v5::properties)::<lambda(mqtt::v5::property::subscription_identifier&&)>, mqtt::broker::broker_t::publish_handler(mqtt::broker::con_sp_t, boost::optional<short unsigned int>, mqtt::publish_options, mqtt::buffer, mqtt::buffer, mqtt::v5::properties)::<lambda(auto:131&&)> >, boost::variant<mqtt::v5::property::payload_format_indicator, mqtt::v5::property::message_expiry_interval, mqtt::v5::property::content_type, mqtt::v5::property::response_topic, mqtt::v5::property::correlation_data, mqtt::v5::property::subscription_identifier, mqtt::v5::property::session_expiry_interval, mqtt::v5::property::assigned_client_identifier, mqtt::v5::property::server_keep_alive, mqtt::v5::property::authentication_method, mqtt::v5::property::authentication_data, mqtt::v5::property::request_problem_information, mqtt::v5::property::will_delay_interval, mqtt::v5::property::request_response_information, mqtt::v5::property::response_information, mqtt::v5::property::server_reference, mqtt::v5::property::reason_string, mqtt::v5::property::receive_maximum, mqtt::v5::property::topic_alias_maximum, mqtt::v5::property::topic_alias, mqtt::v5::property::maximum_qos, mqtt::v5::property::retain_available, mqtt::v5::property::user_property, mqtt::v5::property::maximum_packet_size, mqtt::v5::property::wildcard_subscription_available, mqtt::v5::property::subscription_identifier_available, mqtt::v5::property::shared_subscription_available> >, true>; VoidPtrCV = void*; T = mqtt::v5::property::payload_format_indicator; NoBackupFlag = boost::variant<mqtt::v5::property::payload_format_indicator, mqtt::v5::property::message_expiry_interval, mqtt::v5::property::content_type, mqtt::v5::property::response_topic, mqtt::v5::property::correlation_data, mqtt::v5::property::subscription_identifier, mqtt::v5::property::session_expiry_interval, mqtt::v5::property::assigned_client_identifier, mqtt::v5::property::server_keep_alive, mqtt::v5::property::authentication_method, mqtt::v5::property::authentication_data, mqtt::v5::property::request_problem_information, mqtt::v5::property::will_delay_interval, mqtt::v5::property::request_response_information, mqtt::v5::property::response_information, mqtt::v5::property::server_reference, mqtt::v5::property::reason_string, mqtt::v5::property::receive_maximum, mqtt::v5::property::topic_alias_maximum, mqtt::v5::property::topic_alias, mqtt::v5::property::maximum_qos, mqtt::v5::property::retain_available, mqtt::v5::property::user_property, mqtt::v5::property::maximum_packet_size, mqtt::v5::property::wildcard_subscription_available, mqtt::v5::property::subscription_identifier_available, mqtt::v5::property::shared_subscription_available>::has_fallback_type_; typename Visitor::result_type = void]â€™
/usr/include/boost/variant/detail/visitation_impl.hpp:231:5:   required from â€˜typename Visitor::result_type boost::detail::variant::visitation_impl(int, int, Visitor&, VoidPtrCV, mpl_::false_, NoBackupFlag, Which*, step0*) [with Which = mpl_::int_<0>; step0 = boost::detail::variant::visitation_impl_step<boost::mpl::l_iter<boost::mpl::l_item<mpl_::long_<27>, mqtt::v5::property::payload_format_indicator, boost::mpl::l_item<mpl_::long_<26>, mqtt::v5::property::message_expiry_interval, boost::mpl::l_item<mpl_::long_<25>, mqtt::v5::property::content_type, boost::mpl::l_item<mpl_::long_<24>, mqtt::v5::property::response_topic, boost::mpl::l_item<mpl_::long_<23>, mqtt::v5::property::correlation_data, boost::mpl::l_item<mpl_::long_<22>, mqtt::v5::property::subscription_identifier, boost::mpl::l_item<mpl_::long_<21>, mqtt::v5::property::session_expiry_interval, boost::mpl::l_item<mpl_::long_<20>, mqtt::v5::property::assigned_client_identifier, boost::mpl::l_item<mpl_::long_<19>, mqtt::v5::property::server_keep_alive, boost::mpl::l_item<mpl_::long_<18>, mqtt::v5::property::authentication_method, boost::mpl::l_item<mpl_::long_<17>, mqtt::v5::property::authentication_data, boost::mpl::l_item<mpl_::long_<16>, mqtt::v5::property::request_problem_information, boost::mpl::l_item<mpl_::long_<15>, mqtt::v5::property::will_delay_interval, boost::mpl::l_item<mpl_::long_<14>, mqtt::v5::property::request_response_information, boost::mpl::l_item<mpl_::long_<13>, mqtt::v5::property::response_information, boost::mpl::l_item<mpl_::long_<12>, mqtt::v5::property::server_reference, boost::mpl::l_item<mpl_::long_<11>, mqtt::v5::property::reason_string, boost::mpl::l_item<mpl_::long_<10>, mqtt::v5::property::receive_maximum, boost::mpl::l_item<mpl_::long_<9>, mqtt::v5::property::topic_alias_maximum, boost::mpl::l_item<mpl_::long_<8>, mqtt::v5::property::topic_alias, boost::mpl::l_item<mpl_::long_<7>, mqtt::v5::property::maximum_qos, boost::mpl::l_item<mpl_::long_<6>, mqtt::v5::property::retain_available, boost::mpl::l_item<mpl_::long_<5>, mqtt::v5::property::user_property, boost::mpl::l_item<mpl_::long_<4>, mqtt::v5::property::maximum_packet_size, boost::mpl::l_item<mpl_::long_<3>, mqtt::v5::property::wildcard_subscription_available, boost::mpl::l_item<mpl_::long_<2>, mqtt::v5::property::subscription_identifier_available, boost::mpl::l_item<mpl_::long_<1>, mqtt::v5::property::shared_subscription_available, boost::mpl::l_end> > > > > > > > > > > > > > > > > > > > > > > > > > > >, boost::mpl::l_iter<boost::mpl::l_end> >; Visitor = boost::detail::variant::invoke_visitor<boost::detail::variant::result_wrapper1<mqtt::lambda_visitor<mqtt::broker::broker_t::publish_handler(mqtt::broker::con_sp_t, boost::optional<short unsigned int>, mqtt::publish_options, mqtt::buffer, mqtt::buffer, mqtt::v5::properties)::<lambda(mqtt::v5::property::topic_alias&&)>, mqtt::broker::broker_t::publish_handler(mqtt::broker::con_sp_t, boost::optional<short unsigned int>, mqtt::publish_options, mqtt::buffer, mqtt::buffer, mqtt::v5::properties)::<lambda(mqtt::v5::property::subscription_identifier&&)>, mqtt::broker::broker_t::publish_handler(mqtt::broker::con_sp_t, boost::optional<short unsigned int>, mqtt::publish_options, mqtt::buffer, mqtt::buffer, mqtt::v5::properties)::<lambda(auto:131&&)> >, boost::variant<mqtt::v5::property::payload_format_indicator, mqtt::v5::property::message_expiry_interval, mqtt::v5::property::content_type, mqtt::v5::property::response_topic, mqtt::v5::property::correlation_data, mqtt::v5::property::subscription_identifier, mqtt::v5::property::session_expiry_interval, mqtt::v5::property::assigned_client_identifier, mqtt::v5::property::server_keep_alive, mqtt::v5::property::authentication_method, mqtt::v5::property::authentication_data, mqtt::v5::property::request_problem_information, mqtt::v5::property::will_delay_interval, mqtt::v5::property::request_response_information, mqtt::v5::property::response_information, mqtt::v5::property::server_reference, mqtt::v5::property::reason_string, mqtt::v5::property::receive_maximum, mqtt::v5::property::topic_alias_maximum, mqtt::v5::property::topic_alias, mqtt::v5::property::maximum_qos, mqtt::v5::property::retain_available, mqtt::v5::property::user_property, mqtt::v5::property::maximum_packet_size, mqtt::v5::property::wildcard_subscription_available, mqtt::v5::property::subscription_identifier_available, mqtt::v5::property::shared_subscription_available> >, true>; VoidPtrCV = void*; NoBackupFlag = boost::variant<mqtt::v5::property::payload_format_indicator, mqtt::v5::property::message_expiry_interval, mqtt::v5::property::content_type, mqtt::v5::property::response_topic, mqtt::v5::property::correlation_data, mqtt::v5::property::subscription_identifier, mqtt::v5::property::session_expiry_interval, mqtt::v5::property::assigned_client_identifier, mqtt::v5::property::server_keep_alive, mqtt::v5::property::authentication_method, mqtt::v5::property::authentication_data, mqtt::v5::property::request_problem_information, mqtt::v5::property::will_delay_interval, mqtt::v5::property::request_response_information, mqtt::v5::property::response_information, mqtt::v5::property::server_reference, mqtt::v5::property::reason_string, mqtt::v5::property::receive_maximum, mqtt::v5::property::topic_alias_maximum, mqtt::v5::property::topic_alias, mqtt::v5::property::maximum_qos, mqtt::v5::property::retain_available, mqtt::v5::property::user_property, mqtt::v5::property::maximum_packet_size, mqtt::v5::property::wildcard_subscription_available, mqtt::v5::property::subscription_identifier_available, mqtt::v5::property::shared_subscription_available>::has_fallback_type_; typename Visitor::result_type = void; mpl_::false_ = mpl_::bool_<false>]â€™
/usr/include/boost/variant/variant.hpp:2334:48:   required from â€˜static typename Visitor::result_type boost::variant<T0, TN>::internal_apply_visitor_impl(int, int, Visitor&, VoidPtrCV) [with Visitor = boost::detail::variant::invoke_visitor<boost::detail::variant::result_wrapper1<mqtt::lambda_visitor<mqtt::broker::broker_t::publish_handler(mqtt::broker::con_sp_t, boost::optional<short unsigned int>, mqtt::publish_options, mqtt::buffer, mqtt::buffer, mqtt::v5::properties)::<lambda(mqtt::v5::property::topic_alias&&)>, mqtt::broker::broker_t::publish_handler(mqtt::broker::con_sp_t, boost::optional<short unsigned int>, mqtt::publish_options, mqtt::buffer, mqtt::buffer, mqtt::v5::properties)::<lambda(mqtt::v5::property::subscription_identifier&&)>, mqtt::broker::broker_t::publish_handler(mqtt::broker::con_sp_t, boost::optional<short unsigned int>, mqtt::publish_options, mqtt::buffer, mqtt::buffer, mqtt::v5::properties)::<lambda(auto:131&&)> >, boost::variant<mqtt::v5::property::payload_format_indicator, mqtt::v5::property::message_expiry_interval, mqtt::v5::property::content_type, mqtt::v5::property::response_topic, mqtt::v5::property::correlation_data, mqtt::v5::property::subscription_identifier, mqtt::v5::property::session_expiry_interval, mqtt::v5::property::assigned_client_identifier, mqtt::v5::property::server_keep_alive, mqtt::v5::property::authentication_method, mqtt::v5::property::authentication_data, mqtt::v5::property::request_problem_information, mqtt::v5::property::will_delay_interval, mqtt::v5::property::request_response_information, mqtt::v5::property::response_information, mqtt::v5::property::server_reference, mqtt::v5::property::reason_string, mqtt::v5::property::receive_maximum, mqtt::v5::property::topic_alias_maximum, mqtt::v5::property::topic_alias, mqtt::v5::property::maximum_qos, mqtt::v5::property::retain_available, mqtt::v5::property::user_property, mqtt::v5::property::maximum_packet_size, mqtt::v5::property::wildcard_subscription_available, mqtt::v5::property::subscription_identifier_available, mqtt::v5::property::shared_subscription_available> >, true>; VoidPtrCV = void*; T0_ = mqtt::v5::property::payload_format_indicator; TN = {mqtt::v5::property::message_expiry_interval, mqtt::v5::property::content_type, mqtt::v5::property::response_topic, mqtt::v5::property::correlation_data, mqtt::v5::property::subscription_identifier, mqtt::v5::property::session_expiry_interval, mqtt::v5::property::assigned_client_identifier, mqtt::v5::property::server_keep_alive, mqtt::v5::property::authentication_method, mqtt::v5::property::authentication_data, mqtt::v5::property::request_problem_information, mqtt::v5::property::will_delay_interval, mqtt::v5::property::request_response_information, mqtt::v5::property::response_information, mqtt::v5::property::server_reference, mqtt::v5::property::reason_string, mqtt::v5::property::receive_maximum, mqtt::v5::property::topic_alias_maximum, mqtt::v5::property::topic_alias, mqtt::v5::property::maximum_qos, mqtt::v5::property::retain_available, mqtt::v5::property::user_property, mqtt::v5::property::maximum_packet_size, mqtt::v5::property::wildcard_subscription_available, mqtt::v5::property::subscription_identifier_available, mqtt::v5::property::shared_subscription_available}; typename Visitor::result_type = void]â€™
/usr/include/boost/variant/variant.hpp:2346:43:   required from â€˜typename Visitor::result_type boost::variant<T0, TN>::internal_apply_visitor(Visitor&) [with Visitor = boost::detail::variant::invoke_visitor<boost::detail::variant::result_wrapper1<mqtt::lambda_visitor<mqtt::broker::broker_t::publish_handler(mqtt::broker::con_sp_t, boost::optional<short unsigned int>, mqtt::publish_options, mqtt::buffer, mqtt::buffer, mqtt::v5::properties)::<lambda(mqtt::v5::property::topic_alias&&)>, mqtt::broker::broker_t::publish_handler(mqtt::broker::con_sp_t, boost::optional<short unsigned int>, mqtt::publish_options, mqtt::buffer, mqtt::buffer, mqtt::v5::properties)::<lambda(mqtt::v5::property::subscription_identifier&&)>, mqtt::broker::broker_t::publish_handler(mqtt::broker::con_sp_t, boost::optional<short unsigned int>, mqtt::publish_options, mqtt::buffer, mqtt::buffer, mqtt::v5::properties)::<lambda(auto:131&&)> >, boost::variant<mqtt::v5::property::payload_format_indicator, mqtt::v5::property::message_expiry_interval, mqtt::v5::property::content_type, mqtt::v5::property::response_topic, mqtt::v5::property::correlation_data, mqtt::v5::property::subscription_identifier, mqtt::v5::property::session_expiry_interval, mqtt::v5::property::assigned_client_identifier, mqtt::v5::property::server_keep_alive, mqtt::v5::property::authentication_method, mqtt::v5::property::authentication_data, mqtt::v5::property::request_problem_information, mqtt::v5::property::will_delay_interval, mqtt::v5::property::request_response_information, mqtt::v5::property::response_information, mqtt::v5::property::server_reference, mqtt::v5::property::reason_string, mqtt::v5::property::receive_maximum, mqtt::v5::property::topic_alias_maximum, mqtt::v5::property::topic_alias, mqtt::v5::property::maximum_qos, mqtt::v5::property::retain_available, mqtt::v5::property::user_property, mqtt::v5::property::maximum_packet_size, mqtt::v5::property::wildcard_subscription_available, mqtt::v5::property::subscription_identifier_available, mqtt::v5::property::shared_subscription_available> >, true>; T0_ = mqtt::v5::property::payload_format_indicator; TN = {mqtt::v5::property::message_expiry_interval, mqtt::v5::property::content_type, mqtt::v5::property::response_topic, mqtt::v5::property::correlation_data, mqtt::v5::property::subscription_identifier, mqtt::v5::property::session_expiry_interval, mqtt::v5::property::assigned_client_identifier, mqtt::v5::property::server_keep_alive, mqtt::v5::property::authentication_method, mqtt::v5::property::authentication_data, mqtt::v5::property::request_problem_information, mqtt::v5::property::will_delay_interval, mqtt::v5::property::request_response_information, mqtt::v5::property::response_information, mqtt::v5::property::server_reference, mqtt::v5::property::reason_string, mqtt::v5::property::receive_maximum, mqtt::v5::property::topic_alias_maximum, mqtt::v5::property::topic_alias, mqtt::v5::property::maximum_qos, mqtt::v5::property::retain_available, mqtt::v5::property::user_property, mqtt::v5::property::maximum_packet_size, mqtt::v5::property::wildcard_subscription_available, mqtt::v5::property::subscription_identifier_available, mqtt::v5::property::shared_subscription_available}; typename Visitor::result_type = void]â€™
/usr/include/boost/variant/variant.hpp:2369:52:   required from â€˜typename Visitor::result_type boost::variant<T0, TN>::apply_visitor(Visitor&) && [with Visitor = boost::detail::variant::result_wrapper1<mqtt::lambda_visitor<mqtt::broker::broker_t::publish_handler(mqtt::broker::con_sp_t, boost::optional<short unsigned int>, mqtt::publish_options, mqtt::buffer, mqtt::buffer, mqtt::v5::properties)::<lambda(mqtt::v5::property::topic_alias&&)>, mqtt::broker::broker_t::publish_handler(mqtt::broker::con_sp_t, boost::optional<short unsigned int>, mqtt::publish_options, mqtt::buffer, mqtt::buffer, mqtt::v5::properties)::<lambda(mqtt::v5::property::subscription_identifier&&)>, mqtt::broker::broker_t::publish_handler(mqtt::broker::con_sp_t, boost::optional<short unsigned int>, mqtt::publish_options, mqtt::buffer, mqtt::buffer, mqtt::v5::properties)::<lambda(auto:131&&)> >, boost::variant<mqtt::v5::property::payload_format_indicator, mqtt::v5::property::message_expiry_interval, mqtt::v5::property::content_type, mqtt::v5::property::response_topic, mqtt::v5::property::correlation_data, mqtt::v5::property::subscription_identifier, mqtt::v5::property::session_expiry_interval, mqtt::v5::property::assigned_client_identifier, mqtt::v5::property::server_keep_alive, mqtt::v5::property::authentication_method, mqtt::v5::property::authentication_data, mqtt::v5::property::request_problem_information, mqtt::v5::property::will_delay_interval, mqtt::v5::property::request_response_information, mqtt::v5::property::response_information, mqtt::v5::property::server_reference, mqtt::v5::property::reason_string, mqtt::v5::property::receive_maximum, mqtt::v5::property::topic_alias_maximum, mqtt::v5::property::topic_alias, mqtt::v5::property::maximum_qos, mqtt::v5::property::retain_available, mqtt::v5::property::user_property, mqtt::v5::property::maximum_packet_size, mqtt::v5::property::wildcard_subscription_available, mqtt::v5::property::subscription_identifier_available, mqtt::v5::property::shared_subscription_available> >; T0_ = mqtt::v5::property::payload_format_indicator; TN = {mqtt::v5::property::message_expiry_interval, mqtt::v5::property::content_type, mqtt::v5::property::response_topic, mqtt::v5::property::correlation_data, mqtt::v5::property::subscription_identifier, mqtt::v5::property::session_expiry_interval, mqtt::v5::property::assigned_client_identifier, mqtt::v5::property::server_keep_alive, mqtt::v5::property::authentication_method, mqtt::v5::property::authentication_data, mqtt::v5::property::request_problem_information, mqtt::v5::property::will_delay_interval, mqtt::v5::property::request_response_information, mqtt::v5::property::response_information, mqtt::v5::property::server_reference, mqtt::v5::property::reason_string, mqtt::v5::property::receive_maximum, mqtt::v5::property::topic_alias_maximum, mqtt::v5::property::topic_alias, mqtt::v5::property::maximum_qos, mqtt::v5::property::retain_available, mqtt::v5::property::user_property, mqtt::v5::property::maximum_packet_size, mqtt::v5::property::wildcard_subscription_available, mqtt::v5::property::subscription_identifier_available, mqtt::v5::property::shared_subscription_available}; typename Visitor::result_type = void]â€™
/usr/include/boost/variant/detail/apply_visitor_unary.hpp:137:74:   required from â€˜decltype(auto) boost::apply_visitor(Visitor&&, Visitable&&, typename boost::disable_if<boost::detail::variant::has_result_type<Visitor> >::type*) [with Visitor = mqtt::lambda_visitor<mqtt::broker::broker_t::publish_handler(mqtt::broker::con_sp_t, boost::optional<short unsigned int>, mqtt::publish_options, mqtt::buffer, mqtt::buffer, mqtt::v5::properties)::<lambda(mqtt::v5::property::topic_alias&&)>, mqtt::broker::broker_t::publish_handler(mqtt::broker::con_sp_t, boost::optional<short unsigned int>, mqtt::publish_options, mqtt::buffer, mqtt::buffer, mqtt::v5::properties)::<lambda(mqtt::v5::property::subscription_identifier&&)>, mqtt::broker::broker_t::publish_handler(mqtt::broker::con_sp_t, boost::optional<short unsigned int>, mqtt::publish_options, mqtt::buffer, mqtt::buffer, mqtt::v5::properties)::<lambda(auto:131&&)> >; Visitable = boost::variant<mqtt::v5::property::payload_format_indicator, mqtt::v5::property::message_expiry_interval, mqtt::v5::property::content_type, mqtt::v5::property::response_topic, mqtt::v5::property::correlation_data, mqtt::v5::property::subscription_identifier, mqtt::v5::property::session_expiry_interval, mqtt::v5::property::assigned_client_identifier, mqtt::v5::property::server_keep_alive, mqtt::v5::property::authentication_method, mqtt::v5::property::authentication_data, mqtt::v5::property::request_problem_information, mqtt::v5::property::will_delay_interval, mqtt::v5::property::request_response_information, mqtt::v5::property::response_information, mqtt::v5::property::server_reference, mqtt::v5::property::reason_string, mqtt::v5::property::receive_maximum, mqtt::v5::property::topic_alias_maximum, mqtt::v5::property::topic_alias, mqtt::v5::property::maximum_qos, mqtt::v5::property::retain_available, mqtt::v5::property::user_property, mqtt::v5::property::maximum_packet_size, mqtt::v5::property::wildcard_subscription_available, mqtt::v5::property::subscription_identifier_available, mqtt::v5::property::shared_subscription_available>; typename boost::disable_if<boost::detail::variant::has_result_type<Visitor> >::type = void]â€™
/home/kleunen/mqtt_cpp/include/mqtt/variant.hpp:62:32:   required from â€˜constexpr decltype(auto) mqtt::visit(Visitor&&, Variants&& ...) [with Visitor = mqtt::lambda_visitor<mqtt::broker::broker_t::publish_handler(mqtt::broker::con_sp_t, boost::optional<short unsigned int>, mqtt::publish_options, mqtt::buffer, mqtt::buffer, mqtt::v5::properties)::<lambda(mqtt::v5::property::topic_alias&&)>, mqtt::broker::broker_t::publish_handler(mqtt::broker::con_sp_t, boost::optional<short unsigned int>, mqtt::publish_options, mqtt::buffer, mqtt::buffer, mqtt::v5::properties)::<lambda(mqtt::v5::property::subscription_identifier&&)>, mqtt::broker::broker_t::publish_handler(mqtt::broker::con_sp_t, boost::optional<short unsigned int>, mqtt::publish_options, mqtt::buffer, mqtt::buffer, mqtt::v5::properties)::<lambda(auto:131&&)> >; Variants = {boost::variant<mqtt::v5::property::payload_format_indicator, mqtt::v5::property::message_expiry_interval, mqtt::v5::property::content_type, mqtt::v5::property::response_topic, mqtt::v5::property::correlation_data, mqtt::v5::property::subscription_identifier, mqtt::v5::property::session_expiry_interval, mqtt::v5::property::assigned_client_identifier, mqtt::v5::property::server_keep_alive, mqtt::v5::property::authentication_method, mqtt::v5::property::authentication_data, mqtt::v5::property::request_problem_information, mqtt::v5::property::will_delay_interval, mqtt::v5::property::request_response_information, mqtt::v5::property::response_information, mqtt::v5::property::server_reference, mqtt::v5::property::reason_string, mqtt::v5::property::receive_maximum, mqtt::v5::property::topic_alias_maximum, mqtt::v5::property::topic_alias, mqtt::v5::property::maximum_qos, mqtt::v5::property::retain_available, mqtt::v5::property::user_property, mqtt::v5::property::maximum_packet_size, mqtt::v5::property::wildcard_subscription_available, mqtt::v5::property::subscription_identifier_available, mqtt::v5::property::shared_subscription_available>}]â€™
/home/kleunen/mqtt_cpp/include/mqtt/broker/broker.hpp:1541:13:   required from here
/usr/include/boost/thread/detail/move.hpp:51:16: error: forming pointer to reference type â€˜mqtt::v5::property::payload_format_indicator&â€™
   51 |             T* operator->() const
      |                ^~~~~~~~
make[2]: *** [example/CMakeFiles/broker.dir/build.make:63: example/CMakeFiles/broker.dir/broker.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1909: example/CMakeFiles/broker.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
````

It seems an rvalue is being 'force_moved', is that correct ? 