### PR TITLE
Do not include Boost.Log related headers when MQTT_USE_LOG is off

### DIFF
--- a/example/bench.cpp
+++ b/example/bench.cpp
@@ -10,6 +10,7 @@
 
 #include <thread>
 #include <fstream>
+#include <iostream>
 
 #include <boost/program_options.hpp>
 #include <boost/format.hpp>

--- a/example/broker.cpp
+++ b/example/broker.cpp
@@ -10,6 +10,8 @@
 #include <boost/format.hpp>
 
 #include <fstream>
+#include <iostream>
+#include <iomanip>
 #include <algorithm>
 
 namespace as = boost::asio;

--- a/example/client_cli.cpp
+++ b/example/client_cli.cpp
@@ -6,6 +6,7 @@
 
 #include <iostream>
 #include <iomanip>
+#include <fstream>
 
 #include <boost/program_options.hpp>
 #include <boost/format.hpp>

--- a/example/client_cli.cpp
+++ b/example/client_cli.cpp
@@ -5,6 +5,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #include <iostream>
+#include <iomanip>
 
 #include <boost/program_options.hpp>
 #include <boost/format.hpp>

--- a/include/mqtt/broker/retained_topic_map.hpp
+++ b/include/mqtt/broker/retained_topic_map.hpp
@@ -7,6 +7,8 @@
 #if !defined(MQTT_BROKER_RETAINED_TOPIC_MAP_HPP)
 #define MQTT_BROKER_RETAINED_TOPIC_MAP_HPP
 
+#include <deque>
+
 #include <boost/functional/hash.hpp>
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/ordered_index.hpp>

--- a/include/mqtt/log.hpp
+++ b/include/mqtt/log.hpp
@@ -28,7 +28,7 @@
 #include <boost/preprocessor/cat.hpp>
 #include <boost/preprocessor/comparison/greater_equal.hpp>
 
-#endif
+#endif // defined(MQTT_USE_LOG)
 
 #include <mqtt/namespace.hpp>
 

--- a/include/mqtt/log.hpp
+++ b/include/mqtt/log.hpp
@@ -7,7 +7,11 @@
 #if !defined(MQTT_LOG_HPP)
 #define MQTT_LOG_HPP
 
-#include <tuple>
+#include <cstddef>
+#include <ostream>
+#include <string>
+
+#if defined(MQTT_USE_LOG)
 
 #include <boost/log/core.hpp>
 #include <boost/log/attributes.hpp>
@@ -24,11 +28,11 @@
 #include <boost/preprocessor/cat.hpp>
 #include <boost/preprocessor/comparison/greater_equal.hpp>
 
