### PR TITLE
Add define guards to MQTT_LOG macros when MQTT_USE_LOG is off

### DIFF
--- a/include/mqtt/log.hpp
+++ b/include/mqtt/log.hpp
@@ -136,8 +136,17 @@ BOOST_LOG_ATTRIBUTE_KEYWORD(address, "MqttAddress", void const*)
 
 #else  // defined(MQTT_USE_LOG)
 
+#if !defined(MQTT_LOG)
+
 #define MQTT_LOG(chan, sev) MQTT_NS::detail::null_log(chan, MQTT_NS::severity_level::sev)
+
+#endif // !defined(MQTT_LOG)
+
+#if !defined(MQTT_ADD_VALUE)
+
 #define MQTT_ADD_VALUE(name, val) val
+
+#endif // !defined(MQTT_ADD_VALUE)
 
 #endif // defined(MQTT_USE_LOG)
 


### PR DESCRIPTION
These macros should have guards since we expect users to define them themselves in order to customize logging as demonstrated with spdlog in an earlier pull request: https://github.com/redboltz/mqtt_cpp/pull/927.