### PR TITLE
UPdated publish related api log level from info to trace.

### DIFF
--- a/include/mqtt/endpoint.hpp
+++ b/include/mqtt/endpoint.hpp
@@ -1136,7 +1136,7 @@ public:
         v5::properties props = {},
         any life_keeper = {}
     ) {
-        MQTT_LOG("mqtt_api", info)
+        MQTT_LOG("mqtt_api", trace)
             << MQTT_ADD_VALUE(address, this)
             << "publish"
             << " pid:" << packet_id
@@ -1212,7 +1212,7 @@ public:
         v5::properties props,
         any life_keeper
     ) {
-        MQTT_LOG("mqtt_api", info)
+        MQTT_LOG("mqtt_api", trace)
             << MQTT_ADD_VALUE(address, this)
             << "publish"
             << " pid:" << packet_id
@@ -1265,7 +1265,7 @@ public:
         publish_options pubopts,
         any life_keeper
     ) {
-        MQTT_LOG("mqtt_api", info)
+        MQTT_LOG("mqtt_api", trace)
             << MQTT_ADD_VALUE(address, this)
             << "publish"
             << " pid:" << packet_id
@@ -1320,7 +1320,7 @@ public:
         publish_options pubopts = {},
         any life_keeper = {}
     ) {
-        MQTT_LOG("mqtt_api", info)
+        MQTT_LOG("mqtt_api", trace)
             << MQTT_ADD_VALUE(address, this)
             << "publish"
             << " pid:" << packet_id
@@ -1394,7 +1394,7 @@ public:
         v5::properties props,
         any life_keeper = {}
     ) {
-        MQTT_LOG("mqtt_api", info)
+        MQTT_LOG("mqtt_api", trace)
             << MQTT_ADD_VALUE(address, this)
             << "publish"
             << " pid:" << packet_id
@@ -1952,7 +1952,7 @@ public:
         v5::puback_reason_code reason_code = v5::puback_reason_code::success,
         v5::properties props = {}
     ) {
-        MQTT_LOG("mqtt_api", info)
+        MQTT_LOG("mqtt_api", trace)
             << MQTT_ADD_VALUE(address, this)
             << "puback"
             << " pid:" << packet_id
@@ -1978,7 +1978,7 @@ public:
         v5::pubrec_reason_code reason_code = v5::pubrec_reason_code::success,
         v5::properties props = {}
     ) {
-        MQTT_LOG("mqtt_api", info)
+        MQTT_LOG("mqtt_api", trace)
             << MQTT_ADD_VALUE(address, this)
             << "pubrec"
             << " pid:" << packet_id
@@ -2012,7 +2012,7 @@ public:
         v5::properties props = {},
         any life_keeper = {}
     ) {
-        MQTT_LOG("mqtt_api", info)
+        MQTT_LOG("mqtt_api", trace)
             << MQTT_ADD_VALUE(address, this)
             << "pubrel"
             << " pid:" << packet_id
@@ -2038,7 +2038,7 @@ public:
         v5::pubcomp_reason_code reason_code = v5::pubcomp_reason_code::success,
         v5::properties props = {}
     ) {
-        MQTT_LOG("mqtt_api", info)
+        MQTT_LOG("mqtt_api", trace)
             << MQTT_ADD_VALUE(address, this)
             << "pubcomp"
             << " pid:" << packet_id
@@ -2357,7 +2357,7 @@ public:
         publish_options pubopts = {},
         async_handler_t func = {}
     ) {
-        MQTT_LOG("mqtt_api", info)
+        MQTT_LOG("mqtt_api", trace)
             << MQTT_ADD_VALUE(address, this)
             << "async_publish"
             << " pid:" << packet_id
@@ -2420,7 +2420,7 @@ public:
         any life_keeper = {},
         async_handler_t func = {}
     ) {
-        MQTT_LOG("mqtt_api", info)
+        MQTT_LOG("mqtt_api", trace)
             << MQTT_ADD_VALUE(address, this)
             << "async_publish"
             << " pid:" << packet_id
@@ -2486,7 +2486,7 @@ public:
         any life_keeper = {},
         async_handler_t func = {}
     ) {
-        MQTT_LOG("mqtt_api", info)
+        MQTT_LOG("mqtt_api", trace)
             << MQTT_ADD_VALUE(address, this)
             << "async_publish"
             << " pid:" << packet_id
@@ -2544,7 +2544,7 @@ public:
         any life_keeper = {},
         async_handler_t func = {}
     ) {
-        MQTT_LOG("mqtt_api", info)
+        MQTT_LOG("mqtt_api", trace)
             << MQTT_ADD_VALUE(address, this)
             << "async_publish"
             << " pid:" << packet_id
@@ -2597,7 +2597,7 @@ public:
         any life_keeper = {},
         async_handler_t func = {}
     ) {
-        MQTT_LOG("mqtt_api", info)
+        MQTT_LOG("mqtt_api", trace)
             << MQTT_ADD_VALUE(address, this)
             << "async_publish"
             << " pid:" << packet_id
@@ -2675,7 +2675,7 @@ public:
         any life_keeper = {},
         async_handler_t func = {}
     ) {
-        MQTT_LOG("mqtt_api", info)
+        MQTT_LOG("mqtt_api", trace)
             << MQTT_ADD_VALUE(address, this)
             << "async_publish"
             << " pid:" << packet_id
@@ -3831,7 +3831,7 @@ public:
         packet_id_t packet_id,
         async_handler_t func = {}
     ) {
-        MQTT_LOG("mqtt_api", info)
+        MQTT_LOG("mqtt_api", trace)
             << MQTT_ADD_VALUE(address, this)
             << "async_puback"
             << " pid:" << packet_id;
@@ -3860,7 +3860,7 @@ public:
         v5::properties props,
         async_handler_t func = {}
     ) {
-        MQTT_LOG("mqtt_api", info)
+        MQTT_LOG("mqtt_api", trace)
             << MQTT_ADD_VALUE(address, this)
             << "async_puback"
             << " pid:" << packet_id
@@ -3880,7 +3880,7 @@ public:
         packet_id_t packet_id,
         async_handler_t func = {}
     ) {
-        MQTT_LOG("mqtt_api", info)
+        MQTT_LOG("mqtt_api", trace)
             << MQTT_ADD_VALUE(address, this)
             << "async_pubrec"
             << " pid:" << packet_id;
@@ -3909,7 +3909,7 @@ public:
         v5::properties props,
         async_handler_t func = {}
     ) {
-        MQTT_LOG("mqtt_api", info)
+        MQTT_LOG("mqtt_api", trace)
             << MQTT_ADD_VALUE(address, this)
             << "async_pubrec"
             << " pid:" << packet_id
@@ -3929,7 +3929,7 @@ public:
         packet_id_t packet_id,
         async_handler_t func = {}
     ) {
-        MQTT_LOG("mqtt_api", info)
+        MQTT_LOG("mqtt_api", trace)
             << MQTT_ADD_VALUE(address, this)
             << "async_pubrel"
             << " pid:" << packet_id;
@@ -3965,7 +3965,7 @@ public:
         v5::properties props = {},
         Func&& func = {}
     ) {
-        MQTT_LOG("mqtt_api", info)
+        MQTT_LOG("mqtt_api", trace)
             << MQTT_ADD_VALUE(address, this)
             << "async_pubrel"
             << " pid:" << packet_id
@@ -4004,7 +4004,7 @@ public:
         any life_keeper = {},
         async_handler_t func = {}
     ) {
-        MQTT_LOG("mqtt_api", info)
+        MQTT_LOG("mqtt_api", trace)
             << MQTT_ADD_VALUE(address, this)
             << "async_pubrel"
             << " pid:" << packet_id
@@ -4024,7 +4024,7 @@ public:
         packet_id_t packet_id,
         async_handler_t func = {}
     ) {
-        MQTT_LOG("mqtt_api", info)
+        MQTT_LOG("mqtt_api", trace)
             << MQTT_ADD_VALUE(address, this)
             << "async_pubcomp"
             << " pid:" << packet_id;
@@ -4053,7 +4053,7 @@ public:
         v5::properties props,
         async_handler_t func = {}
     ) {
-        MQTT_LOG("mqtt_api", info)
+        MQTT_LOG("mqtt_api", trace)
             << MQTT_ADD_VALUE(address, this)
             << "async_pubcomp"
             << " pid:" << packet_id

--- a/include/mqtt/setup_log.hpp
+++ b/include/mqtt/setup_log.hpp
@@ -25,6 +25,15 @@ namespace MQTT_NS {
 
 #if defined(MQTT_USE_LOG)
 
+static constexpr char const* log_color_table[] {
+    "\033[0m", // trace
+    "\033[36m", // debug
+    "\033[32m", // info
+    "\033[33m", // warning
+    "\033[35m", // error
+    "\033[31m", // fatal
+};
+
 /**
  * @brief Setup logging
  * @param threshold
@@ -54,6 +63,7 @@ void setup_log(std::map<std::string, severity_level> threshold) {
             }
             // Adjust severity length example
             if (auto v = boost::log::extract<severity_level>("Severity", rec)) {
+                strm << log_color_table[static_cast<std::size_t>(v.get())];
                 strm << "S:" << std::setw(7) << std::left << v.get() << " ";
             }
             if (auto v = boost::log::extract<channel>("Channel", rec)) {
@@ -76,6 +86,7 @@ void setup_log(std::map<std::string, severity_level> threshold) {
             }
 #endif
             strm << rec[boost::log::expressions::smessage];
+            strm << "\033[0m";
         };
 
     // https://www.boost.org/doc/libs/1_73_0/libs/log/doc/html/log/tutorial/sinks.html


### PR DESCRIPTION
Log level info was not so useful because logs are output too much.
connect, subscribe/unsubecribe, etc are status change.
If doesn't happen so often, in typical usecase, it happens after
connection.
On the contrary, publish, puback, pubrec, pubrel, and pubcomp happens
flequenty.
So I updated the log level.

NOTE: pingreq/pingresp has already trace log level.