+#endif
+
 #include <mqtt/namespace.hpp>
 
 namespace MQTT_NS {
-
-namespace log = boost::log;
 
 struct channel : std::string {
     using std::string::string;
@@ -72,7 +76,7 @@ inline constexpr null_log const& operator<<(null_log const& o, T const&) { retur
 
 // template arguments are defined in MQTT_NS
 // filter and formatter can distinguish mqtt_cpp's channel and severity by their types
-using global_logger_t = log::sources::severity_channel_logger<severity_level, channel>;
+using global_logger_t = boost::log::sources::severity_channel_logger<severity_level, channel>;
 inline global_logger_t& logger() {
     thread_local global_logger_t l;
     return l;

--- a/include/mqtt/setup_log.hpp
+++ b/include/mqtt/setup_log.hpp
@@ -15,11 +15,16 @@
 // setup_log() could be  a good reference for your own logging setup code.
 
 #include <mqtt/namespace.hpp>
+
+#if defined(MQTT_USE_LOG)
+
 #include <mqtt/log.hpp>
 #include <mqtt/move.hpp>
 
 #include <boost/filesystem.hpp>
 #include <boost/date_time/posix_time/posix_time_io.hpp>
+
+#endif
 
 namespace MQTT_NS {
 

--- a/include/mqtt/setup_log.hpp
+++ b/include/mqtt/setup_log.hpp
@@ -15,10 +15,10 @@
 // setup_log() could be  a good reference for your own logging setup code.
 
 #include <mqtt/namespace.hpp>
+#include <mqtt/log.hpp>
 
 #if defined(MQTT_USE_LOG)
 
-#include <mqtt/log.hpp>
 #include <mqtt/move.hpp>
 
 #include <boost/filesystem.hpp>

--- a/include/mqtt/setup_log.hpp
+++ b/include/mqtt/setup_log.hpp
@@ -24,7 +24,7 @@
 #include <boost/filesystem.hpp>
 #include <boost/date_time/posix_time/posix_time_io.hpp>
 
-#endif
+#endif // defined(MQTT_USE_LOG)
 
 namespace MQTT_NS {
 


### PR DESCRIPTION
## What

Avoid including headers that are only needed when MQTT_USE_LOG is enabled.

## Why

Reduce the compile times and avoid unexpected linkage with Boost.Log libraries (e.g. when Boost auto-link is enabled).

## Background 

I am happy that mqtt_cpp provides such log customization option. I used it to adapt [spdlog](https://github.com/gabime/spdlog). The code for it here as a reference for other users:

mqttCpp.h:

```cpp
#pragma once

#include <boost/preprocessor/cat.hpp>
#include <boost/preprocessor/comparison/greater_equal.hpp>
#include <boost/preprocessor/if.hpp>
#include <spdlog/common.h>

#include <source_location>
#include <sstream>
#include <string_view>

#define MQTT_NS mqtt_cpp

// forward declare mqtt_cpp severity_level
namespace mqtt_cpp
{
enum class severity_level;
}  // namespace mqtt_cpp

namespace my_app
{
struct MqttNullLogAdapter
{
};

template <class T>
constexpr MqttNullLogAdapter operator<<(MqttNullLogAdapter, const T&) noexcept
{
    return {};
}

struct MqttLogAdapter
{
    std::string_view channel;
    mqtt_cpp::severity_level severity;
    std::source_location location;
    std::ostringstream stream;

    explicit MqttLogAdapter(std::string_view channel, mqtt_cpp::severity_level severity,
                            std::source_location location = std::source_location::current())
        : channel(channel), severity(severity), location(location)
    {
    }

    ~MqttLogAdapter();

    template <class T>
    friend MqttLogAdapter&& operator<<(MqttLogAdapter&& self, const T& t);
};

struct MqttLogOstreamNotImplemented
{
};
}  // namespace my_app

#define MY_APP_MQTT_SEVERITY_SPDLOG_LEVEL_trace SPDLOG_LEVEL_TRACE
#define MY_APP_MQTT_SEVERITY_SPDLOG_LEVEL_debug SPDLOG_LEVEL_DEBUG
#define MY_APP_MQTT_SEVERITY_SPDLOG_LEVEL_info SPDLOG_LEVEL_INFO
#define MY_APP_MQTT_SEVERITY_SPDLOG_LEVEL_warning SPDLOG_LEVEL_WARN
#define MY_APP_MQTT_SEVERITY_SPDLOG_LEVEL_error SPDLOG_LEVEL_ERROR
#define MY_APP_MQTT_SEVERITY_SPDLOG_LEVEL_fatal SPDLOG_LEVEL_CRITICAL

#define MY_APP_MQTT_SEVERITY_TO_SPDLOG_LEVEL(lv) BOOST_PP_CAT(MY_APP_MQTT_SEVERITY_SPDLOG_LEVEL_, lv)

#define MQTT_LOG(chan, sev)                                                                              \
    BOOST_PP_IF(BOOST_PP_GREATER_EQUAL(MY_APP_MQTT_SEVERITY_TO_SPDLOG_LEVEL(sev), SPDLOG_ACTIVE_LEVEL), \
                ::my_app::MqttLogAdapter(chan, MQTT_NS::severity_level::sev),                     \
                ::my_app::MqttNullLogAdapter())

#define MQTT_ADD_VALUE(name, val) ::my_app::MqttLogOstreamNotImplemented()

// Add mqtt_cpp library includes here
#include <mqtt_client_cpp.hpp>

namespace my_app
{
template <class T>
MqttLogAdapter&& operator<<(MqttLogAdapter&& self, const T& t)
{
    if constexpr (!std::is_same_v<mqtt::MqttLogOstreamNotImplemented, T>)
    {
        self.stream << t;
    }
    return std::move(self);
}
}  // namespace my_app
```

mqttCpp.cpp

```cpp
#include "mqttCpp.h"

#include <spdlog/spdlog.h>

namespace my_app
{
MqttLogAdapter::~MqttLogAdapter()
{
    const auto spdlog_level = [&]
    {
        if (mqtt_cpp::severity_level::trace == severity)
        {
            return spdlog::level::trace;
        }
        if (mqtt_cpp::severity_level::debug == severity)
        {
            return spdlog::level::debug;
        }
        if (mqtt_cpp::severity_level::info == severity)
        {
            return spdlog::level::info;
        }
        if (mqtt_cpp::severity_level::warning == severity)
        {
            return spdlog::level::warn;
        }
        if (mqtt_cpp::severity_level::error == severity)
        {
            return spdlog::level::err;
        }
        if (mqtt_cpp::severity_level::fatal == severity)
        {
            return spdlog::level::critical;
        }
        return spdlog::level::off;
    }();
    spdlog::default_logger_raw()->log(
        spdlog::source_loc{location.file_name(), static_cast<int>(location.line()), location.function_name()},
        spdlog_level, "{}: {}", channel, stream.view());
}
}  // namespace my_app
```