### PR TITLE
added client support of TLS-SNI extension

### DIFF
--- a/include/mqtt/client.hpp
+++ b/include/mqtt/client.hpp
@@ -1950,16 +1950,16 @@ private:
                             if (func) func(ec);
                             return;
                         }
+
 #if defined(MQTT_USE_TLS)
-                        if constexpr (has_tls<std::decay_t<decltype(*this)>>::value)
-                        {
-                            if (!SSL_set_tlsext_host_name(any_cast<SSL*>(socket_->native_handle()), host_.c_str()))
-                            {
+                        if (has_tls<std::decay_t<decltype(*this)>>::value) {
+                            if (!SSL_set_tlsext_host_name(any_cast<SSL*>(socket_->native_handle()), host_.c_str())) {
                                 if (func) func(boost::system::errc::make_error_code(boost::system::errc::connection_aborted));
                                 return;
                             }
                         }
 #endif // defined(MQTT_USE_TLS)
+
                         base::set_connect();
                         if (ping_duration_ != std::chrono::steady_clock::duration::zero()) {
                             set_timer();

--- a/include/mqtt/client.hpp
+++ b/include/mqtt/client.hpp
@@ -1950,6 +1950,16 @@ private:
                             if (func) func(ec);
                             return;
                         }
+#if defined(MQTT_USE_TLS)
+                        if constexpr (has_tls<std::decay_t<decltype(*this)>>::value)
+                        {
+                            if (!SSL_set_tlsext_host_name(any_cast<SSL*>(socket_->native_handle()), host_.c_str()))
+                            {
+                                if (func) func(boost::system::errc::make_error_code(boost::system::errc::connection_aborted));
+                                return;
+                            }
+                        }
+#endif // defined(MQTT_USE_TLS)
                         base::set_connect();
                         if (ping_duration_ != std::chrono::steady_clock::duration::zero()) {
                             set_timer();


### PR DESCRIPTION
This client fix is required for some brokers like HiveMQ which use TLS-SNI extension. Without the fix the broker returns "non authorized" error.