### PR TITLE
Removed async_force_disconnect() call from session_state.

### DIFF
--- a/include/mqtt/broker/session_state.hpp
+++ b/include/mqtt/broker/session_state.hpp
@@ -302,7 +302,6 @@ struct session_state {
         }
         shared_targets_.erase(*this);
         unsubscribe_all();
-        if (con_) con_->async_force_disconnect();
     }
 
     template <typename PublishRetainHandler>


### PR DESCRIPTION
async_force_disconnect() was called twice from the broker side  on
disconnection.
One is broker.hpp, the other is session_state.hpp
The latter isn't needed.