### PR TITLE
Improve MQTT_STD_XXX behavior

### DIFF
--- a/include/mqtt/broker/retained_topic_map.hpp
+++ b/include/mqtt/broker/retained_topic_map.hpp
@@ -358,7 +358,7 @@ public:
     void dump(Output &out) {
         auto const& direct_index = map.template get<direct_index_tag>();
         for (auto const& i : direct_index) {
-            out << i.parent_id << " " << i.name << " " << (i.value ? "init" : "-") << " " << i.count << std::endl;
+            out << i.parent_id << " " << i.name << " " << (i.value ? "init" : "-") << " " << i.count << '\n';
         }
     }
 

--- a/include/mqtt/broker/security.hpp
+++ b/include/mqtt/broker/security.hpp
@@ -596,12 +596,7 @@ struct security {
                 append_result(
                     make_string_view(
                         subscription_begin,
-                        static_cast<size_t>(
-                            std::distance(
-                                subscription_begin,
-                                subscription_filter.end()
-                            )
-                        )
+                        subscription_filter.end()
                     )
                 );
                 return result;
@@ -609,12 +604,7 @@ struct security {
 
             auto sub = make_string_view(
                 subscription_begin,
-                static_cast<size_t>(
-                    std::distance(
-                        subscription_begin,
-                        subscription_next
-                    )
-                )
+                subscription_next
             );
 
             if (is_hash(sub)) {

--- a/include/mqtt/broker/security.hpp
+++ b/include/mqtt/broker/security.hpp
@@ -19,7 +19,6 @@
 
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
-#include <boost/optional.hpp>
 #include <boost/iterator/function_output_iterator.hpp>
 
 #include <boost/algorithm/hex.hpp>
@@ -595,7 +594,7 @@ struct security {
 
             if (is_hash(auth)) {
                 append_result(
-                    string_view(
+                    make_string_view(
                         subscription_begin,
                         static_cast<size_t>(
                             std::distance(
@@ -608,7 +607,7 @@ struct security {
                 return result;
             }
 
-            auto sub = string_view(
+            auto sub = make_string_view(
                 subscription_begin,
                 static_cast<size_t>(
                     std::distance(

--- a/include/mqtt/broker/topic_filter.hpp
+++ b/include/mqtt/broker/topic_filter.hpp
@@ -43,7 +43,7 @@ inline std::size_t topic_filter_tokenizer(string_view str, Output write) {
         std::end(str),
         [&write](string_view::const_iterator token_begin, string_view::const_iterator token_end) {
             return write(
-                string_view(
+                make_string_view(
                     token_begin,
                     static_cast<std::size_t>(std::distance(token_begin, token_end)))
             );

--- a/include/mqtt/broker/topic_filter.hpp
+++ b/include/mqtt/broker/topic_filter.hpp
@@ -45,7 +45,8 @@ inline std::size_t topic_filter_tokenizer(string_view str, Output write) {
             return write(
                 make_string_view(
                     token_begin,
-                    static_cast<std::size_t>(std::distance(token_begin, token_end)))
+                    token_end
+                )
             );
         }
     );

--- a/include/mqtt/endpoint.hpp
+++ b/include/mqtt/endpoint.hpp
@@ -19,7 +19,6 @@
 #include <atomic>
 #include <algorithm>
 
-#include <boost/any.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/asio.hpp>
 #include <boost/lexical_cast.hpp>
@@ -149,7 +148,7 @@ constexpr bool check_qos_value(publish_options pubopts) {
 
 template<typename ... Params>
 constexpr bool should_generate_packet_id(Params const& ... params) {
-#if __cplusplus >= 201703L // C++20 date is not determined yet
+#if __cplusplus >= 201703L
     return (check_qos_value(params) || ...); // defaults to false for empty.
 #else  // __cplusplus >= 201703L
     const bool results[] = {false, check_qos_value(params)... };

--- a/include/mqtt/shared_ptr_array.hpp
+++ b/include/mqtt/shared_ptr_array.hpp
@@ -48,9 +48,9 @@ using const_shared_ptr_array = std::shared_ptr<char const []>;
 
 inline shared_ptr_array make_shared_ptr_array(std::size_t size) {
 #ifdef __cpp_lib_shared_ptr_arrays
-#if __cpp_lib_shared_ptr_arrays >= 201711L
+#if __cpp_lib_shared_ptr_arrays >= 201707L
 #define MQTT_HAS_STD_MAKE_SHARED_ARRAY
-#endif // __cpp_lib_shared_ptr_arrays >= 201711L
+#endif // __cpp_lib_shared_ptr_arrays >= 201707L
 #endif // __cpp_lib_shared_ptr_arrays
 #ifdef MQTT_HAS_STD_MAKE_SHARED_ARRAY
     return std::make_shared<char[]>(size);

--- a/include/mqtt/shared_ptr_array.hpp
+++ b/include/mqtt/shared_ptr_array.hpp
@@ -47,17 +47,11 @@ using shared_ptr_array = std::shared_ptr<char []>;
 using const_shared_ptr_array = std::shared_ptr<char const []>;
 
 inline shared_ptr_array make_shared_ptr_array(std::size_t size) {
-#ifdef __cpp_lib_shared_ptr_arrays
 #if __cpp_lib_shared_ptr_arrays >= 201707L
-#define MQTT_HAS_STD_MAKE_SHARED_ARRAY
-#endif // __cpp_lib_shared_ptr_arrays >= 201707L
-#endif // __cpp_lib_shared_ptr_arrays
-#ifdef MQTT_HAS_STD_MAKE_SHARED_ARRAY
     return std::make_shared<char[]>(size);
-#undef MQTT_HAS_STD_MAKE_SHARED_ARRAY
-#else  // MQTT_HAS_STD_MAKE_SHARED_ARRAY
+#else  // __cpp_lib_shared_ptr_arrays >= 201707L
     return std::shared_ptr<char[]>(new char[size]);
-#endif // MQTT_HAS_STD_MAKE_SHARED_ARRAY
+#endif // __cpp_lib_shared_ptr_arrays >= 201707L
 }
 
 } // namespace MQTT_NS

--- a/include/mqtt/shared_ptr_array.hpp
+++ b/include/mqtt/shared_ptr_array.hpp
@@ -47,11 +47,17 @@ using shared_ptr_array = std::shared_ptr<char []>;
 using const_shared_ptr_array = std::shared_ptr<char const []>;
 
 inline shared_ptr_array make_shared_ptr_array(std::size_t size) {
-#if __cplusplus > 201703L // C++20 date is not determined yet
+#ifdef __cpp_lib_shared_ptr_arrays
+#if __cpp_lib_shared_ptr_arrays >= 201711L
+#define MQTT_HAS_STD_MAKE_SHARED_ARRAY
+#endif // __cpp_lib_shared_ptr_arrays >= 201711L
+#endif // __cpp_lib_shared_ptr_arrays
+#ifdef MQTT_HAS_STD_MAKE_SHARED_ARRAY
     return std::make_shared<char[]>(size);
-#else  // __cplusplus > 201703L
+#undef MQTT_HAS_STD_MAKE_SHARED_ARRAY
+#else  // MQTT_HAS_STD_MAKE_SHARED_ARRAY
     return std::shared_ptr<char[]>(new char[size]);
-#endif // __cplusplus > 201703L
+#endif // MQTT_HAS_STD_MAKE_SHARED_ARRAY
 }
 
 } // namespace MQTT_NS

--- a/include/mqtt/string_view.hpp
+++ b/include/mqtt/string_view.hpp
@@ -19,6 +19,12 @@ using std::string_view;
 
 using std::basic_string_view;
 
+// Make string_view from a pair of iterators (pre C++20)
+template<class Begin, class End>
+string_view make_string_view(Begin&& begin, End&& end) {
+    return string_view(std::forward<Begin>(begin).operator->(), std::forward<End>(end));
+}
+
 } // namespace MQTT_NS
 
 #else  // MQTT_STD_STRING_VIEW
@@ -40,6 +46,11 @@ using string_view = boost::string_view;
 
 template<class CharT, class Traits = std::char_traits<CharT> >
 using basic_string_view = boost::basic_string_view<CharT, Traits>;
+
+template<class Begin, class End>
+string_view make_string_view(Begin&& begin, End&& end) {
+    return string_view(std::forward<Begin>(begin), std::forward<End>(end));
+}
 
 } // namespace MQTT_NS
 
@@ -65,6 +76,11 @@ using string_view = boost::string_ref;
 
 template<class CharT, class Traits = std::char_traits<CharT> >
 using basic_string_view = boost::basic_string_ref<CharT, Traits>;
+
+template<class Begin, class End>
+string_view make_string_view(Begin&& begin, End&& end) {
+    return string_view(std::forward<Begin>(begin), std::forward<End>(end));
+}
 
 } // namespace MQTT_NS
 

--- a/include/mqtt/string_view.hpp
+++ b/include/mqtt/string_view.hpp
@@ -35,10 +35,11 @@ auto to_address(const T& p) noexcept
 
 } // namespace detail
 
-// Make string_view from a pair of iterators (pre C++20)
-template<class Begin, class End>
-string_view make_string_view(Begin begin, End end) {
-    return string_view(detail::to_address(begin), static_cast<string_view::size_type>(end - begin));
+// Make string_view from a potentially fancy iterator and a size. This is a common mistake when 
+// using compilers like GCC which by default define std::string_view::iterator as char*.
+template<class Begin>
+string_view make_string_view(Begin begin, string_view::size_type size) {
+    return string_view(detail::to_address(begin), size);
 }
 
 } // namespace MQTT_NS
@@ -63,9 +64,9 @@ using string_view = boost::string_view;
 template<class CharT, class Traits = std::char_traits<CharT> >
 using basic_string_view = boost::basic_string_view<CharT, Traits>;
 
-template<class Begin, class End>
-string_view make_string_view(Begin&& begin, End&& end) {
-    return string_view(std::forward<Begin>(begin), std::forward<End>(end));
+template<class Begin>
+string_view make_string_view(Begin&& begin, string_view::size_type size) {
+    return string_view(std::forward<Begin>(begin), size);
 }
 
 } // namespace MQTT_NS
@@ -93,9 +94,9 @@ using string_view = boost::string_ref;
 template<class CharT, class Traits = std::char_traits<CharT> >
 using basic_string_view = boost::basic_string_ref<CharT, Traits>;
 
-template<class Begin, class End>
-string_view make_string_view(Begin&& begin, End&& end) {
-    return string_view(std::forward<Begin>(begin), std::forward<End>(end));
+template<class Begin>
+string_view make_string_view(Begin&& begin, string_view::size_type size) {
+    return string_view(std::forward<Begin>(begin), size);
 }
 
 } // namespace MQTT_NS

--- a/include/mqtt/string_view.hpp
+++ b/include/mqtt/string_view.hpp
@@ -7,6 +7,8 @@
 #if !defined(MQTT_STRING_VIEW_HPP)
 #define MQTT_STRING_VIEW_HPP
 
+#include <iterator>
+
 #include <mqtt/namespace.hpp>
 
 #ifdef MQTT_STD_STRING_VIEW
@@ -18,29 +20,6 @@ namespace MQTT_NS {
 using std::string_view;
 
 using std::basic_string_view;
-
-namespace detail {
-    
-template<class T>
-T* to_address(T* p) noexcept
-{
-    return p;
-}
- 
-template<class T>
-auto to_address(const T& p) noexcept
-{
-    return detail::to_address(p.operator->());
-}
-
-} // namespace detail
-
-// Make string_view from a potentially fancy iterator and a size. This is a common mistake when 
-// using compilers like GCC which by default define std::string_view::iterator as char*.
-template<class Begin>
-string_view make_string_view(Begin begin, string_view::size_type size) {
-    return string_view(detail::to_address(begin), size);
-}
 
 } // namespace MQTT_NS
 
@@ -63,11 +42,6 @@ using string_view = boost::string_view;
 
 template<class CharT, class Traits = std::char_traits<CharT> >
 using basic_string_view = boost::basic_string_view<CharT, Traits>;
-
-template<class Begin>
-string_view make_string_view(Begin&& begin, string_view::size_type size) {
-    return string_view(std::forward<Begin>(begin), size);
-}
 
 } // namespace MQTT_NS
 
@@ -94,11 +68,6 @@ using string_view = boost::string_ref;
 template<class CharT, class Traits = std::char_traits<CharT> >
 using basic_string_view = boost::basic_string_ref<CharT, Traits>;
 
-template<class Begin>
-string_view make_string_view(Begin&& begin, string_view::size_type size) {
-    return string_view(std::forward<Begin>(begin), size);
-}
-
 } // namespace MQTT_NS
 
 #endif // BOOST_VERSION >= 106100
@@ -107,5 +76,31 @@ string_view make_string_view(Begin&& begin, string_view::size_type size) {
 #endif // !defined(MQTT_NO_BOOST_STRING_VIEW)
 
 #endif // !defined(MQTT_STD_STRING_VIEW)
+
+namespace MQTT_NS {
+
+namespace detail {
+    
+template<class T>
+T* to_address(T* p) noexcept
+{
+    return p;
+}
+ 
+template<class T>
+auto to_address(const T& p) noexcept
+{
+    return detail::to_address(p.operator->());
+}
+
+} // namespace detail
+
+// Make a string_view from a pair of iterators.
+template<typename Begin, typename End>
+string_view make_string_view(Begin begin, End end) {
+    return string_view(detail::to_address(begin), static_cast<string_view::size_type>(std::distance(begin, end)));
+}
+
+} // namespace MQTT_NS
 
 #endif // MQTT_STRING_VIEW_HPP

--- a/include/mqtt/string_view.hpp
+++ b/include/mqtt/string_view.hpp
@@ -19,10 +19,26 @@ using std::string_view;
 
 using std::basic_string_view;
 
+namespace detail {
+    
+template<class T>
+T* to_address(T* p) noexcept
+{
+    return p;
+}
+ 
+template<class T>
+auto to_address(const T& p) noexcept
+{
+    return detail::to_address(p.operator->());
+}
+
+} // namespace detail
+
 // Make string_view from a pair of iterators (pre C++20)
 template<class Begin, class End>
-string_view make_string_view(Begin&& begin, End&& end) {
-    return string_view(std::forward<Begin>(begin).operator->(), std::forward<End>(end));
+string_view make_string_view(Begin begin, End end) {
+    return string_view(detail::to_address(begin), static_cast<string_view::size_type>(end - begin));
 }
 
 } // namespace MQTT_NS

--- a/include/mqtt/v5_message.hpp
+++ b/include/mqtt/v5_message.hpp
@@ -14,7 +14,6 @@
 #include <numeric>
 
 #include <boost/asio/buffer.hpp>
-#include <boost/optional.hpp>
 #include <boost/container/static_vector.hpp>
 #include <boost/numeric/conversion/cast.hpp>
 
@@ -37,6 +36,7 @@
 #include <mqtt/packet_id_type.hpp>
 #include <mqtt/move.hpp>
 #include <mqtt/variant_visit.hpp>
+#include <mqtt/optional.hpp>
 
 #if !defined(MQTT_ALWAYS_SEND_REASON_CODE)
 #define MQTT_ALWAYS_SEND_REASON_CODE false


### PR DESCRIPTION
# What

* Do not include Boost variations of std::optional and std::any when their respective MQTT_STD_XXX options are set.
* Do not assume that std::string_view can be constructed from a pair of iterators because that is a C++20 feature.
* Correctly check for support for `std::make_shared<T[]>`. See https://en.cppreference.com/w/cpp/feature_test
* Do not use <iostream> in `retained_topic_map.hpp` just to get access to `std::endl`, use `'\n'` instead.

# Why

Including headers that are not used unnecessarily increases compile times. It is considered good practice to [include only what you use](https://github.com/include-what-you-use/include-what-you-use).
Enabling the MQTT_STD_XXX options should not assume presence of full C++20 support, otherwise a user's application might not compile even if they are using C++17 with access to such std types.
